### PR TITLE
Remove local path from regression test

### DIFF
--- a/tests/kernel/test_dynamic_integrity_includes_mex_suite.m
+++ b/tests/kernel/test_dynamic_integrity_includes_mex_suite.m
@@ -21,7 +21,7 @@ result=new_test_result('kernel/dynamic_integrity_includes_mex',...
                        'low-feasibility include scripts and integrity utilities must be exercised without mutating the Spinach tree.');
 
 % Locate canonical Spinach subtrees
-spinach_root='/home/kuprov/.openclaw/workspace/Spinach';
+spinach_root=fileparts(fileparts(fileparts(mfilename('fullpath'))));
 includes_dir=fullfile(spinach_root,'kernel','includes');
 integrity_dir=fullfile(spinach_root,'kernel','integrity');
 mex_dir=fullfile(spinach_root,'kernel','mex');


### PR DESCRIPTION
## Summary

- remove a hard-coded local `/home/kuprov/.openclaw/workspace/Spinach` path from `tests/kernel/test_dynamic_integrity_includes_mex_suite.m`
- derive the Spinach root from `mfilename('fullpath')`, so the test follows the checked-out repository location

## Validation

- `rg -n "/home/kuprov|\.openclaw|workspace/Spinach|['\"]/(home|Users|root)/" tests` → no matches
- `git diff --check -- tests/kernel/test_dynamic_integrity_includes_mex_suite.m`
- `checkcode('tests/kernel/test_dynamic_integrity_includes_mex_suite.m','-id')`
- `run_tests('pattern','dynamic_integrity_includes_mex','verbose',true,'stop_on_fail',true)` → 1 passed, 0 failed
