### PR TITLE
Add quantum technology example scripts

### DIFF
--- a/examples/quantum_tech/spin_cavity_purcell_effect.m
+++ b/examples/quantum_tech/spin_cavity_purcell_effect.m
@@ -1,0 +1,72 @@
+% Cavity-induced spin relaxation in the EPR Purcell regime.
+% The Lorentzian Purcell rate follows Bienfait et al., Nature
+% 531, 74-77 (2016), and is plotted together with the corres-
+% ponding survival dynamics.
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function spin_cavity_purcell_effect()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'E','C3'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Purcell parameters
+coupling=2*pi*0.35e6;
+detuning=2*pi*linspace(-8e6,8e6,301);
+kappas=2*pi*[0.5e6 1.0e6 2.0e6 4.0e6];
+
+% Jaynes-Cummings Hamiltonian, included for explicit model syntax
+Hjc=coupling*(operator(spin_system,{'L+','A'},{1,2})+...
+              operator(spin_system,{'L-','C'},{1,2}));
+
+% Clean up numerical asymmetry
+Hjc=(Hjc+Hjc')/2;
+
+% Validate the coupling Hamiltonian
+if norm(Hjc,'fro')==0
+    error('Jaynes-Cummings Hamiltonian must be non-zero.');
+end
+
+% Compute the Lorentzian Purcell rates
+rates=zeros(numel(detuning),numel(kappas));
+for n=1:numel(kappas)
+    rates(:,n)=kappas(n)*coupling^2./(detuning.^2+(kappas(n)/2)^2);
+end
+
+% Pick representative detunings for survival curves
+time_axis=linspace(0,40e-6,250);
+det_pick=2*pi*[0 2e6 6e6];
+survival=zeros(numel(time_axis),numel(det_pick));
+for n=1:numel(det_pick)
+    rate=kappas(2)*coupling^2/(det_pick(n)^2+(kappas(2)/2)^2);
+    survival(:,n)=exp(-rate*time_axis);
+end
+
+% Plot Purcell rate and survival dynamics
+kfigure(); scale_figure([2.0 0.75]);
+subplot(1,2,1); plot(detuning/(2*pi*1e6),rates/(2*pi*1e3),'LineWidth',1.5);
+axis tight; kgrid; kxlabel('spin-cavity detuning, MHz');
+kylabel('$\Gamma_P/2\pi$, kHz');
+ktitle('Purcell rate');
+klegend({'0.5 MHz','1 MHz','2 MHz','4 MHz'},'Location','NorthEast');
+subplot(1,2,2); plot(1e6*time_axis,survival,'LineWidth',1.5);
+axis tight; kgrid; kxlabel('time, $\mu$s');
+kylabel('spin excitation survival');
+ktitle('Purcell relaxation');
+klegend({'0 MHz','2 MHz','6 MHz'},'Location','NorthEast');
+
+end
+

--- a/examples/quantum_tech/spin_cavity_vacuum_rabi.m
+++ b/examples/quantum_tech/spin_cavity_vacuum_rabi.m
@@ -1,0 +1,57 @@
+% Vacuum Rabi oscillation between an electron spin and a micro-
+% wave cavity mode in the Jaynes-Cummings approximation. This
+% is the one-spin limit of the spin-ensemble cavity experiments
+% of Schuster et al. and Kubo et al., Phys. Rev. Lett. 105,
+% 140501 and 140502 (2010).
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function spin_cavity_vacuum_rabi()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'E','C3'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Coupling parameters
+delta=0;
+g=2*pi*8e6;
+
+% Jaynes-Cummings Hamiltonian
+H=delta*operator(spin_system,'Lz',1)+...
+  g*(operator(spin_system,{'L+','A'},{1,2})+...
+     operator(spin_system,{'L-','C'},{1,2}));
+
+% Clean up numerical asymmetry
+H=(H+H')/2;
+
+% Initial state and observables
+rho=state(spin_system,{'ZL1','BL1'},{1,2});
+Ps=state(spin_system,{'ZL1','E'},{1,2});
+Pc=state(spin_system,{'E','BL2'},{1,2});
+
+% Propagate the excitation swap
+pop_s=evolution(spin_system,H,Ps,rho,1e-9,500,'observable');
+pop_c=evolution(spin_system,H,Pc,rho,1e-9,500,'observable');
+
+% Plot the vacuum Rabi dynamics
+time_axis=linspace(0,500,501);
+kfigure(); plot(time_axis,real([pop_s pop_c]),'LineWidth',1.5);
+axis tight; kgrid; kxlabel('time, ns');
+kylabel('excitation population');
+ktitle('spin-cavity vacuum Rabi oscillation');
+klegend({'spin','cavity'},'Location','East');
+
+end
+

--- a/examples/quantum_tech/spin_phonon_avoided_crossing.m
+++ b/examples/quantum_tech/spin_phonon_avoided_crossing.m
@@ -1,0 +1,61 @@
+% Avoided crossing between an electron spin transition and a
+% quantised phonon mode in the resonant spin-phonon exchange
+% model. The phonon is requested with the V# particle syntax.
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function spin_phonon_avoided_crossing()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'E','V3'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Spin and phonon operators
+Sz=operator(spin_system,'Lz',1);
+
+% Coupling parameters
+g=2*pi*4e6;
+detuning=2*pi*linspace(-20e6,20e6,121);
+
+% Exchange Hamiltonian
+action=g*(operator(spin_system,{'L+','A'},{1,2})+...
+          operator(spin_system,{'L-','C'},{1,2}));
+
+% Clean up numerical asymmetry
+action=(action+action')/2;
+
+% Preallocate the eigenvalue array
+levels=zeros(2,numel(detuning));
+
+% Sweep the spin-phonon detuning
+for n=1:numel(detuning)
+
+    % Build the rotating-frame Hamiltonian
+    H=detuning(n)*Sz+action;
+
+    % Extract the dressed one-quantum doublet
+    energies=sort(real(eig(full(H))));
+    levels(:,n)=energies(3:4)/(2*pi*1e6);
+
+end
+
+% Plot the avoided crossing
+kfigure(); plot(detuning/(2*pi*1e6),levels,'LineWidth',1.5);
+axis tight; kgrid; kxlabel('spin-phonon detuning, MHz');
+kylabel('dressed energy, MHz');
+ktitle('spin-phonon avoided crossing');
+
+end
+

--- a/examples/quantum_tech/spin_phonon_dephasing.m
+++ b/examples/quantum_tech/spin_phonon_dephasing.m
@@ -1,0 +1,61 @@
+% Longitudinal spin-phonon coupling producing spin coherence
+% modulation by a quantised vibrational mode. This is a minimal
+% Weyl-algebra version of strain-modulated spin Hamiltonians
+% used for NV-centre and molecular spin-phonon dynamics.
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function spin_phonon_dephasing()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'E','V5'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Spin and phonon operators
+Sz=operator(spin_system,'Lz',1);
+N=operator(spin_system,'N',2);
+Q=operator(spin_system,'C',2)+operator(spin_system,'A',2);
+
+% Longitudinal spin-phonon Hamiltonian parameters
+omega_v=2*pi*20e6;
+g=2*pi*3e6;
+
+% Longitudinal spin-phonon Hamiltonian
+H=omega_v*N+g*Sz*Q;
+
+% Clean up numerical asymmetry
+H=(H+H')/2;
+
+% Initial transverse spin state with the phonon in vacuum
+rho=state(spin_system,{'Lx','BL1'},{1,2});
+Sx=state(spin_system,'Lx',1);
+Qd=state(spin_system,'C',2)+state(spin_system,'A',2);
+
+% Propagate spin coherence and phonon displacement
+traj_s=evolution(spin_system,H,Sx,rho,2e-9,500,'observable');
+traj_q=evolution(spin_system,H,Qd,rho,2e-9,500,'observable');
+
+% Plot the coupled dynamics
+time_axis=linspace(0,1.0,501);
+kfigure(); scale_figure([2.0 0.75]);
+subplot(1,2,1); plot(time_axis,real(traj_s),'LineWidth',1.5);
+axis tight; kgrid; kxlabel('time, $\mu$s');
+kylabel('$S_X$'); ktitle('spin coherence');
+subplot(1,2,2); plot(time_axis,real(traj_q),'LineWidth',1.5);
+axis tight; kgrid; kxlabel('time, $\mu$s');
+kylabel('$a+a^+$'); ktitle('phonon displacement');
+
+end
+

--- a/examples/quantum_tech/spin_phonon_swap.m
+++ b/examples/quantum_tech/spin_phonon_swap.m
@@ -1,0 +1,56 @@
+% Resonant excitation swap between an electron spin and a
+% quantised phonon mode. The model is the spin-phonon Jaynes-
+% Cummings limit used in mechanical spin-qubit proposals such
+% as Rabl et al., Phys. Rev. B 79, 041302 (2009).
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function spin_phonon_swap()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'E','V3'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Coupling parameters
+delta=0;
+g=2*pi*4e6;
+
+% Spin-phonon exchange Hamiltonian
+H=delta*operator(spin_system,'Lz',1)+...
+  g*(operator(spin_system,{'L+','A'},{1,2})+...
+     operator(spin_system,{'L-','C'},{1,2}));
+
+% Clean up numerical asymmetry
+H=(H+H')/2;
+
+% Initial state and observables
+rho=state(spin_system,{'ZL1','BL1'},{1,2});
+Ps=state(spin_system,{'ZL1','E'},{1,2});
+Pv=state(spin_system,{'E','BL2'},{1,2});
+
+% Propagate the excitation swap
+pop_s=evolution(spin_system,H,Ps,rho,1e-9,800,'observable');
+pop_v=evolution(spin_system,H,Pv,rho,1e-9,800,'observable');
+
+% Plot the swap dynamics
+time_axis=linspace(0,800,801);
+kfigure(); plot(time_axis,real([pop_s pop_v]),'LineWidth',1.5);
+axis tight; kgrid; kxlabel('time, ns');
+kylabel('excitation population');
+ktitle('spin-phonon excitation swap');
+klegend({'spin','phonon'},'Location','East');
+
+end
+

--- a/examples/quantum_tech/tavis_cummings_splitting.m
+++ b/examples/quantum_tech/tavis_cummings_splitting.m
@@ -1,0 +1,64 @@
+% Collective normal-mode splitting in the Tavis-Cummings model
+% for one to four identical electron spins coupled to a common
+% microwave cavity mode. The bright-state splitting follows the
+% square-root scaling of Tavis and Cummings, Phys. Rev. 170,
+% 379 (1968).
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function tavis_cummings_splitting()
+
+% Coupling strength
+coupling=2*pi*3e6;
+
+% Preallocate the splitting array
+spin_counts=1:4;
+splitting=zeros(size(spin_counts));
+
+% Loop over ensemble sizes
+for n=spin_counts
+
+    % Magnet field
+    sys.magnet=0;
+
+    % Particle specification
+    sys.isotopes=[repmat({'E'},1,n) {'C3'}];
+
+    % Formalism and basis
+    bas.formalism='zeeman-hilb';
+    bas.approximation='none';
+
+    % Spinach housekeeping
+    spin_system=create(sys,[]);
+    spin_system=basis(spin_system,bas);
+
+    % Build the Tavis-Cummings Hamiltonian
+    H=sparse(prod(spin_system.comp.mults),prod(spin_system.comp.mults));
+    for k=1:n
+        H=H+coupling*(operator(spin_system,{'L+','A'},{k,n+1})+...
+                      operator(spin_system,{'L-','C'},{k,n+1}));
+    end
+
+    % Clean up numerical asymmetry
+    H=(H+H')/2;
+
+    % Extract the bright-mode splitting
+    energies=sort(real(eig(full(H))));
+    positive=min(energies(energies>1e-6));
+    negative=max(energies(energies<-1e-6));
+    splitting(n)=positive-negative;
+
+end
+
+% Plot numerical and analytical splittings
+kfigure(); plot(spin_counts,splitting/(2*pi*1e6),'ko','MarkerFaceColor','k');
+hold on; plot(spin_counts,2*sqrt(spin_counts)*coupling/(2*pi*1e6),'r-','LineWidth',1.5);
+hold off; axis tight; kgrid; kxlabel('number of spins');
+kylabel('normal-mode splitting, MHz');
+ktitle('Tavis-Cummings square-root scaling');
+klegend({'Spinach','2g\surd N'},'Location','NorthWest');
+
+end
+

--- a/examples/quantum_tech/transmon_cavity_swap.m
+++ b/examples/quantum_tech/transmon_cavity_swap.m
@@ -1,0 +1,61 @@
+% Vacuum Rabi swap between a transmon and a microwave cavity
+% mode, both represented by truncated bosonic Weyl algebras.
+% This is the circuit-QED Jaynes-Cummings limit of Blais et
+% al., Phys. Rev. A 69, 062320 (2004).
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function transmon_cavity_swap()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'T3','C3'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Transmon and cavity operators
+Nt=operator(spin_system,'N',1);
+Kt=operator(spin_system,'CCAA',1);
+
+% Coupling parameters
+anharm=-2*pi*250e6;
+delta=0;
+g=2*pi*20e6;
+
+% Transmon-cavity exchange Hamiltonian
+H=delta*Nt+(anharm/2)*Kt+...
+  g*(operator(spin_system,{'C','A'},{1,2})+...
+     operator(spin_system,{'A','C'},{1,2}));
+
+% Clean up numerical asymmetry
+H=(H+H')/2;
+
+% Initial state and observables
+rho=state(spin_system,{'BL2','BL1'},{1,2});
+Pt=state(spin_system,{'BL2','E'},{1,2});
+Pc=state(spin_system,{'E','BL2'},{1,2});
+
+% Propagate the excitation swap
+pop_t=evolution(spin_system,H,Pt,rho,0.5e-9,300,'observable');
+pop_c=evolution(spin_system,H,Pc,rho,0.5e-9,300,'observable');
+
+% Plot the swap dynamics
+time_axis=linspace(0,150,301);
+kfigure(); plot(time_axis,real([pop_t pop_c]),'LineWidth',1.5);
+axis tight; kgrid; kxlabel('time, ns');
+kylabel('excitation population');
+ktitle('transmon-cavity vacuum Rabi swap');
+klegend({'transmon','cavity'},'Location','East');
+
+end
+

--- a/examples/quantum_tech/transmon_duffing_ladder.m
+++ b/examples/quantum_tech/transmon_duffing_ladder.m
@@ -1,0 +1,57 @@
+% Duffing-model energy ladder of a weakly anharmonic transmon,
+% showing how the transition frequencies separate as anharmo-
+% nicity increases. Inspired by the transmon model of Koch et
+% al., Phys. Rev. A 76, 042319 (2007).
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function transmon_duffing_ladder()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'T5'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Transmon number and anharmonicity operators
+N=operator(spin_system,'N',1);
+K=operator(spin_system,'CCAA',1);
+
+% Model parameters
+omega=2*pi*5.0e9;
+anharm=2*pi*linspace(-400e6,-50e6,80);
+
+% Preallocate transition frequency array
+trans_frq=zeros(numel(anharm),4);
+
+% Sweep the Duffing anharmonicity
+for n=1:numel(anharm)
+
+    % Build the Duffing Hamiltonian
+    H=omega*N+(anharm(n)/2)*K;
+
+    % Extract adjacent transition frequencies
+    energies=sort(real(eig(full(H))));
+    trans_frq(n,:)=diff(energies)/(2*pi);
+
+end
+
+% Plot the transition ladder
+kfigure(); plot(-anharm/(2*pi*1e6),trans_frq/1e9,'LineWidth',1.5);
+axis tight; kgrid; kxlabel('$-\alpha/2\pi$, MHz');
+kylabel('transition frequency, GHz');
+ktitle('Duffing transmon ladder');
+klegend({'0-1','1-2','2-3','3-4'},'Location','SouthWest');
+
+end
+

--- a/examples/quantum_tech/transmon_rabi_leakage.m
+++ b/examples/quantum_tech/transmon_rabi_leakage.m
@@ -1,0 +1,63 @@
+% Rabi dynamics of a driven four-level transmon in the Duffing
+% approximation, including leakage into the second and third
+% excited states. Inspired by standard circuit-QED transmon
+% control models.
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function transmon_rabi_leakage()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'T4'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Transmon operators
+Cr=operator(spin_system,'C',1);
+An=operator(spin_system,'A',1);
+K=operator(spin_system,'CCAA',1);
+
+% Rotating-frame drive parameters
+anharm=-2*pi*250e6;
+omega_1=2*pi*25e6;
+
+% Driven Duffing Hamiltonian
+H=(anharm/2)*K+(omega_1/2)*(Cr+An);
+
+% Clean up numerical asymmetry
+H=(H+H')/2;
+
+% Initial state and level projectors
+rho=state(spin_system,'BL1',1);
+L1=state(spin_system,'BL1',1);
+L2=state(spin_system,'BL2',1);
+L3=state(spin_system,'BL3',1);
+L4=state(spin_system,'BL4',1);
+
+% Propagate level populations
+p1=evolution(spin_system,H,L1,rho,1e-9,400,'observable');
+p2=evolution(spin_system,H,L2,rho,1e-9,400,'observable');
+p3=evolution(spin_system,H,L3,rho,1e-9,400,'observable');
+p4=evolution(spin_system,H,L4,rho,1e-9,400,'observable');
+
+% Plot the leakage dynamics
+time_axis=linspace(0,400,401);
+kfigure(); plot(time_axis,real([p1 p2 p3 p4]),'LineWidth',1.5);
+axis tight; kgrid; kxlabel('time, ns');
+kylabel('level population');
+ktitle('transmon Rabi dynamics with leakage');
+klegend({'L1','L2','L3','L4'},'Location','East');
+
+end
+

--- a/examples/quantum_tech/transmon_ramsey_chevron.m
+++ b/examples/quantum_tech/transmon_ramsey_chevron.m
@@ -1,0 +1,71 @@
+% Ramsey chevron of a three-level transmon in the Duffing ap-
+% proximation. A nominal pi/2 pulse prepares a coherence, and
+% detuning during free evolution produces Ramsey fringes.
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function transmon_ramsey_chevron()
+
+% Magnet field
+sys.magnet=0;
+
+% Particle specification
+sys.isotopes={'T3'};
+
+% Formalism and basis
+bas.formalism='zeeman-hilb';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,[]);
+spin_system=basis(spin_system,bas);
+
+% Transmon operators
+Cr=operator(spin_system,'C',1);
+An=operator(spin_system,'A',1);
+N=operator(spin_system,'N',1);
+K=operator(spin_system,'CCAA',1);
+
+% Free-evolution parameters
+anharm=-2*pi*260e6;
+detunings=2*pi*linspace(-20e6,20e6,81);
+time_axis=linspace(0,1.0e-6,151);
+
+% Nominal pi/2 pulse and initial density matrix
+X=(Cr+An)/2;
+U90=expm(-1i*(pi/2)*full(X));
+rho=state(spin_system,'BL1',1);
+rho=U90*rho*U90';
+
+% Detection after the second pi/2 pulse
+L2=state(spin_system,'BL2',1);
+answer=zeros(numel(detunings),numel(time_axis));
+
+% Loop over offsets
+for n=1:numel(detunings)
+
+    % Build the free-evolution Hamiltonian
+    H=detunings(n)*N+(anharm/2)*K;
+
+    % Clean up numerical asymmetry
+    H=(H+H')/2;
+
+    % Propagate the Ramsey interferometer
+    for k=1:numel(time_axis)
+        U=expm(-1i*full(H)*time_axis(k));
+        rho_t=U90*U*rho*U'*U90';
+        answer(n,k)=real(trace(L2*rho_t));
+    end
+
+end
+
+% Plot the Ramsey chevron
+kfigure(); imagesc(1e6*time_axis,detunings/(2*pi*1e6),answer);
+axis xy tight; kxlabel('time, $\mu$s');
+kylabel('detuning, MHz'); kcolourbar;
+ktitle('transmon Ramsey chevron');
+
+end
+


### PR DESCRIPTION
## Summary

Adds ten compact quantum-technology examples under `examples/quantum_tech`:

- transmon Duffing ladder, Rabi leakage, Ramsey chevron, and cavity swap examples
- spin-cavity vacuum Rabi and Purcell-rate examples
- Tavis-Cummings bright-mode splitting example
- spin-phonon swap, avoided-crossing, and dephasing examples

The scripts use the existing Spinach bosonic-mode syntax (`T#`, `C#`, `V#`, `A/C/N/BLn`, and bosonic monomials such as `CCAA`) and keep the Hamiltonians small enough for example-suite use.

## Validation

- `QT_QPA_PLATFORM=offscreen matlab -nodesktop -nosplash -batch "addpath('/home/kuprov/.openclaw/workspace/tmp'); validate_quantum_tech_examples"`
  - result: `ALL_QUANTUM_TECH_EXAMPLES_OK`
- `QT_QPA_PLATFORM=offscreen matlab -nodesktop -nosplash -batch "addpath('/home/kuprov/.openclaw/workspace/tmp'); check_quantum_tech_examples"`
  - result: `CHECKCODE_DONE` with no reported messages after cleanup
