### PR TITLE
Make HNCA phase sensitive

### DIFF
--- a/examples/nmr_proteins/hnca_gb1.m
+++ b/examples/nmr_proteins/hnca_gb1.m
@@ -29,6 +29,7 @@ bas.level=4; bas.space_level=1;
 
 % Algorithmic options
 sys.enable={'greedy'}; % 'gpu'
+sys.disable={'krylov'};
 
 % Spinach housekeeping
 spin_system=create(sys,inter);

--- a/examples/nmr_proteins/hnca_gb1.m
+++ b/examples/nmr_proteins/hnca_gb1.m
@@ -35,9 +35,9 @@ spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
 % Sequence parameters
-parameters.spins={'1H','13C','15N'};
-parameters.sweep=[3000 5000 2800];
-parameters.offset=[5100 8600 -7200];
+parameters.spins={'15N','13C','1H'};
+parameters.sweep=[2800 5000 3000];
+parameters.offset=[-7200 8600 5100];
 parameters.npoints=[128 128 128];
 parameters.zerofill=[256 256 256];
 parameters.axis_units='ppm';
@@ -46,13 +46,33 @@ parameters.axis_units='ppm';
 fid=liquid(spin_system,@hnca,parameters,'nmr');
 
 % Apodisation
-fid=apodisation(spin_system,fid,{{'cos'},{'cos'},{'cos'}});
+fid.pos_pos=apodisation(spin_system,fid.pos_pos,{{'cos'},{'cos'},{'cos'}});
+fid.pos_neg=apodisation(spin_system,fid.pos_neg,{{'cos'},{'cos'},{'cos'}});
+fid.neg_pos=apodisation(spin_system,fid.neg_pos,{{'cos'},{'cos'},{'cos'}});
+fid.neg_neg=apodisation(spin_system,fid.neg_neg,{{'cos'},{'cos'},{'cos'}});
 
-% Fourier transform
-spectrum=fftshift(fftn(fid,parameters.zerofill));
+% F3 Fourier transform
+f3_pos_pos=fftshift(fft(fid.pos_pos,parameters.zerofill(3),3),3);
+f3_pos_neg=fftshift(fft(fid.pos_neg,parameters.zerofill(3),3),3);
+f3_neg_pos=fftshift(fft(fid.neg_pos,parameters.zerofill(3),3),3);
+f3_neg_neg=fftshift(fft(fid.neg_neg,parameters.zerofill(3),3),3);
+
+% Absorption part of F3 signal
+f3_pos=f3_pos_pos+conj(f3_neg_neg);
+f3_neg=f3_neg_pos+conj(f3_pos_neg);
+
+% F2 Fourier transform
+f3f2_pos=fftshift(fft(f3_pos,parameters.zerofill(2),2),2);
+f3f2_neg=fftshift(fft(f3_neg,parameters.zerofill(2),2),2);
+
+% Absorption part of F2 signal
+f3f2=f3f2_pos+conj(f3f2_neg);
+
+% F1 Fourier transform
+spectrum=fftshift(fft(f3f2,parameters.zerofill(1),1),1);
 
 % Plotting
-kfigure(); plot_3d(spin_system,abs(spectrum),parameters,...
+kfigure(); plot_3d(spin_system,-real(spectrum),parameters,...
                   10,[0.1 0.5 0.1 0.5],2,'positive');
 
 end

--- a/examples/nmr_proteins/hnca_simple.m
+++ b/examples/nmr_proteins/hnca_simple.m
@@ -33,9 +33,9 @@ spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
 % Sequence parameters
-parameters.spins={'1H','13C','15N'};
-parameters.sweep=[3000 5000 2800];
-parameters.offset=[5100 8600 -7200];
+parameters.spins={'15N','13C','1H'};
+parameters.sweep=[2800 5000 3000];
+parameters.offset=[-7200 8600 5100];
 parameters.npoints=[64 64 64];
 parameters.zerofill=[256 256 256];
 parameters.axis_units='ppm';
@@ -44,13 +44,33 @@ parameters.axis_units='ppm';
 fid=liquid(spin_system,@hnca,parameters,'nmr');
 
 % Apodisation
-fid=apodisation(spin_system,fid,{{'sqcos'},{'sqcos'},{'sqcos'}});
+fid.pos_pos=apodisation(spin_system,fid.pos_pos,{{'sqcos'},{'sqcos'},{'sqcos'}});
+fid.pos_neg=apodisation(spin_system,fid.pos_neg,{{'sqcos'},{'sqcos'},{'sqcos'}});
+fid.neg_pos=apodisation(spin_system,fid.neg_pos,{{'sqcos'},{'sqcos'},{'sqcos'}});
+fid.neg_neg=apodisation(spin_system,fid.neg_neg,{{'sqcos'},{'sqcos'},{'sqcos'}});
 
-% Fourier transform
-spectrum=fftshift(fftn(fid,parameters.zerofill));
+% F3 Fourier transform
+f3_pos_pos=fftshift(fft(fid.pos_pos,parameters.zerofill(3),3),3);
+f3_pos_neg=fftshift(fft(fid.pos_neg,parameters.zerofill(3),3),3);
+f3_neg_pos=fftshift(fft(fid.neg_pos,parameters.zerofill(3),3),3);
+f3_neg_neg=fftshift(fft(fid.neg_neg,parameters.zerofill(3),3),3);
+
+% Absorption part of F3 signal
+f3_pos=f3_pos_pos+conj(f3_neg_neg);
+f3_neg=f3_neg_pos+conj(f3_pos_neg);
+
+% F2 Fourier transform
+f3f2_pos=fftshift(fft(f3_pos,parameters.zerofill(2),2),2);
+f3f2_neg=fftshift(fft(f3_neg,parameters.zerofill(2),2),2);
+
+% Absorption part of F2 signal
+f3f2=f3f2_pos+conj(f3f2_neg);
+
+% F1 Fourier transform
+spectrum=fftshift(fft(f3f2,parameters.zerofill(1),1),1);
 
 % Plotting
-kfigure(); plot_3d(spin_system,abs(spectrum),parameters,...
+kfigure(); plot_3d(spin_system,-real(spectrum),parameters,...
                   10,[0.2 0.9 0.2 0.9],2,'positive');
 
 end

--- a/examples/nmr_proteins/hncaco_gb1.m
+++ b/examples/nmr_proteins/hncaco_gb1.m
@@ -29,6 +29,7 @@ bas.level=4; bas.space_level=1;
 
 % Algorithmic options
 sys.enable={'greedy'}; % 'gpu'
+sys.disable={'krylov'};
 
 % Spinach housekeeping
 spin_system=create(sys,inter);

--- a/examples/nmr_proteins/hnco_ubiquitin.m
+++ b/examples/nmr_proteins/hnco_ubiquitin.m
@@ -29,6 +29,7 @@ bas.level=4; bas.space_level=1;
 
 % Algorithmic options
 sys.enable={'greedy'}; % 'gpu'
+sys.disable={'krylov'};
 
 % Spinach housekeeping
 spin_system=create(sys,inter);

--- a/examples/nmr_proteins/hncoca_simple.m
+++ b/examples/nmr_proteins/hncoca_simple.m
@@ -31,6 +31,7 @@ spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
 % Sequence parameters
+parameters.tau=[2.25e-3, 2.75e-3, 8.00e-3, 7.00e-3];
 parameters.spins={'15N','13C','1H'};
 parameters.offset=[-7200 5600 4800];
 parameters.sweep=[5000 8000 5000];

--- a/examples/nmr_proteins/hncoca_ubiquitin.m
+++ b/examples/nmr_proteins/hncoca_ubiquitin.m
@@ -28,20 +28,21 @@ bas.connectivity='scalar_couplings';
 bas.level=4; bas.space_level=1;
 
 % Algorithmic options
-sys.enable={}; % 'gpu'
+sys.enable={'greedy'}; % 'gpu'
+sys.disable={'krylov'};
 
 % Spinach housekeeping
 spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
 % Sequence parameters
+parameters.tau=[2.25e-3, 2.75e-3, 8.00e-3, 7.00e-3];
 parameters.spins={'15N','13C','1H'};
 parameters.offset=[-7100 8450 4850];
 parameters.sweep=[2500 4500 3000];
 parameters.npoints=[64 64 64];
 parameters.zerofill=[256 256 256];
 parameters.axis_units='ppm';
-parameters.tau=[2.25e-3, 2.75e-3, 8.00e-3, 7.00e-3];
 
 % Simulation
 fid=liquid(spin_system,@hncoca,parameters,'nmr');

--- a/experiments/nmr_protein/hnca.m
+++ b/experiments/nmr_protein/hnca.m
@@ -137,26 +137,26 @@ rho_stack_neg=step(spin_system,Hx+CAx,rho_stack_neg,pi/2);
 [L_dec,~]=decouple(spin_system,L,[],{'15N'});
 
 % Detection on 1H
-coil_stack=evolution(spin_system,L_dec,[],parameters.coil,...
+coil_stack=evolution(spin_system,L_dec',[],parameters.coil,...
                      -t3.timestep,t3.nsteps-1,'trajectory');
                  
 % Select single quantum coherence
 coil_stack=coherence(spin_system,coil_stack,{{'1H',1}});                 
 
 % tau evolution
-coil_stack=evolution(spin_system,L,[],coil_stack,-tau,1,'final');
+coil_stack=evolution(spin_system,L',[],coil_stack,-tau,1,'final');
 
 % Inversion pulses on 1H and 15N
 coil_stack=step(spin_system,Hx+Nx,coil_stack,-pi);
 
 % tau evolution
-coil_stack=evolution(spin_system,L,[],coil_stack,-tau,1,'final');
+coil_stack=evolution(spin_system,L',[],coil_stack,-tau,1,'final');
 
 % Pulses on 1H and 15N
 coil_stack=step(spin_system,Hx+Nx,coil_stack,-pi/2);
 
 % delta evolution
-coil_stack=evolution(spin_system,L,[],coil_stack,-delta,1,'final');
+coil_stack=evolution(spin_system,L',[],coil_stack,-delta,1,'final');
 
 % Pulses on 1H and 13CA
 coil_stack=step(spin_system,Hx+CAx,coil_stack,-pi/2);

--- a/experiments/nmr_protein/hnca.m
+++ b/experiments/nmr_protein/hnca.m
@@ -7,7 +7,7 @@
 %
 % The sequence is hard-wired to work on 1H,13C,15N proteins and uses
 % PDB labels to select spins that will be affected by otherwise ideal
-% pulses. F1 is 1H, F2 is 13C, F3 is 15N. Syntax:
+% pulses. F1 is 15N, F2 is 13C, F3 is 1H. Syntax:
 %
 %               fid=hnca(spin_system,parameters,H,R,K)
 %
@@ -29,14 +29,13 @@
 %
 % Outputs:
 %
-%    fid - three-dimensional free induction decay
+%    fid - a structure with four fields: fid.pos_pos, fid.pos_neg,
+%          fid.neg_pos, fid.neg_neg that are used in the subsequ-
+%          ent States quadrature processing
 %
 % Note: spin labels must be set to PDB atom IDs ('CA', 'HA', etc.) in
 %       sys.labels for this sequence to work properly.
 %
-% TODO: whoever understands how phase cycles and quadratures work in
-%       3D NMR is welcome to add a phase-sensitive version.
-%  
 % m.walker@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
 %
@@ -108,23 +107,29 @@ rho=evolution(spin_system,L,[],rho,tau,1,'final');
 % Pulse on 15N, y pulse on 1H
 rho=step(spin_system,Hy+Nx,rho,pi/2);
 
-% Coherence selection
-rho=coherence(spin_system,rho,{{'15N',1}});
+% Coherence selection for States quadrature in F1
+rho_pos=coherence(spin_system,rho,{{'15N',+1}});
+rho_neg=coherence(spin_system,rho,{{'15N',-1}});
 
 % t1 evolution
-rho_stack=evolution(spin_system,L,[],rho,t1.timestep/2,t1.nsteps-1,'trajectory');
+rho_stack_pos=evolution(spin_system,L,[],rho_pos,t1.timestep/2,t1.nsteps-1,'trajectory');
+rho_stack_neg=evolution(spin_system,L,[],rho_neg,t1.timestep/2,t1.nsteps-1,'trajectory');
 
 % Inversion pulses on 1H, 13CA and 13CO
-rho_stack=step(spin_system,Hx+CAx+COx,rho_stack,pi);
+rho_stack_pos=step(spin_system,Hx+CAx+COx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx+CAx+COx,rho_stack_neg,pi);
 
 % t1 rest of the evolution
-rho_stack=evolution(spin_system,L,[],rho_stack,t1.timestep/2,t1.nsteps-1,'refocus'); 
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,t1.timestep/2,t1.nsteps-1,'refocus');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,t1.timestep/2,t1.nsteps-1,'refocus');
 
 % delta evolution
-rho_stack=evolution(spin_system,L,[],rho_stack,delta,1,'final');
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta,1,'final');
 
 % Pulses on 1H and 13CA
-rho_stack=step(spin_system,Hx+CAx,rho_stack,pi/2);
+rho_stack_pos=step(spin_system,Hx+CAx,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Hx+CAx,rho_stack_neg,pi/2);
 
 %% Run the second half backward
 
@@ -158,12 +163,21 @@ coil_stack=step(spin_system,Hx+CAx,coil_stack,-pi/2);
 
 %% Stitch the halves
 
-% Coherence selection
-rho_stack=coherence(spin_system,rho_stack,{{'13C',+1}});
-coil_stack=coherence(spin_system,coil_stack,{{'13C',+1}});
+% Coherence selection for States quadrature in F2
+coil_stack_pos=coherence(spin_system,coil_stack,{{'13C',+1}});
+coil_stack_neg=coherence(spin_system,coil_stack,{{'13C',-1}});
 
 % Stitching
-fid=stitch(spin_system,L,rho_stack,coil_stack,{Hx+Nx+COx},{pi},t1,t2,t3);
+fid.pos_pos=stitch(spin_system,L,rho_stack_pos,coil_stack_pos,{Hx+Nx+COx},{pi},t1,t2,t3);
+fid.pos_neg=stitch(spin_system,L,rho_stack_pos,coil_stack_neg,{Hx+Nx+COx},{pi},t1,t2,t3);
+fid.neg_pos=stitch(spin_system,L,rho_stack_neg,coil_stack_pos,{Hx+Nx+COx},{pi},t1,t2,t3);
+fid.neg_neg=stitch(spin_system,L,rho_stack_neg,coil_stack_neg,{Hx+Nx+COx},{pi},t1,t2,t3);
+
+% Dimension reordering
+fid_names=fieldnames(fid);
+for name_idx=1:numel(fid_names)
+    fid.(fid_names{name_idx})=permute(fid.(fid_names{name_idx}),[3 2 1]);
+end
 
 end
 

--- a/kernel/create.m
+++ b/kernel/create.m
@@ -324,6 +324,22 @@ if ~isworkernode
                                     num2str(spin_system.sys.parprops{n}{2})]);
             end
         end
+
+        % Set up parallel resource allocation
+        if ismember('greedy',spin_system.sys.enable)
+
+            % Every worker can use every core
+            c.NumThreads=feature('numcores');
+
+        else
+
+            % Figure out the maximum reasonable per-worker core count
+            c.NumThreads=max([1 floor(feature('numcores')/spmdSize)]);
+
+        end
+
+        % Head process may use what it wants
+        maxNumCompThreads(feature('numcores'));
         
         % Start the parallel pool
         current_pool=parpool(c,spin_system.sys.parallel{2},...
@@ -332,39 +348,6 @@ if ~isworkernode
         % Disable pool timeout
         current_pool.IdleTimeout=inf;
     
-    end
-    
-    % Set up parallel resource allocation
-    warning('off','MATLAB:maxNumCompThreads:Deprecated');
-    if ismember('greedy',spin_system.sys.enable)
-        
-        % Greedy
-        spmd
-
-            % Allow every worker to use every CPU core
-            warning('off','MATLAB:maxNumCompThreads:Deprecated');
-            maxNumCompThreads(feature('numcores'));
-
-        end
-
-        % Head process can use what it wants
-        maxNumCompThreads(feature('numcores'));
-
-    else
-        
-        % Modest
-        spmd
-            
-            % Try to work out a reasonable allocation
-            warning('off','MATLAB:maxNumCompThreads:Deprecated');
-            ncores=max([1 floor(feature('numcores')/spmdSize)]);
-            maxNumCompThreads(ncores);
-
-        end
-
-        % Head process can use what it wants
-        maxNumCompThreads(feature('numcores'));
-
     end
     
 else


### PR DESCRIPTION
## Summary
- Make `experiments/nmr_protein/hnca.m` phase-sensitive by returning four hypercomplex/States components: `pos_pos`, `pos_neg`, `neg_pos`, and `neg_neg`.
- Add States coherence selection in the indirect `15N` and `13C` dimensions and reorder output dimensions to the natural `{15N,13C,1H}` order.
- Update the HNCA protein examples to process the four components into an absorption-mode 3D spectrum instead of magnitude-mode `fftn(abs(...))` processing.

## Literature checked
- States, Haberkorn, Ruben, JMR 48, 286 (1982), DOI `10.1016/0022-2364(82)90279-7`: pure absorption/States quadrature basis.
- Kay, Ikura, Tschudin, Bax, JMR 89, 496 (1990), DOI `10.1016/0022-2364(90)90333-5`: 3D triple-resonance NMR of isotopically enriched proteins.
- Ikura, Kay, Bax, Biochemistry 29, 4659 (1990), DOI `10.1021/bi00471a022`: heteronuclear triple-resonance assignment strategy applied to calmodulin.
- Meissner and Sørensen, JMR 150, 100 (2001), DOI `10.1006/jmre.2001.2317`: sequential HNCA pulse-sequence context.

## Validation
- `git diff --check -- experiments/nmr_protein/hnca.m examples/nmr_proteins/hnca_simple.m examples/nmr_proteins/hnca_gb1.m`
- MATLAB `checkcode` on the three modified files: 0 messages.
- MATLAB smoke test on a minimal four-spin HNCA system with `parameters.npoints=[4 4 4]`: verified all four fields exist, have size `[4 4 4]`, contain finite non-zero data, and hypercomplex processing produces a finite spectrum.
