### PR TITLE
Handle exact Arnoldi breakdown

### DIFF
--- a/kernel/utilities/arnoldi.m
+++ b/kernel/utilities/arnoldi.m
@@ -21,6 +21,9 @@
 %
 %    H - extended Hessenberg matrix
 %
+% If exact Krylov breakdown occurs, V and H are truncated to the
+% completed invariant subspace.
+%
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=arnoldi.m>
@@ -56,7 +59,12 @@ for n=1:niter
     
     % Compute the norm
     H(n+1,n)=norm(V(:,n+1),2);
-    
+
+    % Return if exact Krylov breakdown occurs
+    if H(n+1,n)==0
+        V=V(:,1:n); H=H(1:n,1:n); return;
+    end
+
     % Divide out the norm
     V(:,n+1)=V(:,n+1)/H(n+1,n);
     


### PR DESCRIPTION
## Summary

This patch handles exact Krylov breakdown in `kernel/utilities/arnoldi.m`.

When the newly generated Krylov vector is exactly eliminated by Gram-Schmidt, the previous code divided by `H(n+1,n)=0`, producing non-finite basis entries. The new behaviour detects exact breakdown, truncates `V` and `H`, and returns the completed invariant subspace.

## Validation

Ran a focused MATLAB validation script on this branch:

```text
matlab -nodesktop -nosplash -batch "run('/home/kuprov/.openclaw/workspace/tmp/validate_arnoldi_breakdown_pr.m')"
ARNOLDI_BREAKDOWN_PR_VALIDATION_OK
```

The script checks:

- `checkcode` on `kernel/utilities/arnoldi.m`;
- exact-breakdown identity-operator case returns finite truncated `V,H`;
- ordinary one-step two-dimensional Arnoldi case still returns an orthonormal basis.

## Confession

I did not run the full Spinach example/test suite; this is a focused one-file numerical edge-case fix.
