### PR TITLE
Implement Higham-Tisseur cheap_norm estimator

### DIFF
--- a/kernel/overloads/@polyadic/isreal.m
+++ b/kernel/overloads/@polyadic/isreal.m
@@ -1,0 +1,47 @@
+% Returns true if the polyadic representation is real. Syntax:
+%
+%                         answer=isreal(p)
+%
+% Parameters:
+%
+%     p      - a polyadic object
+%
+% Outputs:
+%
+%     answer - true if all numeric data in the object is real
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=polyadic/isreal.m>
+
+function answer=isreal(p)
+
+% Check the core array
+for n=1:numel(p.cores)
+    for k=1:numel(p.cores{n})
+        if ~isreal(p.cores{n}{k})
+            answer=false; return
+        end
+    end
+end
+
+% Check prefix and suffix arrays
+for n=1:numel(p.prefix)
+    if ~isreal(p.prefix{n})
+        answer=false; return
+    end
+end
+for n=1:numel(p.suffix)
+    if ~isreal(p.suffix{n})
+        answer=false; return
+    end
+end
+
+% All data is real
+answer=true();
+
+end
+
+% A little inaccuracy sometimes saves a ton of explanation.
+%
+% H.H. Munro

--- a/kernel/overloads/@polyadic/mtimes.m
+++ b/kernel/overloads/@polyadic/mtimes.m
@@ -74,8 +74,11 @@ if ~isa(B,'polyadic')&&isnumeric(B)
     end
     B=full(B);
    
+    % Preallocate the core product result
+    core_rows=prod(cellfun(@(x)size(x,1),A.cores{1}));
+    C=zeros(core_rows,size(B,2));
+
     % Multiply by cores
-    C=zeros(size(B));
     for n=1:numel(A.cores)
         C=C+kronm(A.cores{n},B);
     end
@@ -165,4 +168,3 @@ end
 % immediately, so I can work out who to blame."
 %
 % Preface to a cryptanalysis book
-

--- a/kernel/utilities/cheap_norm.m
+++ b/kernel/utilities/cheap_norm.m
@@ -1,36 +1,46 @@
-% The cheapest possible norm for various representations of matrices. CUDA 
+% The cheapest possible norm for various representations of matrices. CUDA
 % stores matrices by rows, Matlab by columns, and polyadic objects can on-
-% ly multiply vectors, in which case Algorithm 2.1 from Hager's paper:
+% ly multiply vectors, in which case Algorithm 2.4 from Higham and
+% Tisseur's paper:
 %
 %                 https://doi.org/10.1137/S0895479899356080
 %
-% is used with Higham's extension to the complex case. Syntax:
+% is used. Syntax:
 %
-%                             n=cheap_norm(A)
+%                            n=cheap_norm(A)
+%                         n=cheap_norm(A,t)
+%                    n=cheap_norm(A,t,itmax)
 %
 % Parameters:
 %
-%     A - a matrix, or a polyadic representation thereof
+%     A     - a matrix, or a polyadic representation thereof
+%
+%     t     - number of probe columns in the polyadic norm estimator,
+%             optional, defaults to 1
+%
+%     itmax - maximum number of estimator iterations, optional,
+%             defaults to 5
 %
 % Outputs:
 %
 %     n - infinity-norm for GPU arrays, 1-norm for CPU arrays,
-%         and Hager's upper bound on 1-norm for polyadics
+%         and a lower-bound 1-norm estimate for polyadics
 %
 % Note: some norms are vastly more expensive than others, this function
 %       uses the cheapest ones available.
-%
-% Note: in very rare cases, Hager's algorithm stagnates. If this happens,
-%       drop us a note and we will implement Higham's more recent work.
 %
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=cheap_norm.m>
 
-function n=cheap_norm(A)
+function n=cheap_norm(A,t,itmax)
+
+% Set the defaults
+if nargin<2, t=1;     end
+if nargin<3, itmax=5; end
 
 % Check consistency
-grumble(A);
+grumble(A,t,itmax);
 
 % Inf-norm is best on GPU
 if isa(A,'gpuArray')
@@ -45,46 +55,125 @@ end
 % Relevant dimension
 dim=size(A,2);
 
-% Starting vector
-x=ones(dim,1)/dim;
+% Respect small dimensions
+t=min(t,dim);
 
-% Column index and counter
-idx_prev=0; n_iter=0;
+% Starting matrix
+X=ones(dim,t);
+if t>1
+    for col_idx=2:t
+        X(:,col_idx)=2*randi([0 1],dim,1)-1;
+    end
+    for col_idx=1:t
+        sign_pool=X(:,[1:(col_idx-1) (col_idx+1):t]);
+        ntries=0;
+        while any(abs(sign_pool'*X(:,col_idx))==dim)
+            X(:,col_idx)=2*randi([0 1],dim,1)-1;
+            sign_pool=X(:,[1:(col_idx-1) (col_idx+1):t]);
+            ntries=ntries+1;
+            if ntries>100
+                break
+            end
+        end
+    end
+end
+X=X/dim;
+
+% Estimator state
+idx_hist=[]; idx=1:t; idx_best=1; est_old=0; S=zeros(dim,t);
 
 % Iteration loop
-while true
-    
-    % Hager's magic
-    y=A*x; z=A'*sign(y);
-    [~,idx]=max(abs(z));
-    
-    % Termination condition
-    if idx==idx_prev
-        n=norm(y,1); break
+for k=1:(itmax+1)
+
+    % Matrix-vector products with the operator
+    Y=A*X; col_norms=sum(abs(Y),1);
+
+    % Extract the current estimate
+    [est,best_col]=max(col_norms);
+    if (est>est_old)||(k==2)
+        if k>=2, idx_best=idx(best_col); end
     end
-    
-    % Follow the largest element
-    x=zeros(dim,1); x(idx)=1;
-    
-    % Column index update
-    idx_prev=idx;
-    
-    % Iteration counter
-    n_iter=n_iter+1;
-    
-    % Fallback scenario
-    if n_iter>10
-        error('norm estimator stagnated.');
+
+    % Stop if the estimate has not improved
+    if (k>=2)&&(est<=est_old)
+        n=est_old; return
     end
-    
+
+    % Keep track of the best estimate
+    est_old=est; S_old=S;
+    if k>itmax
+        n=est_old; return
+    end
+
+    % Phase matrix with the zero convention from the paper
+    S=sign(Y); S(S==0)=1;
+
+    % Remove redundant sign probes in the real case
+    if isreal(A)
+        if all(any(abs(S_old'*S)==dim,1))
+            n=est_old; return
+        end
+        if t>1
+            for col_idx=1:t
+                sign_pool=[S(:,[1:(col_idx-1) (col_idx+1):t]) S_old];
+                ntries=0;
+                while any(abs(sign_pool'*S(:,col_idx))==dim)
+                    S(:,col_idx)=2*randi([0 1],dim,1)-1;
+                    sign_pool=[S(:,[1:(col_idx-1) (col_idx+1):t]) S_old];
+                    ntries=ntries+1;
+                    if ntries>100
+                        n=est_old; return
+                    end
+                end
+            end
+        end
+    end
+
+    % Adjoint products with the phase matrix
+    Z=A'*S; row_scores=max(abs(Z),[],2);
+
+    % Stop when the best column has been reached
+    if (k>=2)&&(max(row_scores)==row_scores(idx_best))
+        n=est_old; return
+    end
+
+    % Follow the largest row scores
+    [~,idx]=sort(row_scores,'descend'); idx=idx(:).';
+
+    % Avoid repeated unit-vector probes
+    if t>1
+        if all(ismember(idx(1:t),idx_hist))
+            n=est_old; return
+        end
+        idx=[idx(~ismember(idx,idx_hist)) idx(ismember(idx,idx_hist))];
+    end
+
+    % Assemble the next probe matrix
+    X=zeros(dim,t);
+    for col_idx=1:t
+        X(idx(col_idx),col_idx)=1;
+    end
+    idx_hist=unique([idx_hist idx(1:t)],'stable');
+
 end
+
+% Return the best lower bound encountered
+n=est_old;
 
 end
 
 % Consistency enforcement
-function grumble(A)
+function grumble(A,t,itmax)
 if ~isnumeric(A)
     error('A must be a matrix or a polyadic.');
+end
+if (~isnumeric(t))||(~isreal(t))||(~isscalar(t))||(t<1)||...
+   (mod(t,1)~=0)
+    error('t must be a positive real integer.');
+end
+if (~isnumeric(itmax))||(~isreal(itmax))||(~isscalar(itmax))||...
+   (itmax<2)||(mod(itmax,1)~=0)
+    error('itmax must be a real integer greater than one.');
 end
 end
 

--- a/kernel/utilities/cheap_norm.m
+++ b/kernel/utilities/cheap_norm.m
@@ -52,23 +52,23 @@ if ~isa(A,'polyadic')
     n=norm(A,1); return
 end
 
-% Relevant dimension
-dim=size(A,2);
+% Relevant dimensions
+row_dim=size(A,1); col_dim=size(A,2);
 
 % Respect small dimensions
-t=min(t,dim);
+t=min(t,col_dim);
 
 % Starting matrix
-X=ones(dim,t);
+X=ones(col_dim,t);
 if t>1
     for col_idx=2:t
-        X(:,col_idx)=2*randi([0 1],dim,1)-1;
+        X(:,col_idx)=2*randi([0 1],col_dim,1)-1;
     end
     for col_idx=1:t
         sign_pool=X(:,[1:(col_idx-1) (col_idx+1):t]);
         ntries=0;
-        while any(abs(sign_pool'*X(:,col_idx))==dim)
-            X(:,col_idx)=2*randi([0 1],dim,1)-1;
+        while any(abs(sign_pool'*X(:,col_idx))==col_dim)
+            X(:,col_idx)=2*randi([0 1],col_dim,1)-1;
             sign_pool=X(:,[1:(col_idx-1) (col_idx+1):t]);
             ntries=ntries+1;
             if ntries>100
@@ -77,10 +77,10 @@ if t>1
         end
     end
 end
-X=X/dim;
+X=X/col_dim;
 
 % Estimator state
-idx_hist=[]; idx=1:t; idx_best=1; est_old=0; S=zeros(dim,t);
+idx_hist=[]; idx=1:t; idx_best=1; est_old=0; S=zeros(row_dim,t);
 
 % Iteration loop
 for k=1:(itmax+1)
@@ -110,15 +110,15 @@ for k=1:(itmax+1)
 
     % Remove redundant sign probes in the real case
     if isreal(A)
-        if all(any(abs(S_old'*S)==dim,1))
+        if all(any(abs(S_old'*S)==row_dim,1))
             n=est_old; return
         end
         if t>1
             for col_idx=1:t
                 sign_pool=[S(:,[1:(col_idx-1) (col_idx+1):t]) S_old];
                 ntries=0;
-                while any(abs(sign_pool'*S(:,col_idx))==dim)
-                    S(:,col_idx)=2*randi([0 1],dim,1)-1;
+                while any(abs(sign_pool'*S(:,col_idx))==row_dim)
+                    S(:,col_idx)=2*randi([0 1],row_dim,1)-1;
                     sign_pool=[S(:,[1:(col_idx-1) (col_idx+1):t]) S_old];
                     ntries=ntries+1;
                     if ntries>100
@@ -149,7 +149,7 @@ for k=1:(itmax+1)
     end
 
     % Assemble the next probe matrix
-    X=zeros(dim,t);
+    X=zeros(col_dim,t);
     for col_idx=1:t
         X(idx(col_idx),col_idx)=1;
     end
@@ -181,4 +181,3 @@ end
 % when they are anything but.
 %
 % Rod Liddle
-

--- a/tests/kernel/test_matrix_utility_suite.m
+++ b/tests/kernel/test_matrix_utility_suite.m
@@ -31,6 +31,42 @@ result=test_close(result,'acomm',acomm(A,B),A*B+B*A,1e-15,1e-15,...
 result=test_close(result,'cheap_norm CPU',cheap_norm(A),norm(A,1),1e-15,1e-15,...
                   'for CPU matrices cheap_norm returns the matrix one-norm');
 
+% Check polyadic norm estimation paths
+P=polyadic({{A}});
+result=test_close(result,'cheap_norm polyadic positive',cheap_norm(P),norm(A,1),1e-15,1e-15,...
+                  'the estimator is exact on non-negative matrices after its forced second iteration');
+result=test_close(result,'cheap_norm polyadic block',cheap_norm(P,2,5),norm(A,1),1e-15,1e-15,...
+                  'the block estimator keeps the non-negative exactness property');
+
+% Check the Higham-Tisseur zero-sign convention
+Z=[-2 0;-1 2];
+P=polyadic({{Z}});
+result=test_close(result,'cheap_norm polyadic zero sign',cheap_norm(P),norm(Z,1),1e-15,1e-15,...
+                  'zero phase entries are treated as one, as required by Algorithm 2.4');
+
+% Check complex adjoint and phase handling
+Z=[-2 0;-1+1i 2];
+P=polyadic({{Z}});
+result=test_close(result,'cheap_norm polyadic complex',cheap_norm(P),norm(Z,1),1e-15,1e-15,...
+                  'complex polyadic estimation uses conjugate transposes and unit phases');
+
+% Check the block estimator lower-bound contract
+rng_state=rng;
+rng_cleanup=onCleanup(@()rng(rng_state));
+rng(1);
+Z=[0 -3 2 1;4 0 -1 2;-2 5 0 -4;1 -1 3 0];
+P=polyadic({{Z}});
+est=cheap_norm(P,3,5);
+result=test_true(result,'cheap_norm polyadic lower bound',(est<=norm(Z,1)+1e-12)&&(est>0),...
+                 'Algorithm 2.4 returns a positive lower bound not exceeding the exact one-norm');
+clear('rng_cleanup');
+
+% Check polyadic realness dispatch
+result=test_true(result,'polyadic isreal true',isreal(polyadic({{Z}})),...
+                 'real polyadic cores are recognised without opening the Kronecker products');
+result=test_true(result,'polyadic isreal false',~isreal(polyadic({{[1 1i;0 2]}})),...
+                 'complex polyadic cores are recognised without opening the Kronecker products');
+
 % Check identity and trace predicates
 result=test_true(result,'iseye true',iseye(speye(3)),...
                  'the sparse unit matrix is recognised as identity');
@@ -70,4 +106,3 @@ result=test_close(result,'clean_up sparse tolerance',C_obs,sparse([0 1;0 2]),1e-
                   'clean_up removes elements below the requested non-zero tolerance');
 
 end
-

--- a/tests/kernel/test_matrix_utility_suite.m
+++ b/tests/kernel/test_matrix_utility_suite.m
@@ -38,6 +38,16 @@ result=test_close(result,'cheap_norm polyadic positive',cheap_norm(P),norm(A,1),
 result=test_close(result,'cheap_norm polyadic block',cheap_norm(P,2,5),norm(A,1),1e-15,1e-15,...
                   'the block estimator keeps the non-negative exactness property');
 
+% Check rectangular polyadic sign-history dimensions
+R=[1 0;2 3;4 5];
+P=polyadic({{R}});
+result=test_close(result,'cheap_norm polyadic tall',cheap_norm(P),norm(R,1),1e-15,1e-15,...
+                  'tall rectangular polyadics use row-length sign vectors and column-length probes');
+R=[1 2 3;4 5 6];
+P=polyadic({{R}});
+result=test_close(result,'cheap_norm polyadic wide',cheap_norm(P,2,5),norm(R,1),1e-15,1e-15,...
+                  'wide rectangular polyadics use row-length sign vectors and column-length probes');
+
 % Check the Higham-Tisseur zero-sign convention
 Z=[-2 0;-1 2];
 P=polyadic({{Z}});


### PR DESCRIPTION
## Summary

- Replaces the polyadic branch of `cheap_norm` with Higham-Tisseur Algorithm 2.4 semantics.
- Corrects the documentation from an upper-bound claim to a lower-bound 1-norm estimate, and adds optional `t` and `itmax` estimator controls while keeping `cheap_norm(A)` backward-compatible.
- Adds `polyadic/isreal` so real-matrix redundancy handling can be selected without expanding the polyadic representation.
- Corrects rectangular polyadic multiplication preallocation for full RHS products through `polyadic/mtimes`.
- Extends matrix utility regression coverage for tall/wide rectangular polyadics, the zero-sign counterexample, complex adjoints/phases, block-estimator lower-bound behaviour, and polyadic realness dispatch.

## Validation

- `checkcode` on:
  - `kernel/utilities/cheap_norm.m`
  - `kernel/overloads/@polyadic/isreal.m`
  - `tests/kernel/test_matrix_utility_suite.m`
- `run_tests('pattern','matrix_utility','verbose',false,'stop_on_fail',true)`
- Focused random validation script: `HIGHAM_TISSEUR_VALIDATION_OK ntests=569`
- Focused rectangular random validation script: `RECTANGULAR_HIGHAM_TISSEUR_VALIDATION_OK ntests=462`
- Full JVM-enabled regression suite: `Spinach regression tests: 94 passed, 0 failed`, marker `FINAL_FULL_REGRESSION_OK`
- Full JVM-enabled regression suite after rectangular follow-up: `Spinach regression tests: 94 passed, 0 failed`, marker `RECTANGULAR_FIX_FULL_REGRESSION_OK`
- `git diff --cached --check`

Note: the full `-nojvm` suite reaches the known Java-dependent Wigner angular test and stops at `java.math.BigInteger`; the JVM-enabled full-suite run above is the authoritative full regression gate for this PR.
