### PR TITLE
fix: repair ttclass audit failures

### DIFF
--- a/kernel/overloads/@ttclass/amensolve.m
+++ b/kernel/overloads/@ttclass/amensolve.m
@@ -51,7 +51,7 @@
 function x=amensolve(A,y,tol,opts,x0)
 
 % Get the default options started
-if isempty(opts), opts=struct; end
+if (nargin<4)||isempty(opts), opts=struct; end
 
 % Maximum number of AMEn sweeps
 if ~isfield(opts, 'nswp');            opts.nswp=20;           end

--- a/kernel/overloads/@ttclass/amensum.m
+++ b/kernel/overloads/@ttclass/amensum.m
@@ -65,9 +65,9 @@ if all(all(rnk==1))
     zy = cell(d+1,1); zy{1}=1; zy{d+1}=1;
     nrm = ones(d,1);
     for k=d:-1:2
-        yx{k}=step_tt_by_cp(yx{k+1},y{k,1},X{k,1},-1);
-        zx{k}=step_tt_by_cp(zx{k+1},z{k,1},X{k,1},-1);
-        zy{k}=step_tt_by_tt(zy{k+1},z{k,1},y{k,1},-1);
+        yx{k}=step_tt_by_cp(yx{k+1},y.cores{k,1},X{k,1},-1);
+        zx{k}=step_tt_by_cp(zx{k+1},z.cores{k,1},X{k,1},-1);
+        zy{k}=step_tt_by_tt(zy{k+1},z.cores{k,1},y.cores{k,1},-1);
         nrm(k)=norm(yx{k},'fro');
         if(nrm(k)>0)
             yx{k}=yx{k}/nrm(k);
@@ -103,7 +103,7 @@ if all(all(rnk==1))
             end
             
             % Check the convergence
-            relative_stepsize=norm(ynew(:)-y{k,1}(:),2)/norm(y{k,1}(:),2);
+            relative_stepsize=norm(ynew(:)-y.cores{k,1}(:),2)/norm(y.cores{k,1}(:),2);
             largest_stepsize=max(largest_stepsize, relative_stepsize);
             
             % Run the truncation
@@ -160,7 +160,7 @@ if all(all(rnk==1))
                 y.cores{k,1} = reshape(U, [ry(k),sz(k,1),sz(k,2),rnew]);
                 
                 % Push the non-orthogonal factor forth the chain                
-                next_core = reshape(y{k+1,1}, [ry(k+1), sz(k+1,1)*sz(k+1,2)*ry(k+2)]);
+                next_core = reshape(y.cores{k+1,1}, [ry(k+1), sz(k+1,1)*sz(k+1,2)*ry(k+2)]);
                 next_core = V*next_core;
                 y.cores{k+1,1} = reshape(next_core, [rnew,sz(k+1,1),sz(k+1,2),ry(k+2)]);
                 
@@ -168,14 +168,14 @@ if all(all(rnk==1))
                 ry(k+1)=rnew;
                 
                 % Update the interfaces
-                yx{k+1}=step_tt_by_cp(yx{k},y{k,1},X{k,1},+1);
+                yx{k+1}=step_tt_by_cp(yx{k},y.cores{k,1},X{k,1},+1);
                 nrm(k)=norm(yx{k+1},'fro');
                 if (nrm(k)>0)
                     yx{k+1}=yx{k+1}/nrm(k);
                 end
                 if opts.enrichment_rank>0
                     zx{k+1}=step_tt_by_cp(zx{k},znew,X{k,1},+1);
-                    zy{k+1}=step_tt_by_tt(zy{k},znew,y{k,1},+1);
+                    zy{k+1}=step_tt_by_tt(zy{k},znew,y.cores{k,1},+1);
                     if (nrm(k)>0)
                         zx{k+1}=zx{k+1}/nrm(k);
                     end
@@ -203,12 +203,11 @@ if all(all(rnk==1))
         flipped = ~flipped;
         
         % And exit only if the direction is correct
-        satisfied = (largest_stepsize<tol) && (iter<=opts.max_swp);
+        satisfied = (largest_stepsize<tol) || (iter>=opts.max_swp);
         
         % Report if necessary
         if opts.verb>0
-            str=sprintf('iter=%d, max_dx=%3.3e, max_r=%d\n',iter, largest_stepsize, max(y.ranks));
-            report(spin_system,str);
+            fprintf('amensum: iter=%d, max_dx=%3.3e, max_r=%d\n',iter, largest_stepsize, max(y.ranks));
         end
         
     end

--- a/kernel/overloads/@ttclass/hdot.m
+++ b/kernel/overloads/@ttclass/hdot.m
@@ -37,7 +37,7 @@ for na=1:ntrains_a
         for k=1:ncores
             core_b=reshape(b.cores{k,nb},[ranks_b(k,nb),mode_sizes(k,1)*mode_sizes(k,2)*ranks_b(k+1,nb)]);
             core_b=x*core_b;
-            core_b=reshape(core_b,[ranks_a(k,nb)*mode_sizes(k,1)*mode_sizes(k,2),ranks_b(k+1,nb)]);      
+            core_b=reshape(core_b,[ranks_a(k,na)*mode_sizes(k,1)*mode_sizes(k,2),ranks_b(k+1,nb)]);      
             core_a=reshape(a.cores{k,na},[ranks_a(k,na)*mode_sizes(k,1)*mode_sizes(k,2),ranks_a(k+1,na)]);
             x=core_a'*core_b;          
         end

--- a/kernel/overloads/@ttclass/isreal.m
+++ b/kernel/overloads/@ttclass/isreal.m
@@ -18,7 +18,7 @@ if isa(tt,'ttclass')
     if answer
        for n=1:tt.ntrains
            for k=1:tt.ncores
-               answer=isreal(tt{k,n});
+               answer=isreal(tt.cores{k,n});
                if ~answer, return; end
            end
        end 


### PR DESCRIPTION
## Summary
- fix invalid core access in `@ttclass/isreal`
- fix buffered-rank indexing in `@ttclass/hdot`
- fix missing default-options guard in `@ttclass/amensolve`, which also restores the 3-argument `mldivide` path
- fix multiple invalid `ttclass` brace accesses and the stopping/reporting path in `@ttclass/amensum`

## Validation
- `matlab -nodesktop -nosplash -batch "run('/home/administrator/.openclaw/workspace/tmp/ttclass_checkcode_audit.m')"`
  - `CHECKCODE_OK`
- `matlab -nodesktop -nosplash -batch "addpath('/home/administrator/.openclaw/workspace/tmp'); ttclass_matrix_parity_audit"`
  - `TOTAL_PASSED=56`
  - `TTCLASS_TESTS_OK`

## Notes
- The `kron` audit was validated against the tensor-train ordering documented in `@ttclass/kron.m`, not naive flat `kron(...)` output.
