### PR TITLE
Remove dead diamond defect input placeholders

### DIFF
--- a/etc/diamond_defects/diamond_co.m
+++ b/etc/diamond_defects/diamond_co.m
@@ -36,7 +36,7 @@ hz_per_mt=abs(spin('E'))/(2*pi)*1e-3;
 
 % Select the cobalt centre
 centre=lower(parameters.centre);
-electron='E'; zfs=[];
+electron='E';
 
 % Get cobalt centre table data
 switch centre
@@ -70,7 +70,7 @@ end
 
 % Build electron and cobalt tensors
 gmat=((frame)*diag(gvals)*(frame)');
-nuclei={struct('iso','59Co','A',((frame)*diag(Aco*hz_per_mt)*(frame)'),'Q',[])};
+nucleus=struct('iso','59Co','A',((frame)*diag(Aco*hz_per_mt)*(frame)'));
 
 % Build the Spinach structures
 switch parameters.orientation
@@ -83,25 +83,11 @@ switch parameters.orientation
     otherwise
         error('unknown orientation specification.');
 end
-sys.isotopes={electron};
+sys.isotopes={electron,nucleus.iso};
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
 inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
-for n=1:numel(nuclei)
-    sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
-    end
-end
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+inter.coupling.matrix{1,2}=C*nucleus.A*C';
 
 end
 

--- a/etc/diamond_defects/diamond_gev0.m
+++ b/etc/diamond_defects/diamond_gev0.m
@@ -46,9 +46,9 @@ nuclei={};
 % Add the germanium isotope if requested
 germanium=parameters.germanium;
 if strcmp(germanium,'73Ge')
-    nuclei{end+1}=struct('iso','73Ge','A',eye(3)*1.64*hz_per_mt,'Q',[]);
+    nuclei{end+1}=struct('iso','73Ge','A',eye(3)*1.64*hz_per_mt);
 elseif ~strcmp(germanium,'none')
-    nuclei{end+1}=struct('iso',germanium,'A',zeros(3),'Q',[]);
+    nuclei{end+1}=struct('iso',germanium);
 end
 
 % Build the Spinach structures
@@ -63,22 +63,17 @@ switch parameters.orientation
         error('unknown orientation specification.');
 end
 sys.isotopes={electron};
-inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
 for n=1:numel(nuclei)
     sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
+end
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
+inter.zeeman.matrix{1}=C*gmat*C';
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+[~,~,zfs]=mat2ias(C*zfs*C');
+inter.coupling.matrix{1,1}=zfs;
+for n=1:numel(nuclei)
+    if isfield(nuclei{n},'A')&&norm(nuclei{n}.A,2)>0
+        inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
     end
 end
 

--- a/etc/diamond_defects/diamond_n2vm.m
+++ b/etc/diamond_defects/diamond_n2vm.m
@@ -52,12 +52,12 @@ cframe=anax2dcm([-1 -1 0],-2.0*pi/180)*...
 % Build the electron tensors
 electron='E';
 gmat=((gframe)*diag([2.00345 2.00274 2.00271])*(gframe)');
-zfs=[]; nuclei={};
+nuclei={};
 
 % Add nitrogen tensors
 if strcmp(parameters.nitrogen,'15N')
-    nuclei{end+1}=struct('iso','15N','A',((nframe)*diag([3.47e6 4.51e6 4.09e6])*(nframe)'),'Q',[]);
-    nuclei{end+1}=struct('iso','15N','A',((c2rot*nframe)*diag([3.47e6 4.51e6 4.09e6])*(c2rot*nframe)'),'Q',[]);
+    nuclei{end+1}=struct('iso','15N','A',((nframe)*diag([3.47e6 4.51e6 4.09e6])*(nframe)'));
+    nuclei{end+1}=struct('iso','15N','A',((c2rot*nframe)*diag([3.47e6 4.51e6 4.09e6])*(c2rot*nframe)'));
 elseif strcmp(parameters.nitrogen,'14N')
     scale=spin('14N')/spin('15N');
     Qframe=[-1/sqrt(2) -1/sqrt(6) 1/sqrt(3);...
@@ -73,8 +73,8 @@ end
 
 % Add reported nearest-neighbour carbons
 if parameters.include_13c
-    nuclei{end+1}=struct('iso','13C','A',((cframe)*diag([202.3e6 202.3e6 317.5e6])*(cframe)'),'Q',[]);
-    nuclei{end+1}=struct('iso','13C','A',((c2rot*cframe)*diag([202.3e6 202.3e6 317.5e6])*(c2rot*cframe)'),'Q',[]);
+    nuclei{end+1}=struct('iso','13C','A',((cframe)*diag([202.3e6 202.3e6 317.5e6])*(cframe)'));
+    nuclei{end+1}=struct('iso','13C','A',((c2rot*cframe)*diag([202.3e6 202.3e6 317.5e6])*(c2rot*cframe)'));
 end
 
 % Build the Spinach structures
@@ -89,22 +89,19 @@ switch parameters.orientation
         error('unknown orientation specification.');
 end
 sys.isotopes={electron};
-inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
 for n=1:numel(nuclei)
     sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
+end
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
+inter.zeeman.matrix{1}=C*gmat*C';
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+for n=1:numel(nuclei)
+    if isfield(nuclei{n},'A')&&norm(nuclei{n}.A,2)>0
+        inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
+    end
+    if isfield(nuclei{n},'Q')&&~isempty(nuclei{n}.Q)
         [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
         inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
     end
 end
 

--- a/etc/diamond_defects/diamond_n_inter.m
+++ b/etc/diamond_defects/diamond_n_inter.m
@@ -38,7 +38,7 @@ if ~strcmp(parameters.nitrogen,'15N')
 end
 
 % Build the common frame
-electron='E'; zfs=[]; nuclei={};
+electron='E';
 gframe=diamond_frame_xyz([sind(90)*cosd(45);sind(90)*sind(45);cosd(90)],...
                          [sind(180)*cosd(45);sind(180)*sind(45);cosd(180)],...
                          [sind(90)*cosd(315);sind(90)*sind(315);cosd(90)]);
@@ -60,7 +60,7 @@ switch centre
 end
 
 % Add the nitrogen hyperfine tensor
-nuclei{end+1}=struct('iso','15N','A',Amat,'Q',[]);
+nucleus=struct('iso','15N','A',Amat);
 
 % Build the Spinach structures
 switch parameters.orientation
@@ -73,25 +73,11 @@ switch parameters.orientation
     otherwise
         error('unknown orientation specification.');
 end
-sys.isotopes={electron};
+sys.isotopes={electron,nucleus.iso};
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
 inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
-for n=1:numel(nuclei)
-    sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
-    end
-end
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+inter.coupling.matrix{1,2}=C*nucleus.A*C';
 
 end
 

--- a/etc/diamond_defects/diamond_ni.m
+++ b/etc/diamond_defects/diamond_ni.m
@@ -56,16 +56,16 @@ switch centre
         gmat=eye(3)*2.032;
         nickel=parameters.nickel;
         if strcmp(nickel,'61Ni')
-            nuclei{end+1}=struct('iso','61Ni','A',eye(3)*0.65*hz_per_mt,'Q',[]);
+            nuclei{end+1}=struct('iso','61Ni','A',eye(3)*0.65*hz_per_mt);
         elseif ~strcmp(nickel,'none')
-            nuclei{end+1}=struct('iso',nickel,'A',zeros(3),'Q',[]);
+            nuclei{end+1}=struct('iso',nickel);
         end
         if parameters.include_13c
             Cmat=((frame_111)*diag([0.340 0.340 1.339]*hz_per_mt)*(frame_111)');
             nuc_idx=numel(nuclei);
             nuclei(nuc_idx+1:nuc_idx+4)={[]};
             for n=1:4
-                nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat,'Q',[]);
+                nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat);
             end
         end
     case {'ne1','ne2','ne3','ne5','ne8'}
@@ -100,7 +100,7 @@ switch centre
         gmat=((frame)*diag(gvals)*(frame)');
         nuclei=cell(1,size(avalues,1));
         for n=1:size(avalues,1)
-            nuclei{n}=struct('iso','14N','A',((frame)*diag(avalues(n,:)*hz_per_mt)*(frame)'),'Q',[]);
+            nuclei{n}=struct('iso','14N','A',((frame)*diag(avalues(n,:)*hz_per_mt)*(frame)'));
         end
     case 'ne4'
         electron='E';
@@ -147,22 +147,19 @@ switch parameters.orientation
         error('unknown orientation specification.');
 end
 sys.isotopes={electron};
+for n=1:numel(nuclei)
+    sys.isotopes{n+1}=nuclei{n}.iso;
+end
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
 inter.zeeman.matrix{1}=C*gmat*C';
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
 if ~isempty(zfs)
     [~,~,zfs]=mat2ias(C*zfs*C');
     inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
 end
 for n=1:numel(nuclei)
-    sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
+    if isfield(nuclei{n},'A')&&norm(nuclei{n}.A,2)>0
+        inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
     end
 end
 

--- a/etc/diamond_defects/diamond_nv0_es.m
+++ b/etc/diamond_defects/diamond_nv0_es.m
@@ -40,7 +40,7 @@ gmat=((frame)*diag([2.0035 2.0035 2.0029])*(frame)');
 zfs=frame*zfs2mat(1685e6,0,0,0,0)*frame';
 
 % Add the nitrogen hyperfine tensor
-nuclei={struct('iso','15N','A',((frame)*diag([-23.8e6 -23.8e6 -35.7e6])*(frame)'),'Q',[])};
+nucleus=struct('iso','15N','A',((frame)*diag([-23.8e6 -23.8e6 -35.7e6])*(frame)'));
 
 % Build the Spinach structures
 switch parameters.orientation
@@ -53,25 +53,13 @@ switch parameters.orientation
     otherwise
         error('unknown orientation specification.');
 end
-sys.isotopes={electron};
+sys.isotopes={electron,nucleus.iso};
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
 inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
-for n=1:numel(nuclei)
-    sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
-    end
-end
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+[~,~,zfs]=mat2ias(C*zfs*C');
+inter.coupling.matrix{1,1}=zfs;
+inter.coupling.matrix{1,2}=C*nucleus.A*C';
 
 end
 

--- a/etc/diamond_defects/diamond_nvm_gs.m
+++ b/etc/diamond_defects/diamond_nvm_gs.m
@@ -68,6 +68,8 @@ end
 
 % Define spin system isotopes
 sys.isotopes={'E3',parameters.nitrogen};
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
 
 % Electron relaxation rates
 a1=0.8*parameters.concentration;    % s^-1*ppm^-1
@@ -113,9 +115,6 @@ end
 % Electron g-tensor
 inter.zeeman.matrix{1}=R*diag([2.0031 2.0031 2.0029])*R';
 
-% Nuclear shielding tensor is ignored
-inter.zeeman.matrix{2}=zeros(3);
-
 % Electron ZFS tensor
 inter.coupling.matrix{1,1}=R*zfs2mat(2872e6,0,0,0,0)*R';
 
@@ -132,7 +131,6 @@ switch parameters.nitrogen
 
         % Only hyperfine coupling, opposite sign
         inter.coupling.matrix{1,2}=R*diag([3.65e6 3.65e6 3.03e6])*R';
-        inter.coupling.matrix{2,2}=[];
 
     otherwise
 

--- a/etc/diamond_defects/diamond_p.m
+++ b/etc/diamond_defects/diamond_p.m
@@ -38,7 +38,7 @@ hz_per_mt=abs(spin('E'))/(2*pi)*1e-3;
 
 % Select the phosphorus centre
 centre=lower(parameters.centre);
-electron='E'; zfs=[];
+electron='E';
 nuclei={}; frame=eye(3);
 
 % Set the trigonal principal-axis frame
@@ -51,47 +51,47 @@ switch centre
     case 'ma1'
         gmat=eye(3)*2.0025;
         nuclei{end+1}=struct('iso','31P','A',...
-            ((frame_111)*diag([1.96 1.96 2.32]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([1.96 1.96 2.32]*hz_per_mt)*(frame_111)'));
         if parameters.include_13c
             nuclei{end+1}=struct('iso','13C','A',...
-                ((frame_111)*diag([13.92 13.92 18.13]*hz_per_mt)*(frame_111)'),'Q',[]);
+                ((frame_111)*diag([13.92 13.92 18.13]*hz_per_mt)*(frame_111)'));
         end
     case 'np1'
         gmat=((frame)*diag([2.00243 2.0028 2.0026])*(frame)');
-        nuclei{end+1}=struct('iso','31P','A',((frame)*diag([2.08 2.02 2.18]*hz_per_mt)*(frame)'),'Q',[]);
-        nuclei{end+1}=struct('iso','14N','A',((frame)*diag([4.08 3.10 3.00]*hz_per_mt)*(frame)'),'Q',[]);
+        nuclei{end+1}=struct('iso','31P','A',((frame)*diag([2.08 2.02 2.18]*hz_per_mt)*(frame)'));
+        nuclei{end+1}=struct('iso','14N','A',((frame)*diag([4.08 3.10 3.00]*hz_per_mt)*(frame)'));
     case 'np2'
         gmat=eye(3)*2.0025;
         nuclei{end+1}=struct('iso','31P','A',...
-            ((frame_111)*diag([2.09 2.09 2.34]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([2.09 2.09 2.34]*hz_per_mt)*(frame_111)'));
         nuclei{end+1}=struct('iso','14N','A',...
-            ((frame_111)*diag([3.09 3.09 6.42]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([3.09 3.09 6.42]*hz_per_mt)*(frame_111)'));
     case 'np3'
         gmat=eye(3)*2.0025;
         nuclei{end+1}=struct('iso','31P','A',...
-            ((frame_111)*diag([18.23 18.23 17.48]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([18.23 18.23 17.48]*hz_per_mt)*(frame_111)'));
         nuclei{end+1}=struct('iso','14N','A',...
-            ((frame_111)*diag([0.33 0.33 0.10]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([0.33 0.33 0.10]*hz_per_mt)*(frame_111)'));
     case 'np4'
         gmat=((frame)*diag([2.0009 2.0012 2.00047])*(frame)');
-        nuclei{end+1}=struct('iso','31P','A',((frame)*diag([5.456 3.838 3.80]*hz_per_mt)*(frame)'),'Q',[]);
+        nuclei{end+1}=struct('iso','31P','A',((frame)*diag([5.456 3.838 3.80]*hz_per_mt)*(frame)'));
     case 'np5'
         gmat=((frame_111)*diag([2.0009 2.0009 2.00087])*(frame_111)');
         nuclei{end+1}=struct('iso','31P','A',...
-            ((frame_111)*diag([1.024 1.024 6.522]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([1.024 1.024 6.522]*hz_per_mt)*(frame_111)'));
     case 'np6'
         gmat=((frame_111)*diag([2.00083 2.00083 2.00085])*(frame_111)');
-        nuclei{end+1}=struct('iso','31P','A',((frame)*diag([7.585 2.942 2.328]*hz_per_mt)*(frame)'),'Q',[]);
+        nuclei{end+1}=struct('iso','31P','A',((frame)*diag([7.585 2.942 2.328]*hz_per_mt)*(frame)'));
     case 'np8'
         gmat=((frame_111)*diag([2.0016 2.0016 2.0048])*(frame_111)');
         nuclei{end+1}=struct('iso','31P','A',...
-            ((frame_111)*diag([3.2 3.2 5.6]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([3.2 3.2 5.6]*hz_per_mt)*(frame_111)'));
         nuclei{end+1}=struct('iso','31P','A',...
-            ((frame_111)*diag([8.8 8.8 13.6]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([8.8 8.8 13.6]*hz_per_mt)*(frame_111)'));
     case 'np9'
         gmat=((frame_111)*diag([2.0038 2.0038 2.0030])*(frame_111)');
         nuclei{end+1}=struct('iso','31P','A',...
-            ((frame_111)*diag([2.2 2.2 1.4]*hz_per_mt)*(frame_111)'),'Q',[]);
+            ((frame_111)*diag([2.2 2.2 1.4]*hz_per_mt)*(frame_111)'));
     otherwise
         error('unknown phosphorus centre.');
 end
@@ -108,22 +108,15 @@ switch parameters.orientation
         error('unknown orientation specification.');
 end
 sys.isotopes={electron};
-inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
 for n=1:numel(nuclei)
     sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
+end
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
+inter.zeeman.matrix{1}=C*gmat*C';
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+for n=1:numel(nuclei)
+    if isfield(nuclei{n},'A')&&norm(nuclei{n}.A,2)>0
+        inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
     end
 end
 

--- a/etc/diamond_defects/diamond_p1.m
+++ b/etc/diamond_defects/diamond_p1.m
@@ -41,6 +41,8 @@ end
 
 % Define spin system isotopes
 sys.isotopes={'E',parameters.nitrogen};
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
 
 % Electron relaxation rates
 % (room temp, central line)
@@ -82,9 +84,6 @@ end
 % Electron g-tensor
 inter.zeeman.matrix{1}=R*diag([2.00220 2.00220 2.00218])*R';
 
-% Nuclear shielding tensor is ignored
-inter.zeeman.matrix{2}=zeros(3);
-
 % HFC and NQI tensor
 switch parameters.nitrogen
 
@@ -98,7 +97,6 @@ switch parameters.nitrogen
 
         % Only hyperfine coupling, opposite sign
         inter.coupling.matrix{1,2}=R*diag([-114.0e6 -114.0e6 -159.9e6])*R';
-        inter.coupling.matrix{2,2}=[];
 
     otherwise
 

--- a/etc/diamond_defects/diamond_r2.m
+++ b/etc/diamond_defects/diamond_r2.m
@@ -38,7 +38,6 @@ frame=[0 0 1;...
             0 1 0];
 gmat=((frame)*diag([2.0019 2.0019 2.0021])*(frame)');
 zfs=frame*zfs2mat(parameters.d_sign*4173e6,0,0,0,0)*frame';
-nuclei={};
 
 % Build the Spinach structures
 switch parameters.orientation
@@ -52,24 +51,11 @@ switch parameters.orientation
         error('unknown orientation specification.');
 end
 sys.isotopes={electron};
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
 inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
-for n=1:numel(nuclei)
-    sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
-    end
-end
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+[~,~,zfs]=mat2ias(C*zfs*C');
+inter.coupling.matrix{1,1}=zfs;
 
 end
 

--- a/etc/diamond_defects/diamond_siv0.m
+++ b/etc/diamond_defects/diamond_siv0.m
@@ -44,9 +44,9 @@ nuclei={};
 % Add the silicon isotope if requested
 silicon=parameters.silicon;
 if strcmp(silicon,'29Si')
-    nuclei{end+1}=struct('iso','29Si','A',((frame)*diag([78.9e6 78.9e6 76.3e6])*(frame)'),'Q',[]);
+    nuclei{end+1}=struct('iso','29Si','A',((frame)*diag([78.9e6 78.9e6 76.3e6])*(frame)'));
 elseif ~strcmp(silicon,'none')
-    nuclei{end+1}=struct('iso',silicon,'A',zeros(3),'Q',[]);
+    nuclei{end+1}=struct('iso',silicon);
 end
 
 % Add reported nearest-neighbour carbons
@@ -55,7 +55,7 @@ if parameters.include_13c
     nuc_idx=numel(nuclei);
     nuclei(nuc_idx+1:nuc_idx+6)={[]};
     for n=1:6
-        nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat,'Q',[]);
+        nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat);
     end
 end
 
@@ -71,22 +71,17 @@ switch parameters.orientation
         error('unknown orientation specification.');
 end
 sys.isotopes={electron};
-inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
 for n=1:numel(nuclei)
     sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
+end
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
+inter.zeeman.matrix{1}=C*gmat*C';
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+[~,~,zfs]=mat2ias(C*zfs*C');
+inter.coupling.matrix{1,1}=zfs;
+for n=1:numel(nuclei)
+    if isfield(nuclei{n},'A')&&norm(nuclei{n}.A,2)>0
+        inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
     end
 end
 

--- a/etc/diamond_defects/diamond_ti.m
+++ b/etc/diamond_defects/diamond_ti.m
@@ -39,7 +39,7 @@ hz_per_mt=abs(spin('E'))/(2*pi)*1e-3;
 
 % Select the titanium centre
 centre=lower(parameters.centre);
-electron='E'; nuclei={}; zfs=[];
+electron='E'; nuclei={};
 
 % Select centre-specific magnetic parameters
 switch centre
@@ -61,20 +61,20 @@ aframe=diamond_frame_alpha(A_alpha);
 gmat=((gframe)*diag(gvals)*(gframe)');
 
 % Add the nitrogen hyperfine tensor
-nuclei{end+1}=struct('iso','14N','A',((aframe)*diag(An*hz_per_mt)*(aframe)'),'Q',[]);
+nuclei{end+1}=struct('iso','14N','A',((aframe)*diag(An*hz_per_mt)*(aframe)'));
 
 % Add the titanium isotope if requested
 titanium=parameters.titanium;
 if ~strcmp(titanium,'none')
-    nuclei{end+1}=struct('iso',titanium,'A',((aframe)*diag(Ati*hz_per_mt)*(aframe)'),'Q',[]);
+    nuclei{end+1}=struct('iso',titanium,'A',((aframe)*diag(Ati*hz_per_mt)*(aframe)'));
 end
 
 % Add reported OK1 nearest-neighbour carbons
 if strcmp(centre,'ok1')&&parameters.include_13c
     Cmat=((diamond_frame_xz([1 1 0],[1 -1 -1]))*diag([2.62 2.62 4.38]*hz_per_mt)*(diamond_frame_xz([1 1 0],[1 -1 -1]))');
-    nuclei{end+1}=struct('iso','13C','A',Cmat,'Q',[]);
+    nuclei{end+1}=struct('iso','13C','A',Cmat);
     Cmat=((diamond_frame_xz([1 1 0],[-1 1 -1]))*diag([2.62 2.62 4.38]*hz_per_mt)*(diamond_frame_xz([1 1 0],[-1 1 -1]))');
-    nuclei{end+1}=struct('iso','13C','A',Cmat,'Q',[]);
+    nuclei{end+1}=struct('iso','13C','A',Cmat);
 end
 
 % Build the Spinach structures
@@ -89,22 +89,15 @@ switch parameters.orientation
         error('unknown orientation specification.');
 end
 sys.isotopes={electron};
-inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
 for n=1:numel(nuclei)
     sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
+end
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
+inter.zeeman.matrix{1}=C*gmat*C';
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+for n=1:numel(nuclei)
+    if isfield(nuclei{n},'A')&&norm(nuclei{n}.A,2)>0
+        inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
     end
 end
 

--- a/etc/diamond_defects/diamond_vacancy.m
+++ b/etc/diamond_defects/diamond_vacancy.m
@@ -75,7 +75,6 @@ end
 
 % Build the electron tensors
 gmat=eye(3)*giso;
-nuclei={};
 
 % Build the Spinach structures
 switch parameters.orientation
@@ -89,24 +88,11 @@ switch parameters.orientation
         error('unknown orientation specification.');
 end
 sys.isotopes={electron};
+inter.zeeman.matrix=cell(1,numel(sys.isotopes));
 inter.zeeman.matrix{1}=C*gmat*C';
-if ~isempty(zfs)
-    [~,~,zfs]=mat2ias(C*zfs*C');
-    inter.coupling.matrix{1,1}=zfs;
-else
-    inter.coupling.matrix{1,1}=[];
-end
-for n=1:numel(nuclei)
-    sys.isotopes{n+1}=nuclei{n}.iso;
-    inter.zeeman.matrix{n+1}=zeros(3);
-    inter.coupling.matrix{1,n+1}=C*nuclei{n}.A*C';
-    if ~isempty(nuclei{n}.Q)
-        [~,~,nqi]=mat2ias(C*nuclei{n}.Q*C');
-        inter.coupling.matrix{n+1,n+1}=nqi;
-    else
-        inter.coupling.matrix{n+1,n+1}=[];
-    end
-end
+inter.coupling.matrix=cell(numel(sys.isotopes),numel(sys.isotopes));
+[~,~,zfs]=mat2ias(C*zfs*C');
+inter.coupling.matrix{1,1}=zfs;
 
 end
 


### PR DESCRIPTION
Summary:
- Removes dead zero-field splitting branches, unused quadrupole fields, and explicit empty coupling assignments from etc/diamond_defects.
- Preallocates Zeeman and coupling cell arrays to the required Spinach input sizes, and only fills tensors that are physically present.
- Omits zero hyperfine tensors for requested isotopes with no reported hyperfine coupling, while still returning the requested spin isotope.

Validation:
- MATLAB checkcode on all 13 etc/diamond_defects functions: 0 messages.
- Before/after MATLAB snapshot over 219 representative diamond-defect parameter cases: effective tensors unchanged after normalising removed zero/empty placeholders; every case accepted by create().
- Full Spinach regression suite: 94 passed, 0 failed.
- git diff --check passed.