### PR TITLE
Fix bosonic quantum technology examples

### DIFF
--- a/examples/quantum_tech/spin_cavity_purcell_effect.m
+++ b/examples/quantum_tech/spin_cavity_purcell_effect.m
@@ -28,22 +28,33 @@ coupling=2*pi*0.35e6;
 detuning=2*pi*linspace(-8e6,8e6,301);
 kappas=2*pi*[0.5e6 1.0e6 2.0e6 4.0e6];
 
-% Jaynes-Cummings Hamiltonian, included for explicit model syntax
+% Jaynes-Cummings Hamiltonian in the one-excitation manifold
 Hjc=coupling*(operator(spin_system,{'L+','A'},{1,2})+...
               operator(spin_system,{'L-','C'},{1,2}));
 
 % Clean up numerical asymmetry
 Hjc=(Hjc+Hjc')/2;
 
-% Validate the coupling Hamiltonian
-if norm(Hjc,'fro')==0
-    error('Jaynes-Cummings Hamiltonian must be non-zero.');
+% Project the Hamiltonian coupling into the active doublet
+spin_exc=state(spin_system,{'ZL2','BL1'},{1,2});
+cav_exc=state(spin_system,{'ZL1','BL2'},{1,2});
+jc_coupling=norm(cav_exc*Hjc*spin_exc,'fro');
+
+% Validate the active matrix element
+if abs(jc_coupling-coupling)>1e-10*coupling
+    error('Jaynes-Cummings matrix element is inconsistent.');
 end
 
 % Compute the Lorentzian Purcell rates
 rates=zeros(numel(detuning),numel(kappas));
 for n=1:numel(kappas)
-    rates(:,n)=kappas(n)*coupling^2./(detuning.^2+(kappas(n)/2)^2);
+    rates(:,n)=kappas(n)*jc_coupling^2./...
+               (detuning.^2+(kappas(n)/2)^2);
+end
+
+% Validate resonant enhancement of the Purcell rate
+if rates(ceil(end/2),2)<=rates(1,2)
+    error('Purcell rate is not resonantly enhanced.');
 end
 
 % Pick representative detunings for survival curves
@@ -51,7 +62,7 @@ time_axis=linspace(0,40e-6,250);
 det_pick=2*pi*[0 2e6 6e6];
 survival=zeros(numel(time_axis),numel(det_pick));
 for n=1:numel(det_pick)
-    rate=kappas(2)*coupling^2/(det_pick(n)^2+(kappas(2)/2)^2);
+    rate=kappas(2)*jc_coupling^2/(det_pick(n)^2+(kappas(2)/2)^2);
     survival(:,n)=exp(-rate*time_axis);
 end
 
@@ -69,4 +80,3 @@ ktitle('Purcell relaxation');
 klegend({'0 MHz','2 MHz','6 MHz'},'Location','NorthEast');
 
 end
-

--- a/examples/quantum_tech/spin_cavity_vacuum_rabi.m
+++ b/examples/quantum_tech/spin_cavity_vacuum_rabi.m
@@ -36,22 +36,31 @@ H=delta*operator(spin_system,'Lz',1)+...
 % Clean up numerical asymmetry
 H=(H+H')/2;
 
-% Initial state and observables
-rho=state(spin_system,{'ZL1','BL1'},{1,2});
-Ps=state(spin_system,{'ZL1','E'},{1,2});
-Pc=state(spin_system,{'E','BL2'},{1,2});
+% Initial spin excitation and observables
+rho=state(spin_system,{'ZL2','BL1'},{1,2});
+Ps=state(spin_system,{'ZL2','E'},{1,2});
+Pc=state(spin_system,{'ZL1','BL2'},{1,2});
 
 % Propagate the excitation swap
 pop_s=evolution(spin_system,H,Ps,rho,1e-9,500,'observable');
 pop_c=evolution(spin_system,H,Pc,rho,1e-9,500,'observable');
 
+% Validate visible excitation exchange
+if (max(real(pop_c))<0.95)||(min(real(pop_s))>0.05)
+    error('vacuum Rabi exchange is not visible.');
+end
+
+% Validate population conservation in the active doublet
+if max(abs(real(pop_s+pop_c)-1))>1e-6
+    error('active-doublet population is not conserved.');
+end
+
 % Plot the vacuum Rabi dynamics
 time_axis=linspace(0,500,501);
 kfigure(); plot(time_axis,real([pop_s pop_c]),'LineWidth',1.5);
-axis tight; kgrid; kxlabel('time, ns');
+axis tight; ylim([-0.05 1.05]); kgrid; kxlabel('time, ns');
 kylabel('excitation population');
 ktitle('spin-cavity vacuum Rabi oscillation');
 klegend({'spin','cavity'},'Location','East');
 
 end
-

--- a/examples/quantum_tech/spin_phonon_avoided_crossing.m
+++ b/examples/quantum_tech/spin_phonon_avoided_crossing.m
@@ -22,8 +22,8 @@ bas.approximation='none';
 spin_system=create(sys,[]);
 spin_system=basis(spin_system,bas);
 
-% Spin and phonon operators
-Sz=operator(spin_system,'Lz',1);
+% Spin operator
+electron_z=operator(spin_system,'Lz',1);
 
 % Coupling parameters
 g=2*pi*4e6;
@@ -36,6 +36,14 @@ action=g*(operator(spin_system,{'L+','A'},{1,2})+...
 % Clean up numerical asymmetry
 action=(action+action')/2;
 
+% Locate the one-excitation manifold
+spin_exc=state(spin_system,{'ZL2','BL1'},{1,2});
+phon_exc=state(spin_system,{'ZL1','BL2'},{1,2});
+one_quant=speye(size(action,1));
+spin_idx=find(diag(spin_exc)>0.5);
+phon_idx=find(diag(phon_exc)>0.5);
+one_quant=one_quant(:,[spin_idx phon_idx]);
+
 % Preallocate the eigenvalue array
 levels=zeros(2,numel(detuning));
 
@@ -43,12 +51,18 @@ levels=zeros(2,numel(detuning));
 for n=1:numel(detuning)
 
     % Build the rotating-frame Hamiltonian
-    H=detuning(n)*Sz+action;
+    H=detuning(n)*electron_z+action;
 
     % Extract the dressed one-quantum doublet
-    energies=sort(real(eig(full(H))));
-    levels(:,n)=energies(3:4)/(2*pi*1e6);
+    H=one_quant'*H*one_quant;
+    levels(:,n)=sort(real(eig(full(H))))/(2*pi*1e6);
 
+end
+
+% Validate the resonant avoided-crossing gap
+gap=min(levels(2,:)-levels(1,:));
+if abs(gap-2*g/(2*pi*1e6))>1e-6
+    error('spin-phonon avoided-crossing gap is inconsistent.');
 end
 
 % Plot the avoided crossing
@@ -58,4 +72,3 @@ kylabel('dressed energy, MHz');
 ktitle('spin-phonon avoided crossing');
 
 end
-

--- a/examples/quantum_tech/spin_phonon_dephasing.m
+++ b/examples/quantum_tech/spin_phonon_dephasing.m
@@ -1,7 +1,8 @@
 % Longitudinal spin-phonon coupling producing spin coherence
-% modulation by a quantised vibrational mode. This is a minimal
-% Weyl-algebra version of strain-modulated spin Hamiltonians
-% used for NV-centre and molecular spin-phonon dynamics.
+% modulation and spin-conditioned displacement of a quantised
+% vibrational mode. This is a minimal Weyl-algebra version of
+% strain-modulated spin Hamiltonians used for NV-centre and
+% molecular spin-phonon dynamics.
 %
 % Calculation time: seconds
 %
@@ -13,7 +14,7 @@ function spin_phonon_dephasing()
 sys.magnet=0;
 
 % Particle specification
-sys.isotopes={'E','V5'};
+sys.isotopes={'E','V7'};
 
 % Formalism and basis
 bas.formalism='zeeman-hilb';
@@ -30,7 +31,7 @@ Q=operator(spin_system,'C',2)+operator(spin_system,'A',2);
 
 % Longitudinal spin-phonon Hamiltonian parameters
 omega_v=2*pi*20e6;
-g=2*pi*3e6;
+g=2*pi*4e6;
 
 % Longitudinal spin-phonon Hamiltonian
 H=omega_v*N+g*Sz*Q;
@@ -38,14 +39,27 @@ H=omega_v*N+g*Sz*Q;
 % Clean up numerical asymmetry
 H=(H+H')/2;
 
-% Initial transverse spin state with the phonon in vacuum
-rho=state(spin_system,{'Lx','BL1'},{1,2});
+% Initial states for coherence and displacement
+rho_coh=state(spin_system,{'Lx','BL1'},{1,2});
+rho_disp=state(spin_system,{'ZL2','BL1'},{1,2});
+
+% Detection operators
 Sx=state(spin_system,'Lx',1);
 Qd=state(spin_system,'C',2)+state(spin_system,'A',2);
 
-% Propagate spin coherence and phonon displacement
-traj_s=evolution(spin_system,H,Sx,rho,2e-9,500,'observable');
-traj_q=evolution(spin_system,H,Qd,rho,2e-9,500,'observable');
+% Propagate spin coherence and spin-conditioned phonon displacement
+traj_s=evolution(spin_system,H,Sx,rho_coh,2e-9,500,'observable');
+traj_q=evolution(spin_system,H,Qd,rho_disp,2e-9,500,'observable');
+
+% Validate visible oscillator displacement
+if max(abs(real(traj_q)))<0.2
+    error('spin-conditioned displacement is not visible.');
+end
+
+% Validate visible spin coherence modulation
+if (max(real(traj_s))-min(real(traj_s)))<0.02
+    error('spin coherence modulation is not visible.');
+end
 
 % Plot the coupled dynamics
 time_axis=linspace(0,1.0,501);
@@ -55,7 +69,6 @@ axis tight; kgrid; kxlabel('time, $\mu$s');
 kylabel('$S_X$'); ktitle('spin coherence');
 subplot(1,2,2); plot(time_axis,real(traj_q),'LineWidth',1.5);
 axis tight; kgrid; kxlabel('time, $\mu$s');
-kylabel('$a+a^+$'); ktitle('phonon displacement');
+kylabel('$a+a^+$'); ktitle('conditional displacement');
 
 end
-

--- a/examples/quantum_tech/spin_phonon_swap.m
+++ b/examples/quantum_tech/spin_phonon_swap.m
@@ -35,22 +35,31 @@ H=delta*operator(spin_system,'Lz',1)+...
 % Clean up numerical asymmetry
 H=(H+H')/2;
 
-% Initial state and observables
-rho=state(spin_system,{'ZL1','BL1'},{1,2});
-Ps=state(spin_system,{'ZL1','E'},{1,2});
-Pv=state(spin_system,{'E','BL2'},{1,2});
+% Initial spin excitation and observables
+rho=state(spin_system,{'ZL2','BL1'},{1,2});
+Ps=state(spin_system,{'ZL2','E'},{1,2});
+Pv=state(spin_system,{'ZL1','BL2'},{1,2});
 
 % Propagate the excitation swap
 pop_s=evolution(spin_system,H,Ps,rho,1e-9,800,'observable');
 pop_v=evolution(spin_system,H,Pv,rho,1e-9,800,'observable');
 
+% Validate visible excitation exchange
+if (max(real(pop_v))<0.95)||(min(real(pop_s))>0.05)
+    error('spin-phonon exchange is not visible.');
+end
+
+% Validate population conservation in the active doublet
+if max(abs(real(pop_s+pop_v)-1))>1e-6
+    error('active-doublet population is not conserved.');
+end
+
 % Plot the swap dynamics
 time_axis=linspace(0,800,801);
 kfigure(); plot(time_axis,real([pop_s pop_v]),'LineWidth',1.5);
-axis tight; kgrid; kxlabel('time, ns');
+axis tight; ylim([-0.05 1.05]); kgrid; kxlabel('time, ns');
 kylabel('excitation population');
 ktitle('spin-phonon excitation swap');
 klegend({'spin','phonon'},'Location','East');
 
 end
-

--- a/examples/quantum_tech/tavis_cummings_splitting.m
+++ b/examples/quantum_tech/tavis_cummings_splitting.m
@@ -44,21 +44,39 @@ for n=spin_counts
     % Clean up numerical asymmetry
     H=(H+H')/2;
 
-    % Extract the bright-mode splitting
-    energies=sort(real(eig(full(H))));
-    positive=min(energies(energies>1e-6));
-    negative=max(energies(energies<-1e-6));
-    splitting(n)=positive-negative;
+    % Locate the one-excitation manifold
+    one_quant=speye(size(H,1));
+    subspace=zeros(n+1,1);
+    for k=1:n
+        spin_state=repmat({'ZL1'},1,n);
+        spin_state{k}='ZL2';
+        projector=state(spin_system,[spin_state {'BL1'}],num2cell(1:(n+1)));
+        subspace(k)=find(diag(projector)>0.5);
+    end
+    projector=state(spin_system,[repmat({'ZL1'},1,n) {'BL2'}],num2cell(1:(n+1)));
+    subspace(n+1)=find(diag(projector)>0.5);
+    one_quant=one_quant(:,subspace);
 
+    % Extract the bright-mode splitting
+    energies=sort(real(eig(full(one_quant'*H*one_quant))));
+    splitting(n)=max(energies)-min(energies);
+
+end
+
+% Compute the analytical splitting
+analytical=2*sqrt(spin_counts)*coupling;
+
+% Validate the square-root scaling
+if max(abs(splitting-analytical)./analytical)>1e-10
+    error('Tavis-Cummings splitting does not follow square-root scaling.');
 end
 
 % Plot numerical and analytical splittings
 kfigure(); plot(spin_counts,splitting/(2*pi*1e6),'ko','MarkerFaceColor','k');
-hold on; plot(spin_counts,2*sqrt(spin_counts)*coupling/(2*pi*1e6),'r-','LineWidth',1.5);
+hold on; plot(spin_counts,analytical/(2*pi*1e6),'r-','LineWidth',1.5);
 hold off; axis tight; kgrid; kxlabel('number of spins');
 kylabel('normal-mode splitting, MHz');
 ktitle('Tavis-Cummings square-root scaling');
 klegend({'Spinach','2g\surd N'},'Location','NorthWest');
 
 end
-


### PR DESCRIPTION
## Summary

This PR fixes the bosonic-mode quantum-technology examples added in PR #87.

The root problem was not the Weyl syntax itself; it was that several scripts either initialized the zero-excitation dark state or selected/plotted the wrong manifold/observable. Under the current conventions, `C#`/`V#` are Weyl bosons, `BL1` is vacuum, `BL2` is one quantum, `ZL1` is the lower spin-1/2 level, `ZL2` is the upper level, and `L+ A + L- C` is the rotating-wave exchange term.

## Changes

- `spin_cavity_vacuum_rabi.m`: starts in `ZL2,BL1`, observes the spin/cavity one-excitation doublet, and asserts visible population exchange plus doublet population conservation.
- `spin_phonon_swap.m`: same correction for the spin/phonon one-excitation swap.
- `spin_phonon_avoided_crossing.m`: projects onto the `|ZL2,BL1>` / `|ZL1,BL2>` one-excitation manifold and asserts the resonant gap is `2g`.
- `spin_phonon_dephasing.m`: separates spin-coherence and spin-eigenstate displacement initial conditions so the plotted oscillator displacement does not cancel by symmetry; adds visibility assertions.
- `tavis_cummings_splitting.m`: extracts the one-excitation manifold and compares the bright-mode splitting with `2g*sqrt(N)`.
- `spin_cavity_purcell_effect.m`: actually uses the Jaynes-Cummings matrix element from `Hjc` in the Purcell rate/survival calculation and asserts resonant enhancement.

## Validation

- `QT_QPA_PLATFORM=offscreen matlab -nodesktop -nosplash -batch "addpath('/home/kuprov/.openclaw/workspace/tmp'); check_quantum_tech_examples"`
  - `CHECKCODE_DONE`
- `QT_QPA_PLATFORM=offscreen matlab -nodesktop -nosplash -batch "addpath('/home/kuprov/.openclaw/workspace/tmp'); validate_quantum_tech_examples"`
  - `ALL_QUANTUM_TECH_EXAMPLES_OK`
- `QT_QPA_PLATFORM=offscreen matlab -nodesktop -nosplash -batch "addpath('/home/kuprov/.openclaw/workspace/tmp'); validate_bosonic_example_physics"`
  - `BOSONIC_EXAMPLE_PHYSICS_OK`
- `QT_QPA_PLATFORM=offscreen matlab -nodesktop -nosplash -batch "addpath('/home/kuprov/.openclaw/workspace/tmp'); export_bosonic_example_figures"`
  - `BOSONIC_EXAMPLE_FIGURES_OK`
- Figure inspection of the exported PNGs found no obvious plot failures: Rabi oscillations, spin-phonon swap, avoided crossing, conditional displacement, Purcell resonance/survival, and Tavis-Cummings dots on the red sqrt curve are all visible.
- `git diff --check`
