### PR TITLE
Rewrite row/column replication helpers

### DIFF
--- a/kernel/utilities/reprows.m
+++ b/kernel/utilities/reprows.m
@@ -1,11 +1,11 @@
-% Replicates specified rows of a matrix a specified num-
-% ber of times. Syntax:
+% Replicates specified rows of a matrix or cell array a specified
+% number of times. Syntax:
 %
 %            B=reprows(A,row_nums,rep_counts)
 %
 % Parameters:
 %
-%   A          - a sparse matrix
+%   A          - a numeric matrix or a cell array
 %
 %   row_nums   - vector of row indices to replicate
 %
@@ -14,7 +14,7 @@
 %
 % Output:
 %
-%   B          - a sparse matrix
+%   B          - same type as A
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -25,63 +25,24 @@ function B=reprows(A,row_nums,rep_counts)
 % Check consistency
 grumble(A,row_nums,rep_counts);
 
-% Sort user indices top to bottom
-R=row_nums(:); S=rep_counts(:);
-[R,ord]=sort(R); S=S(ord);
+% Replication counts for every row
+n=size(A,1); rep_map=ones(1,n); rep_map(row_nums)=rep_counts(:);
 
-% Number of extra rows after each original row
-n=size(A,1); extra_rows=zeros(1,n); extra_rows(R)=S-1;
+% Build row index vector
+row_idx=repelem(1:n,rep_map);
 
-% Shift map for row insertion
-shift=[0 cumsum(extra_rows(1:end-1))];
-
-% Original matrix information
-m=size(A,2); [ri,ci,vi]=find(A);
-nnz_per_row=accumarray(ri,1,[n 1],@sum,0);
-total_new_nnz=nnz(A)+sum((S-1).*nnz_per_row(R));
-
-% Preallocate output triplets
-ro=zeros(total_new_nnz,1,'like',ri);
-co=zeros(total_new_nnz,1,'like',ci);
-vo=zeros(total_new_nnz,1,'like',vi);
-
-% Copy non-replicated rows
-is_rep=false(n,1); is_rep(R)=true;
-nonrep_idx=~is_rep(ri);
-cnt=sum(nonrep_idx);
-ro(1:cnt)=ri(nonrep_idx)+shift(ri(nonrep_idx))';
-co(1:cnt)=ci(nonrep_idx);
-vo(1:cnt)=vi(nonrep_idx); k=cnt;
-
-% Replicate requested rows
-for p=1:numel(R)
-
-    row=R(p); rep=S(p);
-    mask=(ri==row);
-    cdup=ci(mask);
-    vdup=vi(mask);
-    nnzr=numel(cdup);
-    base=row+shift(row);
-
-    for j=0:(rep-1)
-        ro(k+1:k+nnzr)=base+j;
-        co(k+1:k+nnzr)=cdup;
-        vo(k+1:k+nnzr)=vdup;
-        k=k+nnzr;
-    end
-
-end
-
-% Build the output matrix
-B=sparse(ro,co,vo,n+sum(S-1),m);
-if ~issparse(A), B=full(B); end
+% Extract and replicate
+B=A(row_idx,:);
 
 end
 
 % Consistency enforcement
 function grumble(A,row_nums,rep_counts)
-if ~isnumeric(A)
-    error('A must be a numeric matrix.');
+if (~isnumeric(A))&&(~iscell(A))
+    error('A must be numeric or a cell array.');
+end
+if ndims(A)~=2
+    error('A must be two-dimensional.');
 end
 if (~isnumeric(row_nums))||(~isvector(row_nums))||...
    any(row_nums<1)||any(mod(row_nums,1)~=0)
@@ -105,4 +66,3 @@ end
 % mer is a tragedy, the latter a blessing.
 %
 % Hannah Tomes, in The Spectator
-


### PR DESCRIPTION
## Summary
- simplify `reprows` and `repcols`
- use index generation instead of manual sparse indexing
- allow cell arrays to be processed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688739a47f888329bc1c990d87df0889