### PR TITLE
Refactor repcols to match house style

### DIFF
--- a/kernel/utilities/repcols.m
+++ b/kernel/utilities/repcols.m
@@ -1,102 +1,110 @@
-% REPCOLS  Replicate selected sparse columns in‑place.
+% Replicates selected columns of a sparse matrix. Syntax:
 %
-% B = REPCOLS(A, C, R) returns a sparse matrix B obtained from the sparse
-% matrix A by replacing each column C(i) with R(i) identical consecutive
-% copies.  All other columns stay in the same left‑to‑right order.
+%                     B=repcols(A,column_numbers,replication_counts)
 %
-% INPUT:
-%   A  – m‑by‑n sparse matrix (any numeric class)
-%   C  – vector of 1‑based column indices to be replicated
-%   R  – vector of positive integers, same size as C, telling how many
-%        copies to make of the corresponding column in C
+% Parameters:
 %
-% OUTPUT:
-%   B  – m‑by‑(n + sum(R‑1)) sparse matrix
+%   A                  - m-by-n sparse matrix
+%   column_numbers     - vector of column indices to replicate
+%   replication_counts - vector of positive integers specifying how many
+%                        copies of each column to make
 %
-% EXAMPLE:
-%   A = sparse([1 0 2 ; 0 3 0 ; 4 0 5]);
-%   % replicate column 1 three times, column 3 twice:
-%   B = repcols(A, [1 3], [3 2]);
+% Output:
 %
-% ChatGPT o3
+%   B                  - m-by-(n+sum(replication_counts-1)) sparse matrix
+%
 % ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=repcols.m>
 
-function B = repcols(A, column_numbers, replication_counts)
+function B=repcols(A,column_numbers,replication_counts)
 
-    %--------------------------- validation ------------------------------%
-    if nargin~=3
-        error('Exactly three inputs required: B = repcols(A,C,R).');
+% Check consistency
+grumble(A,column_numbers,replication_counts);
+
+% Guarantee sparsity
+A=sparse(A);
+C=column_numbers(:);
+R=replication_counts(:);
+n=size(A,2);
+
+% Sort columns left to right
+[c_sorted,ord]=sort(C);
+r_sorted=R(ord);
+
+% Number of extra columns after each original column
+extra=zeros(1,n);
+extra(c_sorted)=r_sorted-1;
+
+% Shift map for column insertion
+shift=[0 cumsum(extra(1:end-1))];
+
+% Original matrix information
+m=size(A,1);
+[ri,ci,vi]=find(A);
+nnz_per_col=accumarray(ci,1,[n 1],@sum,0);
+total_new_nnz=nnz(A)+sum((r_sorted-1).*nnz_per_col(c_sorted));
+
+% Preallocate output triplets
+ro=zeros(total_new_nnz,1,'like',ri);
+co=zeros(total_new_nnz,1,'like',ci);
+vo=zeros(total_new_nnz,1,'like',vi);
+
+% Copy non-replicated columns
+is_rep=false(n,1); is_rep(c_sorted)=true;
+nonrep_idx=~is_rep(ci);
+
+cnt=sum(nonrep_idx);
+ro(1:cnt)=ri(nonrep_idx);
+co(1:cnt)=ci(nonrep_idx)+shift(ci(nonrep_idx))';
+vo(1:cnt)=vi(nonrep_idx);
+k=cnt;
+
+% Replicate requested columns
+for p=1:numel(c_sorted)
+    col=c_sorted(p);
+    rep=r_sorted(p);
+
+    mask=ci==col;
+    rdup=ri(mask);
+    vdup=vi(mask);
+    nnzc=numel(rdup);
+
+    base=col+shift(col);
+
+    for j=0:rep-1
+        ro(k+1:k+nnzc)=rdup;
+        co(k+1:k+nnzc)=base+j;
+        vo(k+1:k+nnzc)=vdup;
+        k=k+nnzc;
     end
-    A  = sparse(A);                     % guarantees sparsity
-    C  = column_numbers(:);
-    R  = replication_counts(:);
-    if ~isequal(size(C),size(R))
-        error('column_numbers and replication_counts must be the same size.');
-    end
-    if any(R < 1 | R ~= round(R))
-        error('replication_counts must be positive integers.');
-    end
-    n = size(A,2);
-    if any(C < 1 | C > n)
-        error('column_numbers contain indices outside 1..size(A,2).');
-    end
-    if numel(unique(C)) ~= numel(C)
-        error('column_numbers must not contain duplicates.');
-    end
+end
 
-    %---------------------- preparation & bookkeeping --------------------%
-    [Csort,ord] = sort(C);              % process left‑to‑right for clarity
-    Rsort       = R(ord);
+% Build output matrix
+B=sparse(ro,co,vo,m,n+sum(R-1));
 
-    extra          = zeros(1,n);        % how many *new* columns after each old
-    extra(Csort)   = Rsort - 1;         % e.g. replicate 4 → add 3 extras
+end
 
-    % shift(k) = how many columns have already been *inserted* before col k
-    shift          = [0 cumsum(extra(1:end-1))];
-
-    m  = size(A,1);
-    [ri,ci,vi]     = find(A);           % original triplets
-    nnz_per_col    = accumarray(ci,1,[n 1],@sum,0);
-    total_new_nnz  = nnz(A) + sum((Rsort-1).*nnz_per_col(Csort));
-
-    % preallocate output triplets
-    ro = zeros(total_new_nnz,1,'like',ri);
-    co = zeros(total_new_nnz,1,'like',ci);
-    vo = zeros(total_new_nnz,1,'like',vi);
-
-    %---------------------- copy non‑replicated columns -------------------%
-    is_rep     = false(n,1);  is_rep(Csort) = true;
-    nonrep_idx = ~is_rep(ci);           % logical mask on entries, not cols
-
-    cnt        = sum(nonrep_idx);
-    ro(1:cnt)  = ri(nonrep_idx);
-    co(1:cnt)  = ci(nonrep_idx) + shift(ci(nonrep_idx))';
-    vo(1:cnt)  = vi(nonrep_idx);
-    k          = cnt;                   % running index
-
-    %---------------------- replicate requested columns ------------------%
-    for p = 1:numel(Csort)
-        col = Csort(p);
-        rep = Rsort(p);
-
-        mask  = (ci == col);            % entries belonging to this column
-        rdup  = ri(mask);
-        vdup  = vi(mask);
-        nnzc  = numel(rdup);
-
-        base  = col + shift(col);       % where first copy will land
-
-        for j = 0:rep-1
-            ro(k+1 : k+nnzc) = rdup;
-            co(k+1 : k+nnzc) = base + j;
-            vo(k+1 : k+nnzc) = vdup;
-            k = k + nnzc;
-        end
-    end
-
-    %--------------------------- build output ----------------------------%
-    B = sparse(ro,co,vo, m, n + sum(R-1));
-
+% Consistency enforcement
+function grumble(A,column_numbers,replication_counts)
+if (~isnumeric(A))||(~issparse(A))
+    error('A must be a sparse numeric matrix.');
+end
+if (~isnumeric(column_numbers))||(~isvector(column_numbers))||...
+   any(column_numbers<1)||any(mod(column_numbers,1)~=0)
+    error('column_numbers must be a vector of positive integers.');
+end
+if (~isnumeric(replication_counts))||(~isvector(replication_counts))||...
+   any(replication_counts<1)||any(mod(replication_counts,1)~=0)||...
+   (numel(replication_counts)~=numel(column_numbers))
+    error('replication_counts must match column_numbers in size and contain positive integers.');
+end
+if numel(unique(column_numbers))~=numel(column_numbers)
+    error('column_numbers must not contain duplicates.');
+end
+if any(column_numbers>size(A,2))
+    error('column_numbers contain indices outside the matrix.');
+end
 end
 
 % Капиталисты сами продадут нам верёвку, 


### PR DESCRIPTION
## Summary
- refactor `repcols.m` to comply with Spinach house style
- add argument validation helper `grumble`
- remove spacing around operators and add documentation block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68872d88421883299118bcb0249d02a3