### PR TITLE
Allow GRAPE SNS array bounds

### DIFF
--- a/kernel/optimcon/ctrl_trajan.m
+++ b/kernel/optimcon/ctrl_trajan.m
@@ -183,6 +183,14 @@ end
 lower_bound=spin_system.control.l_bound*average_power;
 upper_bound=spin_system.control.u_bound*average_power;
 
+% Match the stairs plot extension
+if strcmp(spin_system.control.integrator,'rectangle')&&(~isscalar(lower_bound))
+    lower_bound=[lower_bound lower_bound(:,end)];
+end
+if strcmp(spin_system.control.integrator,'rectangle')&&(~isscalar(upper_bound))
+    upper_bound=[upper_bound upper_bound(:,end)];
+end
+
 % Plot Cartesian controls
 if ismember('xy_controls',spin_system.control.plotting)
     
@@ -218,17 +226,43 @@ if ismember('xy_controls',spin_system.control.plotting)
        
     % Compute axis limits
     x_lower=0; x_upper=max(t_axis);
-    y_lower=min([min(waveform(:)), lower_bound-0.05*abs(lower_bound)])/(2*pi);
-    y_upper=max([max(waveform(:)), upper_bound+0.05*abs(upper_bound)])/(2*pi);
+    y_lower=min([waveform(:); lower_bound(:)-0.05*abs(lower_bound(:))])/(2*pi);
+    y_upper=max([waveform(:); upper_bound(:)+0.05*abs(upper_bound(:))])/(2*pi);
 
     % Set axis limits
     xlim('tight'); ylim([y_lower y_upper]);
     
     % Draw power bounds
-    fb_pwr=refline([0 lower_bound/(2*pi)]);
-    set(fb_pwr,'Color','k','LineStyle','--');
-    cb_pwr=refline([0 upper_bound/(2*pi)]);
-    set(cb_pwr,'Color','k','LineStyle','--');
+    if isscalar(lower_bound)
+        fb_pwr=refline([0 lower_bound/(2*pi)]);
+        set(fb_pwr,'Color','k','LineStyle','--','HandleVisibility','off');
+    else
+        hold on;
+        switch spin_system.control.integrator
+            case 'trapezium'
+                fb_pwr=plot(t_axis',lower_bound'/(2*pi));
+            case 'rectangle'
+                fb_pwr=stairs(t_axis',lower_bound'/(2*pi));
+            otherwise
+                error('unknown integrator.');
+        end
+        set(fb_pwr,'Color','k','LineStyle','--','HandleVisibility','off');
+    end
+    if isscalar(upper_bound)
+        cb_pwr=refline([0 upper_bound/(2*pi)]);
+        set(cb_pwr,'Color','k','LineStyle','--','HandleVisibility','off');
+    else
+        hold on;
+        switch spin_system.control.integrator
+            case 'trapezium'
+                cb_pwr=plot(t_axis',upper_bound'/(2*pi));
+            case 'rectangle'
+                cb_pwr=stairs(t_axis',upper_bound'/(2*pi));
+            otherwise
+                error('unknown integrator.');
+        end
+        set(cb_pwr,'Color','k','LineStyle','--','HandleVisibility','off');
+    end
 
     % Set labels and title
     control_labels=cell(1,size(waveform,1));
@@ -364,10 +398,10 @@ if ismember('amp_controls',spin_system.control.plotting)
     
     % Determine the amplitude bound
     if ismember('SNSA',spin_system.control.penalties)
-        amp_bound=abs(upper_bound);
+        amp_bound=max(abs(upper_bound(:)));
     else
-        amp_bound=max([sqrt(2)*abs(upper_bound) ...
-                       sqrt(2)*abs(lower_bound)]);
+        amp_bound=max([sqrt(2)*abs(upper_bound(:)); ...
+                       sqrt(2)*abs(lower_bound(:))]);
     end
     
     % Axis limits with approproate padding of the Y axis
@@ -629,4 +663,5 @@ end
 % understand it well enough.
 %
 % Albert Einstein
+
 

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -1046,12 +1046,32 @@ end
 % Process lower and upper bounds
 if isfield(control,'u_bound')&&isfield(control,'l_bound')
 
+    % Expected waveform dimensions
+    wf_dims=[spin_system.control.ncontrols spin_system.control.pulse_ntpts];
+
     % Input validation
-    if (~isnumeric(control.u_bound))||(~isreal(control.u_bound))||(~isscalar(control.u_bound))
-        error('control.u_bound must be a real scalar.');
+    if (~isnumeric(control.u_bound))||(~isreal(control.u_bound))
+        error('control.u_bound must be a real scalar or a real array.');
     end
-    if (~isnumeric(control.l_bound))||(~isreal(control.l_bound))||(~isscalar(control.l_bound))
-        error('control.l_bound must be a real scalar.');
+    if (~isnumeric(control.l_bound))||(~isreal(control.l_bound))
+        error('control.l_bound must be a real scalar or a real array.');
+    end
+    if (~isscalar(control.u_bound))&&(~isequal(size(control.u_bound),wf_dims))
+        error(['control.u_bound must be a scalar or have dimensions ' int2str(wf_dims) '.']);
+    end
+    if (~isscalar(control.l_bound))&&(~isequal(size(control.l_bound),wf_dims))
+        error(['control.l_bound must be a scalar or have dimensions ' int2str(wf_dims) '.']);
+    end
+    if any(control.u_bound-control.l_bound<0,'all')
+        error('control.u_bound must be greater than or equal to control.l_bound.');
+    end
+    if ((~isscalar(control.u_bound))||(~isscalar(control.l_bound)))&&...
+       ismember('SNSA',spin_system.control.penalties)
+        error('array bounds are not supported with SNSA amplitude penalty.');
+    end
+    if ((~isscalar(control.u_bound))||(~isscalar(control.l_bound)))&&...
+       isfield(spin_system.control,'amplitudes')
+        error('array bounds are not supported for phase-modulated optimisations.');
     end
         
     % Absorb bounds
@@ -1067,10 +1087,24 @@ else
 end
 
 % Inform the user
-report(spin_system,[pad('SNS penalty ceiling, fraction of power level',60) ...
-                         num2str(spin_system.control.u_bound,'%+.9g')]);
-report(spin_system,[pad('SNS penalty floor, fraction of power level',60) ...
-                         num2str(spin_system.control.l_bound,'%+.9g')]);
+if isscalar(spin_system.control.u_bound)
+    report(spin_system,[pad('SNS penalty ceiling, fraction of power level',60) ...
+                             num2str(spin_system.control.u_bound,'%+.9g')]);
+else
+    report(spin_system,[pad('SNS penalty ceiling, fraction of power level',60) ...
+                             'array ' int2str(size(spin_system.control.u_bound)) ...
+                             ', range [' num2str(min(spin_system.control.u_bound(:)),'%+.9g') ...
+                             ',' num2str(max(spin_system.control.u_bound(:)),'%+.9g') ']']);
+end
+if isscalar(spin_system.control.l_bound)
+    report(spin_system,[pad('SNS penalty floor, fraction of power level',60) ...
+                             num2str(spin_system.control.l_bound,'%+.9g')]);
+else
+    report(spin_system,[pad('SNS penalty floor, fraction of power level',60) ...
+                             'array ' int2str(size(spin_system.control.l_bound)) ...
+                             ', range [' num2str(min(spin_system.control.l_bound(:)),'%+.9g') ...
+                             ',' num2str(max(spin_system.control.l_bound(:)),'%+.9g') ']']);
+end
 
 % Process ensemble correlations
 if isfield(control,'ens_corrs')
@@ -1322,4 +1356,5 @@ end
 % is the opposite of charity.
 %
 % Ayn Rand, "Atlas Shrugged"
+
 

--- a/kernel/optimcon/penalty.m
+++ b/kernel/optimcon/penalty.m
@@ -31,13 +31,16 @@
 %                                   with waveform rows ordered as:
 %                                   [Xa Ya Xb Yb ... Xn Yn]
 %
-%    fb                          -  floor bound, the lower bound on
-%                                   waveform used in the SNS penal-
-%                                   ty function.
+%    fb                          -  floor bound, a scalar or an array
+%                                   with the same dimensions as the
+%                                   waveform used in the SNS penalty
+%                                   function.
 %                                   
-%    cb                          -  ceiling bound, the upper bound
-%                                   on waveform used in the SNS and
-%                                   SNSA penalty functions.
+%    cb                          -  ceiling bound, a scalar or an ar-
+%                                   ray with the same dimensions as
+%                                   the waveform used in the SNS pen-
+%                                   alty function, scalar only for
+%                                   the SNSA penalty function.
 %
 % Outputs:
 %
@@ -213,11 +216,14 @@ end
 if ~(isscalar(cb)||(isnumeric(cb)&&isequal(size(cb),size(wf))))
     error('ceiling bound must be a scalar or a numeric array.');
 end
-if any(cb<fb)
+if any(cb-fb<0,'all')
     error('ceiling bound should be above the floor bound.');
 end
 if ~ischar(type)
     error('type must be a character string.');
+end
+if strcmp(type,'SNSA')&&((~isscalar(fb))||(~isscalar(cb)))
+    error('SNSA bounds must be scalar.');
 end
 if ismember(type,{'SNSA'})&&logical(mod(size(wf,1),2))
     error('waveform must have an even number of rows.')
@@ -227,4 +233,5 @@ end
 % I would never die for my beliefs because I might be wrong.
 %
 % Bertrand Russell
+
 


### PR DESCRIPTION
## Summary
- Allow `control.u_bound` and `control.l_bound` to be either scalars or arrays matching the Cartesian waveform dimensions `[ncontrols pulse_ntpts]`.
- Keep array bounds limited to Cartesian `grape_xy`/`SNS` use; reject them for `SNSA` and phase-modulated optimisations.
- Make `ctrl_trajan` plot scalar bounds as before and array bounds as dashed black bound tracks.

## Validation
- `checkcode` clean for `kernel/optimcon/optimcon.m`, `kernel/optimcon/penalty.m`, and `kernel/optimcon/ctrl_trajan.m`.
- Focused MATLAB probe: scalar/array `SNS` equivalence, array-bound gradient/Hessian checks, rectangle/trapezium validation, plotting with array bounds, and rejection of unsupported `SNSA`/phase-modulated array bounds.
- `fmaxnewton` smoke with array bounds and production `grape_xy`/`SNS` penalty: passed.
- Waveform-basis smoke with array bounds: passed.
- Existing optimal-control example setup pass: 31 transformed examples passed through `optimcon` setup using a stub optimiser.
- Production cost-function smoke subset: 17 representative optimal-control examples passed one cost-function/gradient evaluation.

## Notes
- I did not run every original optimal-control example to full optimisation convergence; several examples are intentionally long. The broad production smoke was therefore bounded to one setup pass across the set and one cost-function pass over a representative subset.
