### PR TITLE
Print regression test summaries on startup

### DIFF
--- a/tests/kernel/test_apodisation_exp_window.m
+++ b/tests/kernel/test_apodisation_exp_window.m
@@ -13,6 +13,9 @@
 
 function result=test_apodisation_exp_window()
 
+% Announce the test target
+fprintf('TESTING: Exponential FID apodisation\n');
+
 % State the processing target of the test
 result=new_test_result('kernel/apodisation_exp_window',...
                        'Exponential FID apodisation',...

--- a/tests/kernel/test_cache_temp_scratch.m
+++ b/tests/kernel/test_cache_temp_scratch.m
@@ -14,6 +14,9 @@
 
 function result=test_cache_temp_scratch()
 
+% Announce the test target
+fprintf('TESTING: Temporary scratch cache management\n');
+
 % State the cache-management target of the test
 result=new_test_result('kernel/cache_temp_scratch',...
                        'Temporary scratch cache management',...

--- a/tests/kernel/test_chemical_exchange_conservation.m
+++ b/tests/kernel/test_chemical_exchange_conservation.m
@@ -13,6 +13,9 @@
 
 function result=test_chemical_exchange_conservation()
 
+% Announce the test target
+fprintf('TESTING: Chemical exchange conservation\n');
+
 % State the kinetics target of the test
 result=new_test_result('kernel/chemical_exchange_conservation',...
                        'Chemical exchange conservation',...

--- a/tests/kernel/test_commutator_utility.m
+++ b/tests/kernel/test_commutator_utility.m
@@ -13,6 +13,9 @@
 
 function result=test_commutator_utility()
 
+% Announce the test target
+fprintf('TESTING: Matrix commutator utility\n');
+
 % State the mathematical target of the test
 result=new_test_result('kernel/commutator_utility',...
                        'Matrix commutator utility',...

--- a/tests/kernel/test_ctx_doublerot_acquire.m
+++ b/tests/kernel/test_ctx_doublerot_acquire.m
@@ -14,6 +14,9 @@
 
 function result=test_ctx_doublerot_acquire()
 
+% Announce the test target
+fprintf('TESTING: Double-rotor acquire path\n');
+
 % State the double-rotor target of the test
 result=new_test_result('kernel/ctx_doublerot_acquire',...
                        'Double-rotor acquire path',...

--- a/tests/kernel/test_ctx_floquet_acquire.m
+++ b/tests/kernel/test_ctx_floquet_acquire.m
@@ -14,6 +14,9 @@
 
 function result=test_ctx_floquet_acquire()
 
+% Announce the test target
+fprintf('TESTING: Floquet acquire path\n');
+
 % State the Floquet-context target of the test
 result=new_test_result('kernel/ctx_floquet_acquire',...
                        'Floquet acquire path',...

--- a/tests/kernel/test_ctx_gridfree_acquire.m
+++ b/tests/kernel/test_ctx_gridfree_acquire.m
@@ -14,6 +14,9 @@
 
 function result=test_ctx_gridfree_acquire()
 
+% Announce the test target
+fprintf('TESTING: Grid-free acquire path\n');
+
 % State the grid-free target of the test
 result=new_test_result('kernel/ctx_gridfree_acquire',...
                        'Grid-free acquire path',...

--- a/tests/kernel/test_ctx_liquid_acquire.m
+++ b/tests/kernel/test_ctx_liquid_acquire.m
@@ -14,6 +14,9 @@
 
 function result=test_ctx_liquid_acquire()
 
+% Announce the test target
+fprintf('TESTING: Liquid context acquire path\n');
+
 % State the liquid-context target of the test
 result=new_test_result('kernel/ctx_liquid_acquire',...
                        'Liquid context acquire path',...

--- a/tests/kernel/test_ctx_powder_average.m
+++ b/tests/kernel/test_ctx_powder_average.m
@@ -13,6 +13,9 @@
 
 function result=test_ctx_powder_average()
 
+% Announce the test target
+fprintf('TESTING: Powder weighted sum path\n');
+
 % State the powder-averaging target of the test
 result=new_test_result('kernel/ctx_powder_average',...
                        'Powder weighted sum path',...

--- a/tests/kernel/test_ctx_powder_crystal.m
+++ b/tests/kernel/test_ctx_powder_crystal.m
@@ -14,6 +14,9 @@
 
 function result=test_ctx_powder_crystal()
 
+% Announce the test target
+fprintf('TESTING: Powder and crystal single orientation\n');
+
 % State the static-context target of the test
 result=new_test_result('kernel/ctx_powder_crystal',...
                        'Powder and crystal single orientation',...

--- a/tests/kernel/test_ctx_singlerot_acquire.m
+++ b/tests/kernel/test_ctx_singlerot_acquire.m
@@ -14,6 +14,9 @@
 
 function result=test_ctx_singlerot_acquire()
 
+% Announce the test target
+fprintf('TESTING: Single-rotor acquire path\n');
+
 % State the single-rotor target of the test
 result=new_test_result('kernel/ctx_singlerot_acquire',...
                        'Single-rotor acquire path',...

--- a/tests/kernel/test_dynamic_chem_geometry_suite.m
+++ b/tests/kernel/test_dynamic_chem_geometry_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_chem_geometry_suite()
 
+% Announce the test target
+fprintf('TESTING: Chemistry and geometry utilities\n');
+
 % State the chemistry and geometry target of the test
 result=new_test_result('kernel/dynamic_chem_geometry_suite',...
                        'Chemistry and geometry utilities',...

--- a/tests/kernel/test_dynamic_equilibrium_frontends.m
+++ b/tests/kernel/test_dynamic_equilibrium_frontends.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_equilibrium_frontends()
 
+% Announce the test target
+fprintf('TESTING: Dynamic equilibrium front ends\n');
+
 % State the dynamic equilibrium target of the test
 result=new_test_result('kernel/dynamic_equilibrium_frontends',...
                        'Dynamic equilibrium front ends',...

--- a/tests/kernel/test_dynamic_examples_smoke.m
+++ b/tests/kernel/test_dynamic_examples_smoke.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_examples_smoke()
 
+% Announce the test target
+fprintf('TESTING: Dynamic plotting example smoke paths\n');
+
 % State the dynamic example-stage target of the test
 result=new_test_result('examples/dynamic_examples_smoke',...
                        'Dynamic plotting example smoke paths',...

--- a/tests/kernel/test_dynamic_filter_frontends.m
+++ b/tests/kernel/test_dynamic_filter_frontends.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_filter_frontends()
 
+% Announce the test target
+fprintf('TESTING: Dynamic state-filter front ends\n');
+
 % State the dynamic filter target of the test
 result=new_test_result('kernel/dynamic_filter_frontends',...
                        'Dynamic state-filter front ends',...

--- a/tests/kernel/test_dynamic_fp_contexts.m
+++ b/tests/kernel/test_dynamic_fp_contexts.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_fp_contexts()
 
+% Announce the test target
+fprintf('TESTING: Fokker-Planck imaging and meshflow contexts\n');
+
 % State the context target of the test
 result=new_test_result('kernel/dynamic_fp_contexts',...
                        'Fokker-Planck imaging and meshflow contexts',...

--- a/tests/kernel/test_dynamic_frame_frontends.m
+++ b/tests/kernel/test_dynamic_frame_frontends.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_frame_frontends()
 
+% Announce the test target
+fprintf('TESTING: Dynamic frame and averaging front ends\n');
+
 % State the dynamic frame target of the test
 result=new_test_result('kernel/dynamic_frame_frontends',...
                        'Dynamic frame and averaging front ends',...

--- a/tests/kernel/test_dynamic_grid_plot.m
+++ b/tests/kernel/test_dynamic_grid_plot.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_grid_plot()
 
+% Announce the test target
+fprintf('TESTING: Spherical grid plotting\n');
+
 % State the grid_plot target of the test
 result=new_test_result('kernel/dynamic_grid_plot',...
                        'Offscreen spherical grid plotting',...

--- a/tests/kernel/test_dynamic_integrity_includes_mex_suite.m
+++ b/tests/kernel/test_dynamic_integrity_includes_mex_suite.m
@@ -15,6 +15,9 @@
 
 function result=test_dynamic_integrity_includes_mex_suite()
 
+% Announce the test target
+fprintf('TESTING: Dynamic integrity, include, and MEX helper coverage\n');
+
 % State the integrity/include/MEX target of the test
 result=new_test_result('kernel/dynamic_integrity_includes_mex',...
                        'Dynamic integrity, include, and MEX helper coverage',...

--- a/tests/kernel/test_dynamic_iserstep_highorder.m
+++ b/tests/kernel/test_dynamic_iserstep_highorder.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_iserstep_highorder()
 
+% Announce the test target
+fprintf('TESTING: Nonlinear high-order iserstep branches\n');
+
 % State the nonlinear Lie-step target of the test
 result=new_test_result('kernel/dynamic_iserstep_highorder',...
                        'Nonlinear high-order iserstep branches',...

--- a/tests/kernel/test_dynamic_metadata_partition_suite.m
+++ b/tests/kernel/test_dynamic_metadata_partition_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_metadata_partition_suite()
 
+% Announce the test target
+fprintf('TESTING: Metadata and partition utilities\n');
+
 % State the metadata and partition target of the test
 result=new_test_result('kernel/dynamic_metadata_partition_suite',...
                        'Metadata, hashing, and partition utilities',...

--- a/tests/kernel/test_dynamic_optimcon_remaining.m
+++ b/tests/kernel/test_dynamic_optimcon_remaining.m
@@ -16,6 +16,9 @@
 
 function result=test_dynamic_optimcon_remaining()
 
+% Announce the test target
+fprintf('TESTING: Remaining optimal-control dynamic helpers\n');
+
 % State the dynamic optimal-control target of the test
 result=new_test_result('kernel/dynamic_optimcon_remaining',...
                        'Remaining optimal-control dynamic helpers',...

--- a/tests/kernel/test_dynamic_overload_cell_struct_suite.m
+++ b/tests/kernel/test_dynamic_overload_cell_struct_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_overload_cell_struct_suite()
 
+% Announce the test target
+fprintf('TESTING: Cell and structure overload dispatch\n');
+
 % State the overload target of the test
 result=new_test_result('tmp/dynamic_overloads_retry/cell_struct',...
                        'Dynamic cell and struct overload dispatch',...

--- a/tests/kernel/test_dynamic_overload_sparse_polyadic_suite.m
+++ b/tests/kernel/test_dynamic_overload_sparse_polyadic_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_overload_sparse_polyadic_suite()
 
+% Announce the test target
+fprintf('TESTING: Sparse, polyadic, and OPIUM overload dispatch\n');
+
 % State the overload target of the test
 result=new_test_result('kernel/dynamic_overload_sparse_polyadic_suite',...
                        'Dynamic sparse and polyadic overload dispatch',...

--- a/tests/kernel/test_dynamic_overload_ttclass_suite.m
+++ b/tests/kernel/test_dynamic_overload_ttclass_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_overload_ttclass_suite()
 
+% Announce the test target
+fprintf('TESTING: Tensor-train overload dispatch\n');
+
 % State the overload target of the test
 result=new_test_result('kernel/dynamic_overload_ttclass_suite',...
                        'Dynamic ttclass overload dispatch',...

--- a/tests/kernel/test_dynamic_parse_text_reporting_suite.m
+++ b/tests/kernel/test_dynamic_parse_text_reporting_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_parse_text_reporting_suite()
 
+% Announce the test target
+fprintf('TESTING: Parsing, text, and reporting utilities\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/dynamic_parse_text_reporting_suite',...
                        'Parsing, text, and reporting utilities',...

--- a/tests/kernel/test_dynamic_physics_formulae_suite.m
+++ b/tests/kernel/test_dynamic_physics_formulae_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_physics_formulae_suite()
 
+% Announce the test target
+fprintf('TESTING: Physical formula utilities\n');
+
 % State the physical formula target of the test
 result=new_test_result('kernel/dynamic_physics_formulae_suite',...
                        'Physical formula utilities',...

--- a/tests/kernel/test_dynamic_propagation_frontends.m
+++ b/tests/kernel/test_dynamic_propagation_frontends.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_propagation_frontends()
 
+% Announce the test target
+fprintf('TESTING: Dynamic propagation front ends\n');
+
 % State the dynamic propagation target of the test
 result=new_test_result('kernel/dynamic_propagation_frontends',...
                        'Dynamic propagation front ends',...

--- a/tests/kernel/test_dynamic_pulse_utilities_deep.m
+++ b/tests/kernel/test_dynamic_pulse_utilities_deep.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_pulse_utilities_deep()
 
+% Announce the test target
+fprintf('TESTING: Dynamic pulse utility paths\n');
+
 % State the pulse-utility target of the test
 result=new_test_result('kernel/dynamic_pulse_utilities_deep',...
                        'Dynamic pulse utility paths',...

--- a/tests/kernel/test_dynamic_relaxation_models_suite.m
+++ b/tests/kernel/test_dynamic_relaxation_models_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_relaxation_models_suite()
 
+% Announce the test target
+fprintf('TESTING: Dynamic relaxation model helpers\n');
+
 % State the relaxation-model target of the test
 result=new_test_result('kernel/dynamic_relaxation_models_suite',...
                        'Dynamic relaxation model helpers',...

--- a/tests/kernel/test_dynamic_remaining_core_suite.m
+++ b/tests/kernel/test_dynamic_remaining_core_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_remaining_core_suite()
 
+% Announce the test target
+fprintf('TESTING: Remaining deterministic utility helpers\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/dynamic_remaining_core_suite',...
                        'Remaining deterministic utility helpers',...

--- a/tests/kernel/test_dynamic_remaining_parallel_suite.m
+++ b/tests/kernel/test_dynamic_remaining_parallel_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_remaining_parallel_suite()
 
+% Announce the test target
+fprintf('TESTING: Remaining parallel and stochastic utilities\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/dynamic_remaining_parallel_suite',...
                        'Remaining parallel and stochastic utilities',...

--- a/tests/kernel/test_dynamic_remaining_regularisation_suite.m
+++ b/tests/kernel/test_dynamic_remaining_regularisation_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_remaining_regularisation_suite()
 
+% Announce the test target
+fprintf('TESTING: Remaining regularisation utilities\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/dynamic_remaining_regularisation_suite',...
                        'Remaining regularisation utilities',...

--- a/tests/kernel/test_dynamic_remaining_spectral_suite.m
+++ b/tests/kernel/test_dynamic_remaining_spectral_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_remaining_spectral_suite()
 
+% Announce the test target
+fprintf('TESTING: Remaining spectral and spatial utilities\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/dynamic_remaining_spectral_suite',...
                        'Remaining spectral and spatial utilities',...

--- a/tests/kernel/test_dynamic_rlx_split_suite.m
+++ b/tests/kernel/test_dynamic_rlx_split_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_rlx_split_suite()
 
+% Announce the test target
+fprintf('TESTING: Relaxation component splitting\n');
+
 % State the relaxation-splitting target of the test
 result=new_test_result('kernel/dynamic_rlx_split_suite',...
                        'Relaxation component splitting',...

--- a/tests/kernel/test_dynamic_shaped_pulses_deep.m
+++ b/tests/kernel/test_dynamic_shaped_pulses_deep.m
@@ -14,6 +14,9 @@
 
 function result=test_dynamic_shaped_pulses_deep()
 
+% Announce the test target
+fprintf('TESTING: Dynamic shaped pulse propagation paths\n');
+
 % State the dynamic shaped-pulse target of the test
 result=new_test_result('kernel/dynamic_shaped_pulses_deep',...
                        'Dynamic shaped pulse propagation paths',...

--- a/tests/kernel/test_dynamic_spin_edit_suite.m
+++ b/tests/kernel/test_dynamic_spin_edit_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_spin_edit_suite()
 
+% Announce the test target
+fprintf('TESTING: Spin-system editing utilities\n');
+
 % State the spin editing target of the test
 result=new_test_result('kernel/dynamic_spin_edit_suite',...
                        'Spin-system editing utilities',...

--- a/tests/kernel/test_dynamic_state_equilibrium_suite.m
+++ b/tests/kernel/test_dynamic_state_equilibrium_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_state_equilibrium_suite()
 
+% Announce the test target
+fprintf('TESTING: Thermal equilibrium constructors\n');
+
 % State the equilibrium-constructor target of the test
 result=new_test_result('kernel/dynamic_state_equilibrium_suite',...
                        'Thermal equilibrium constructors',...

--- a/tests/kernel/test_dynamic_state_projection_suite.m
+++ b/tests/kernel/test_dynamic_state_projection_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_state_projection_suite()
 
+% Announce the test target
+fprintf('TESTING: Dynamic state projection helpers\n');
+
 % State the state-projection target of the test
 result=new_test_result('kernel/dynamic_state_projection_suite',...
                        'Dynamic state projection helpers',...

--- a/tests/kernel/test_dynamic_superop.m
+++ b/tests/kernel/test_dynamic_superop.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_superop()
 
+% Announce the test target
+fprintf('TESTING: Spherical-tensor superoperator construction\n');
+
 % State the superop target of the test
 result=new_test_result('kernel/dynamic_superop',...
                        'Spherical-tensor superoperator construction',...

--- a/tests/kernel/test_dynamic_trajectory_frontends.m
+++ b/tests/kernel/test_dynamic_trajectory_frontends.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_trajectory_frontends()
 
+% Announce the test target
+fprintf('TESTING: Dynamic trajectory analysis front ends\n');
+
 % State the dynamic trajectory target of the test
 result=new_test_result('kernel/dynamic_trajectory_frontends',...
                        'Dynamic trajectory analysis front ends',...

--- a/tests/kernel/test_dynamic_voitlander.m
+++ b/tests/kernel/test_dynamic_voitlander.m
@@ -13,6 +13,9 @@
 
 function result=test_dynamic_voitlander()
 
+% Announce the test target
+fprintf('TESTING: Voitlander spherical-triangle integration\n');
+
 % State the Voitlander target of the test
 result=new_test_result('kernel/dynamic_voitlander',...
                        'Adaptive Voitlander triangle integral',...

--- a/tests/kernel/test_euler_rotation_matrix.m
+++ b/tests/kernel/test_euler_rotation_matrix.m
@@ -13,6 +13,9 @@
 
 function result=test_euler_rotation_matrix()
 
+% Announce the test target
+fprintf('TESTING: Euler active rotation matrix\n');
+
 % State the physical target of the test
 result=new_test_result('kernel/euler_rotation_matrix',...
                        'Euler active rotation matrix',...

--- a/tests/kernel/test_exponential_krylov_suite.m
+++ b/tests/kernel/test_exponential_krylov_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_exponential_krylov_suite()
 
+% Announce the test target
+fprintf('TESTING: Exponential and Krylov numerical utilities\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/exponential_krylov_suite',...
                        'Exponential and Krylov numerical utilities',...

--- a/tests/kernel/test_finite_difference_suite.m
+++ b/tests/kernel/test_finite_difference_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_finite_difference_suite()
 
+% Announce the test target
+fprintf('TESTING: Finite-difference and spectral differentiation functions\n');
+
 % State the differentiation target of the test
 result=new_test_result('kernel/finite_difference_suite',...
                        'Finite-difference and spectral differentiation functions',...

--- a/tests/kernel/test_graph_geometry_suite.m
+++ b/tests/kernel/test_graph_geometry_suite.m
@@ -15,6 +15,9 @@
 
 function result=test_graph_geometry_suite()
 
+% Announce the test target
+fprintf('TESTING: Graph, geometry, and coordinate utilities\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/graph_geometry_suite',...
                        'Graph, geometry, and coordinate utilities',...

--- a/tests/kernel/test_grid_geometry_suite.m
+++ b/tests/kernel/test_grid_geometry_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_grid_geometry_suite()
 
+% Announce the test target
+fprintf('TESTING: Grid and spherical geometry helpers\n');
+
 % State the grid target of the test
 result=new_test_result('kernel/grid_geometry_suite',...
                        'Grid and spherical geometry helpers',...

--- a/tests/kernel/test_hilbert_operator.m
+++ b/tests/kernel/test_hilbert_operator.m
@@ -13,6 +13,9 @@
 
 function result=test_hilbert_operator()
 
+% Announce the test target
+fprintf('TESTING: Hilbert-space operator generation\n');
+
 % State the physical target of the test
 result=new_test_result('kernel/hilbert_operator',...
                        'Hilbert-space operator generation',...

--- a/tests/kernel/test_hilbert_state.m
+++ b/tests/kernel/test_hilbert_state.m
@@ -13,6 +13,9 @@
 
 function result=test_hilbert_state()
 
+% Announce the test target
+fprintf('TESTING: Hilbert-space state generation\n');
+
 % State the physical target of the test
 result=new_test_result('kernel/hilbert_state',...
                        'Hilbert-space state generation',...

--- a/tests/kernel/test_indexing_inverse_suite.m
+++ b/tests/kernel/test_indexing_inverse_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_indexing_inverse_suite()
 
+% Announce the test target
+fprintf('TESTING: Indexing inverse helpers\n');
+
 % State the indexing target of the test
 result=new_test_result('kernel/indexing_inverse_suite',...
                        'Indexing inverse helpers',...

--- a/tests/kernel/test_indexing_roundtrip_suite.m
+++ b/tests/kernel/test_indexing_roundtrip_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_indexing_roundtrip_suite()
 
+% Announce the test target
+fprintf('TESTING: Indexing conversion functions\n');
+
 % State the indexing target of the test
 result=new_test_result('kernel/indexing_roundtrip_suite',...
                        'Indexing conversion functions',...

--- a/tests/kernel/test_kinetics_generator_suite.m
+++ b/tests/kernel/test_kinetics_generator_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_kinetics_generator_suite()
 
+% Announce the test target
+fprintf('TESTING: Kinetics and flow generator functions\n');
+
 % State the kinetics target of the test
 result=new_test_result('kernel/kinetics_generator_suite',...
                        'Kinetics and flow generator functions',...

--- a/tests/kernel/test_kinetics_invariants_suite.m
+++ b/tests/kernel/test_kinetics_invariants_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_kinetics_invariants_suite()
 
+% Announce the test target
+fprintf('TESTING: Chemical kinetics invariants\n');
+
 % State the kinetics target of the test
 result=new_test_result('kernel/kinetics_invariants_suite',...
                        'Chemical kinetics invariants',...

--- a/tests/kernel/test_linear_perturbation_suite.m
+++ b/tests/kernel/test_linear_perturbation_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_linear_perturbation_suite()
 
+% Announce the test target
+fprintf('TESTING: Linear algebra and perturbation utilities\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/linear_perturbation_suite',...
                        'Linear algebra and perturbation utilities',...

--- a/tests/kernel/test_liouville_commutator.m
+++ b/tests/kernel/test_liouville_commutator.m
@@ -13,6 +13,9 @@
 
 function result=test_liouville_commutator()
 
+% Announce the test target
+fprintf('TESTING: Liouville commutation superoperator\n');
+
 % State the Liouville-space target of the test
 result=new_test_result('kernel/liouville_commutator',...
                        'Liouville commutation superoperator',...

--- a/tests/kernel/test_liquid_single_spin_fid.m
+++ b/tests/kernel/test_liquid_single_spin_fid.m
@@ -13,6 +13,9 @@
 
 function result=test_liquid_single_spin_fid()
 
+% Announce the test target
+fprintf('TESTING: Single-spin liquid-state FID\n');
+
 % State the NMR target of the test
 result=new_test_result('kernel/liquid_single_spin_fid',...
                        'Single-spin liquid-state FID',...

--- a/tests/kernel/test_lowlevel_utilities_suite.m
+++ b/tests/kernel/test_lowlevel_utilities_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_lowlevel_utilities_suite()
 
+% Announce the test target
+fprintf('TESTING: Low-level utility functions\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/lowlevel_utilities_suite',...
                        'Low-level utility functions',...

--- a/tests/kernel/test_matrix_utility_suite.m
+++ b/tests/kernel/test_matrix_utility_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_matrix_utility_suite()
 
+% Announce the test target
+fprintf('TESTING: Matrix utility functions\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/matrix_utility_suite',...
                        'Matrix utility functions',...

--- a/tests/kernel/test_operator_basis_suite.m
+++ b/tests/kernel/test_operator_basis_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_operator_basis_suite()
 
+% Announce the test target
+fprintf('TESTING: Operator-basis construction functions\n');
+
 % State the operator-basis target of the test
 result=new_test_result('kernel/operator_basis_suite',...
                        'Operator-basis construction functions',...

--- a/tests/kernel/test_operator_conversion_suite.m
+++ b/tests/kernel/test_operator_conversion_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_operator_conversion_suite()
 
+% Announce the test target
+fprintf('TESTING: Hilbert/Liouville conversion helpers\n');
+
 % State the operator-conversion target of the test
 result=new_test_result('kernel/operator_conversion_suite',...
                        'Hilbert/Liouville conversion helpers',...

--- a/tests/kernel/test_operator_elementary_suite.m
+++ b/tests/kernel/test_operator_elementary_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_operator_elementary_suite()
 
+% Announce the test target
+fprintf('TESTING: Elementary operator generators\n');
+
 % State the operator target of the test
 result=new_test_result('kernel/operator_elementary_suite',...
                        'Elementary operator generators',...

--- a/tests/kernel/test_operator_expansion_suite.m
+++ b/tests/kernel/test_operator_expansion_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_operator_expansion_suite()
 
+% Announce the test target
+fprintf('TESTING: Operator expansion and conversion helpers\n');
+
 % State the expansion target of the test
 result=new_test_result('kernel/operator_expansion_suite',...
                        'Operator expansions and conversions',...

--- a/tests/kernel/test_optimcon_grape_one_spin.m
+++ b/tests/kernel/test_optimcon_grape_one_spin.m
@@ -14,6 +14,9 @@
 
 function result=test_optimcon_grape_one_spin()
 
+% Announce the test target
+fprintf('TESTING: One-spin optimal-control setup and GRAPE gradient\n');
+
 % State the optimal-control target of the test
 result=new_test_result('optimcon/grape_one_spin',...
                        'One-spin optimal-control setup and GRAPE gradient',...

--- a/tests/kernel/test_optimcon_support_paths.m
+++ b/tests/kernel/test_optimcon_support_paths.m
@@ -13,6 +13,9 @@
 
 function result=test_optimcon_support_paths()
 
+% Announce the test target
+fprintf('TESTING: Optimal-control support helper paths\n');
+
 % State the support-path target of the test
 result=new_test_result('optimcon/support_paths',...
                        'Optimal-control support helper paths',...

--- a/tests/kernel/test_orientation_average_suite.m
+++ b/tests/kernel/test_orientation_average_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_orientation_average_suite()
 
+% Announce the test target
+fprintf('TESTING: Orientation and average helpers\n');
+
 % State the rotational-kernel target of the test
 result=new_test_result('kernel/orientation_average_suite',...
                        'Orientation and average helpers',...

--- a/tests/kernel/test_overload_arithmetic_suite.m
+++ b/tests/kernel/test_overload_arithmetic_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_overload_arithmetic_suite()
 
+% Announce the test target
+fprintf('TESTING: Cheap overload arithmetic\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/overload_arithmetic_suite',...
                        'Cheap overload arithmetic',...

--- a/tests/kernel/test_pauli_spin_half_algebra.m
+++ b/tests/kernel/test_pauli_spin_half_algebra.m
@@ -14,6 +14,9 @@
 
 function result=test_pauli_spin_half_algebra()
 
+% Announce the test target
+fprintf('TESTING: Spin-half angular momentum algebra\n');
+
 % State the physical target of the test
 result=new_test_result('kernel/pauli_spin_half_algebra',...
                        'Spin-half angular momentum algebra',...

--- a/tests/kernel/test_pauli_spin_one_algebra.m
+++ b/tests/kernel/test_pauli_spin_one_algebra.m
@@ -13,6 +13,9 @@
 
 function result=test_pauli_spin_one_algebra()
 
+% Announce the test target
+fprintf('TESTING: Spin-one angular momentum algebra\n');
+
 % State the physical target of the test
 result=new_test_result('kernel/pauli_spin_one_algebra',...
                        'Spin-one angular momentum algebra',...

--- a/tests/kernel/test_pi_pulse_rotation.m
+++ b/tests/kernel/test_pi_pulse_rotation.m
@@ -13,6 +13,9 @@
 
 function result=test_pi_pulse_rotation()
 
+% Announce the test target
+fprintf('TESTING: Hard pi pulse rotation\n');
+
 % State the pulse target of the test
 result=new_test_result('kernel/pi_pulse_rotation',...
                        'Hard pi pulse rotation',...

--- a/tests/kernel/test_plotting_helpers_offscreen.m
+++ b/tests/kernel/test_plotting_helpers_offscreen.m
@@ -14,6 +14,9 @@
 
 function result=test_plotting_helpers_offscreen()
 
+% Announce the test target
+fprintf('TESTING: Offscreen plotting helpers\n');
+
 % State the plotting-helper target of the test
 result=new_test_result('kernel/plotting_helpers_offscreen',...
                        'Offscreen plotting helpers',...

--- a/tests/kernel/test_plotting_remaining_suite.m
+++ b/tests/kernel/test_plotting_remaining_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_plotting_remaining_suite()
 
+% Announce the test target
+fprintf('TESTING: Remaining offscreen plotting helpers\n');
+
 % State the remaining plotting-helper target of the test
 result=new_test_result('kernel/plotting_remaining_suite',...
                        'Remaining plotting helper gaps',...

--- a/tests/kernel/test_ppm_hz_roundtrip.m
+++ b/tests/kernel/test_ppm_hz_roundtrip.m
@@ -13,6 +13,9 @@
 
 function result=test_ppm_hz_roundtrip()
 
+% Announce the test target
+fprintf('TESTING: Chemical-shift frequency conversion\n');
+
 % State the physical target of the test
 result=new_test_result('kernel/ppm_hz_roundtrip',...
                        'Chemical-shift frequency conversion',...

--- a/tests/kernel/test_pulses_propagation_suite.m
+++ b/tests/kernel/test_pulses_propagation_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_pulses_propagation_suite()
 
+% Announce the test target
+fprintf('TESTING: Pulse coordinate and propagation helpers\n');
+
 % State the propagation-helper target of the test
 result=new_test_result('kernel/pulses_propagation_suite',...
                        'Pulse coordinate and propagation helpers',...

--- a/tests/kernel/test_pulses_waveform_suite.m
+++ b/tests/kernel/test_pulses_waveform_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_pulses_waveform_suite()
 
+% Announce the test target
+fprintf('TESTING: Pulse waveform generators\n');
+
 % State the waveform target of the test
 result=new_test_result('kernel/pulses_waveform_suite',...
                        'Pulse waveform generators',...

--- a/tests/kernel/test_relaxation_t2_rate.m
+++ b/tests/kernel/test_relaxation_t2_rate.m
@@ -13,6 +13,9 @@
 
 function result=test_relaxation_t2_rate()
 
+% Announce the test target
+fprintf('TESTING: Phenomenological T2 decay rate\n');
+
 % State the relaxation target of the test
 result=new_test_result('kernel/relaxation_t2_rate',...
                        'Phenomenological T2 decay rate',...

--- a/tests/kernel/test_remtrace_tensor.m
+++ b/tests/kernel/test_remtrace_tensor.m
@@ -13,6 +13,9 @@
 
 function result=test_remtrace_tensor()
 
+% Announce the test target
+fprintf('TESTING: Traceless rank-two tensor construction\n');
+
 % State the physical target of the test
 result=new_test_result('kernel/remtrace_tensor',...
                        'Traceless rank-two tensor construction',...

--- a/tests/kernel/test_rf_cartesian_polar.m
+++ b/tests/kernel/test_rf_cartesian_polar.m
@@ -13,6 +13,9 @@
 
 function result=test_rf_cartesian_polar()
 
+% Announce the test target
+fprintf('TESTING: RF Cartesian/polar conversion\n');
+
 % State the pulse-control target of the test
 result=new_test_result('kernel/rf_cartesian_polar',...
                        'RF Cartesian/polar conversion',...

--- a/tests/kernel/test_scalar_coupling_hamiltonian.m
+++ b/tests/kernel/test_scalar_coupling_hamiltonian.m
@@ -13,6 +13,9 @@
 
 function result=test_scalar_coupling_hamiltonian()
 
+% Announce the test target
+fprintf('TESTING: Scalar coupling Hamiltonian\n');
+
 % State the Hamiltonian target of the test
 result=new_test_result('kernel/scalar_coupling_hamiltonian',...
                        'Scalar coupling Hamiltonian',...

--- a/tests/kernel/test_shaped_pulse_rotation.m
+++ b/tests/kernel/test_shaped_pulse_rotation.m
@@ -13,6 +13,9 @@
 
 function result=test_shaped_pulse_rotation()
 
+% Announce the test target
+fprintf('TESTING: Piecewise Cartesian pulse rotation\n');
+
 % State the pulse target of the test
 result=new_test_result('kernel/shaped_pulse_rotation',...
                        'Piecewise Cartesian pulse rotation',...

--- a/tests/kernel/test_sparse_tensor_graph_suite.m
+++ b/tests/kernel/test_sparse_tensor_graph_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_sparse_tensor_graph_suite()
 
+% Announce the test target
+fprintf('TESTING: Sparse, tensor, and graph helper functions\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/sparse_tensor_graph_suite',...
                        'Sparse, tensor, and graph helper functions',...

--- a/tests/kernel/test_sparse_tensor_utility_suite.m
+++ b/tests/kernel/test_sparse_tensor_utility_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_sparse_tensor_utility_suite()
 
+% Announce the test target
+fprintf('TESTING: Sparse, tensor, and numerical utility functions\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/sparse_tensor_utility_suite',...
                        'Sparse, tensor, and numerical utility functions',...

--- a/tests/kernel/test_state_constructor_suite.m
+++ b/tests/kernel/test_state_constructor_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_state_constructor_suite()
 
+% Announce the test target
+fprintf('TESTING: State-constructor functions\n');
+
 % State the state-constructor target of the test
 result=new_test_result('kernel/state_constructor_suite',...
                        'State-constructor functions',...

--- a/tests/kernel/test_states_composite_suite.m
+++ b/tests/kernel/test_states_composite_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_states_composite_suite()
 
+% Announce the test target
+fprintf('TESTING: Composite state generators\n');
+
 % State the state-generation target of the test
 result=new_test_result('kernel/states_composite_suite',...
                        'Composite state generators',...

--- a/tests/kernel/test_step_matches_expm.m
+++ b/tests/kernel/test_step_matches_expm.m
@@ -13,6 +13,9 @@
 
 function result=test_step_matches_expm()
 
+% Announce the test target
+fprintf('TESTING: Hilbert propagation against expm\n');
+
 % State the propagation target of the test
 result=new_test_result('kernel/step_matches_expm',...
                        'Hilbert propagation against expm',...

--- a/tests/kernel/test_step_zero_time.m
+++ b/tests/kernel/test_step_zero_time.m
@@ -13,6 +13,9 @@
 
 function result=test_step_zero_time()
 
+% Announce the test target
+fprintf('TESTING: Zero-duration propagation identity\n');
+
 % State the propagation target of the test
 result=new_test_result('kernel/step_zero_time',...
                        'Zero-duration propagation identity',...

--- a/tests/kernel/test_tensor_vector_suite.m
+++ b/tests/kernel/test_tensor_vector_suite.m
@@ -15,6 +15,9 @@
 
 function result=test_tensor_vector_suite()
 
+% Announce the test target
+fprintf('TESTING: Tensor, vector, and relaxation utilities\n');
+
 % State the utility target of the test
 result=new_test_result('kernel/tensor_vector_suite',...
                        'Tensor, vector, and relaxation utilities',...

--- a/tests/kernel/test_transform_rotation_suite.m
+++ b/tests/kernel/test_transform_rotation_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_transform_rotation_suite()
 
+% Announce the test target
+fprintf('TESTING: Rotation transform helpers\n');
+
 % State the geometric target of the test
 result=new_test_result('kernel/transform_rotation_suite',...
                        'Rotation transform helpers',...

--- a/tests/kernel/test_transform_roundtrip_suite.m
+++ b/tests/kernel/test_transform_roundtrip_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_transform_roundtrip_suite()
 
+% Announce the test target
+fprintf('TESTING: Coordinate and tensor transform functions\n');
+
 % State the transform target of the test
 result=new_test_result('kernel/transform_roundtrip_suite',...
                        'Coordinate and tensor transform functions',...

--- a/tests/kernel/test_transform_tensor_suite.m
+++ b/tests/kernel/test_transform_tensor_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_transform_tensor_suite()
 
+% Announce the test target
+fprintf('TESTING: Tensor transform helpers\n');
+
 % State the tensor target of the test
 result=new_test_result('kernel/transform_tensor_suite',...
                        'Tensor transform helpers',...

--- a/tests/kernel/test_transform_units_coordinates_suite.m
+++ b/tests/kernel/test_transform_units_coordinates_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_transform_units_coordinates_suite()
 
+% Announce the test target
+fprintf('TESTING: Unit and coordinate transforms\n');
+
 % State the conversion target of the test
 result=new_test_result('kernel/transform_units_coordinates_suite',...
                        'Unit and coordinate transforms',...

--- a/tests/kernel/test_unit_conversion_suite.m
+++ b/tests/kernel/test_unit_conversion_suite.m
@@ -14,6 +14,9 @@
 
 function result=test_unit_conversion_suite()
 
+% Announce the test target
+fprintf('TESTING: Unit-conversion functions\n');
+
 % State the conversion target of the test
 result=new_test_result('kernel/unit_conversion_suite',...
                        'Unit-conversion functions',...

--- a/tests/kernel/test_wave_basis_orthonormality.m
+++ b/tests/kernel/test_wave_basis_orthonormality.m
@@ -13,6 +13,9 @@
 
 function result=test_wave_basis_orthonormality()
 
+% Announce the test target
+fprintf('TESTING: Waveform basis orthonormality\n');
+
 % State the numerical target of the test
 result=new_test_result('kernel/wave_basis_orthonormality',...
                        'Waveform basis orthonormality',...

--- a/tests/kernel/test_wigner_angular_suite.m
+++ b/tests/kernel/test_wigner_angular_suite.m
@@ -13,6 +13,9 @@
 
 function result=test_wigner_angular_suite()
 
+% Announce the test target
+fprintf('TESTING: Angular-momentum coefficient functions\n');
+
 % State the angular target of the test
 result=new_test_result('kernel/wigner_angular_suite',...
                        'Angular-momentum coefficient functions',...

--- a/tests/kernel/test_zeeman_hamiltonian.m
+++ b/tests/kernel/test_zeeman_hamiltonian.m
@@ -13,6 +13,9 @@
 
 function result=test_zeeman_hamiltonian()
 
+% Announce the test target
+fprintf('TESTING: Zeeman Hamiltonian sign and units\n');
+
 % State the Hamiltonian target of the test
 result=new_test_result('kernel/zeeman_hamiltonian',...
                        'Zeeman Hamiltonian sign and units',...


### PR DESCRIPTION
## Summary

- add a one-line `TESTING: ...` console announcement at the start of each manifest-listed regression test under `tests/kernel/`
- derive the printed text from the existing manifest/test summary names, keeping one line per test

## Validation

- `TESTING_LINE_COVERAGE_OK 94` coverage check: every manifest-listed test has exactly one matching `fprintf('TESTING: ...\\n')`
- `git diff --check -- tests/kernel`
- MATLAB `checkcode` over `tests/kernel/test_*.m` → `TEST_CHECKCODE_MESSAGES 0`
- focused output smoke: `run_tests('pattern','hilbert_state','verbose',true,'stop_on_fail',true)` prints `TESTING: Hilbert-space state generation` and passes
- full suite before final whitespace normalisation: `run_tests('verbose',false)` → `94 passed, 0 failed`, with `TESTING:` lines printed for all tests
