### PR TITLE
Harden SpinXML schema identifiers

### DIFF
--- a/interfaces/spinxml/parsexml.m
+++ b/interfaces/spinxml/parsexml.m
@@ -23,12 +23,11 @@ function xml=parsexml(filename)
 % Check consistency
 grumble(filename);
 
-% TODO: validation against the schema,
-%       best just call Java here
+% Use Matlab's native XML engine, avoiding Java
 
 % Read the file
 try
-   tree=xmlread(filename);
+   tree=xmlread(filename,'XMLEngine','maxp');
 catch
    error('Could not read XML file %s.',filename);
 end
@@ -45,14 +44,14 @@ end
 % Child node parsing
 function children=parseChildNodes(theNode)
 children=[];
-if theNode.hasChildNodes
-    childNodes=theNode.getChildNodes;
-    numChildNodes=childNodes.getLength;
+if isprop(theNode,'Children')&&(~isempty(theNode.Children))
+    childNodes=theNode.Children;
+    numChildNodes=numel(childNodes);
     allocCell=cell(1,numChildNodes);
     children=struct('name',allocCell,'attributes',allocCell,...
                     'data',allocCell,'children',allocCell);
     for n=1:numChildNodes
-        theChild=childNodes.item(n-1);
+        theChild=childNodes(n);
         children(n)=makeStructFromNode(theChild);
     end
 end
@@ -60,28 +59,42 @@ end
 
 % Structure creation
 function nodeStruct=makeStructFromNode(theNode)
-nodeStruct=struct('name',char(theNode.getNodeName),...
-                  'attributes',parseAttributes(theNode),...
-                  'data','','children',parseChildNodes(theNode));
-if ismember('getData',methods(theNode))
-   nodeStruct.data=char(theNode.getData); 
+if isprop(theNode,'TagName')
+    nodeName=char(theNode.TagName);
 else
-   nodeStruct.data='';
+    switch class(theNode)
+        case 'matlab.io.xml.dom.Text'
+            nodeName='#text';
+        case 'matlab.io.xml.dom.Comment'
+            nodeName='#comment';
+        otherwise
+            nodeName=class(theNode);
+    end
 end
+if isprop(theNode,'TagName')
+    nodeData='';
+elseif isprop(theNode,'TextContent')
+    nodeData=char(theNode.TextContent);
+else
+    nodeData='';
+end
+nodeStruct=struct('name',nodeName,...
+                  'attributes',parseAttributes(theNode),...
+                  'data',nodeData,'children',parseChildNodes(theNode));
 end
 
 % Attribute parsing
 function attributes=parseAttributes(theNode)
 attributes=[];
-if theNode.hasAttributes
+if isprop(theNode,'HasAttributes')&&theNode.HasAttributes
    theAttributes=theNode.getAttributes;
-   numAttributes=theAttributes.getLength;
+   numAttributes=theAttributes.Length;
    allocCell=cell(1,numAttributes);
    attributes=struct('name',allocCell,'value',allocCell);
    for n=1:numAttributes
       attrib=theAttributes.item(n-1);
-      attributes(n).name=char(attrib.getName);
-      attributes(n).value=char(attrib.getValue);
+      attributes(n).name=char(attrib.Name);
+      attributes(n).value=char(attrib.Value);
    end
 end
 end

--- a/interfaces/spinxml/spinxml_schema.xsd
+++ b/interfaces/spinxml/spinxml_schema.xsd
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           version="1.1">
+
+    <xs:simpleType name="positive_id">
+        <xs:restriction base="xs:positiveInteger" />
+    </xs:simpleType>
 
     <xs:complexType name="vector">
         <xs:attribute name="x"
@@ -189,7 +194,7 @@
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="id"
-                      type="xs:integer"
+                      type="positive_id"
                       use="required" />
         <xs:attribute name="units"
                       use="required">
@@ -206,10 +211,10 @@
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="spin_a"
-                      type="xs:integer"
+                      type="positive_id"
                       use="required" />
         <xs:attribute name="spin_b"
-                      type="xs:integer"
+                      type="positive_id"
                       use="optional" />
         <xs:attribute name="reference"
                       type="xs:string"
@@ -223,7 +228,7 @@
         <xs:sequence minOccurs="1"
                      maxOccurs="1">
             <xs:element name="spin"
-                        minOccurs="0"
+                        minOccurs="1"
                         maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:sequence minOccurs="0"
@@ -232,7 +237,7 @@
                                     type="vector" />
                     </xs:sequence>
                     <xs:attribute name="id"
-                                  type="xs:integer"
+                                  type="positive_id"
                                   use="required" />
                     <xs:attribute name="isotope"
                                   type="xs:string"
@@ -247,9 +252,33 @@
                         minOccurs="0"
                         maxOccurs="unbounded" />
         </xs:sequence>
+        <xs:assert test="every $spin_id in 1 to count(spin) satisfies spin[xs:integer(@id)=$spin_id]" />
+        <xs:assert test="count(interaction)=0 or every $inter_id in 1 to count(interaction) satisfies interaction[xs:integer(@id)=$inter_id]" />
+        <xs:assert test="every $inter in interaction[@kind=('hfc','dipolar','jcoupling','exchange')] satisfies exists($inter/@spin_b)" />
+        <xs:assert test="every $inter in interaction[@kind=('shielding','shift','quadrupolar','gtensor','zfs','spinrotation')] satisfies empty($inter/@spin_b)" />
+        <xs:assert test="every $inter in interaction[@spin_b] satisfies $inter/@spin_a ne $inter/@spin_b" />
     </xs:complexType>
 
     <xs:element name="spin_system" 
-                type="spin_system" />
+                type="spin_system">
+        <xs:key name="spin_id_key">
+            <xs:selector xpath="spin" />
+            <xs:field xpath="@id" />
+        </xs:key>
+        <xs:key name="interaction_id_key">
+            <xs:selector xpath="interaction" />
+            <xs:field xpath="@id" />
+        </xs:key>
+        <xs:keyref name="spin_a_reference"
+                   refer="spin_id_key">
+            <xs:selector xpath="interaction" />
+            <xs:field xpath="@spin_a" />
+        </xs:keyref>
+        <xs:keyref name="spin_b_reference"
+                   refer="spin_id_key">
+            <xs:selector xpath="interaction" />
+            <xs:field xpath="@spin_b" />
+        </xs:keyref>
+    </xs:element>
 
 </xs:schema>

--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -757,8 +757,10 @@ for n=1:numel(xml.children)
                         inter.spinrot.matrix{inter_spin_a}=A;
                     case 'kHz'
                         inter.spinrot.matrix{inter_spin_a}=1e3*A;
-                    case 'GHz'
+                    case 'MHz'
                         inter.spinrot.matrix{inter_spin_a}=1e6*A;
+                    case 'GHz'
+                        inter.spinrot.matrix{inter_spin_a}=1e9*A;
                     otherwise
                         error('unknown spin-rotation tensor units.');
                 end

--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -635,7 +635,8 @@ for n=1:numel(xml.children)
                 % Assign the J-coupling
                 switch inter_units
                     case 'Hz'
-                        inter.coupling.matrix{inter_spin_a,inter_spin_b}=A;
+                        inter.coupling.matrix{inter_spin_a,inter_spin_b}=...
+                        inter.coupling.matrix{inter_spin_a,inter_spin_b}+A;
                     otherwise
                         error('unknown J-coupling units.');
                 end
@@ -729,9 +730,11 @@ for n=1:numel(xml.children)
                 % Assign the exchange coupling
                 switch inter_units
                     case 'MHz'
-                        inter.coupling.matrix{inter_spin_a,inter_spin_b}=1e6*A;
+                        inter.coupling.matrix{inter_spin_a,inter_spin_b}=...
+                        inter.coupling.matrix{inter_spin_a,inter_spin_b}+1e6*A;
                     case 'GHz'
-                        inter.coupling.matrix{inter_spin_a,inter_spin_b}=1e9*A;
+                        inter.coupling.matrix{inter_spin_a,inter_spin_b}=...
+                        inter.coupling.matrix{inter_spin_a,inter_spin_b}+1e9*A;
                     otherwise
                         error('unknown exchange coupling units.');
                 end


### PR DESCRIPTION
Summary:
- require at least one spin and use positive integer identifiers for spins and interactions
- add schema identity constraints for unique spin/interaction IDs and spin_a/spin_b references
- add XSD 1.1 assertions for gapless IDs, required/forbidden spin_b by interaction kind, and no self-couplings
- switch parsexml.m to xmlread(filename,'XMLEngine','maxp') and adapt parsing to MATLAB DOM objects, avoiding Java for SpinXML import
- fix spinrotation unit conversion in x2spinach.m: add MHz support and convert GHz with 1e9 instead of 1e6
- make jcoupling and exchange add into existing pair coupling matrices instead of overwriting previous contributions

Validation:
- git diff --check -- interfaces/spinxml/parsexml.m interfaces/spinxml/x2spinach.m interfaces/spinxml/spinxml_schema.xsd
- Python xmlschema.XMLSchema11 validation of alanine.sxml, complete_test.sxml, and nitroxide.sxml
- Python xmlschema.XMLSchema11 negative cases for empty systems, zero/negative IDs, duplicate/gapped IDs, bad spin references, duplicate/gapped interaction IDs, missing/forbidden spin_b, and self-couplings
- Python xmlschema.XMLSchema11 validation of spinrotation units Hz, kHz, MHz, and GHz
- Python xmlschema.XMLSchema11 validation of repeated jcoupling and exchange contributions to the same spin pair
- MATLAB -nojvm checkcode('interfaces/spinxml/parsexml.m','-id') reported zero messages
- MATLAB -nojvm checkcode('interfaces/spinxml/x2spinach.m','-id') reported zero messages
- MATLAB -nojvm x2spinach parsed alanine.sxml, complete_test.sxml, and nitroxide.sxml
- MATLAB -nojvm x2spinach focused spinrotation probes returned factors 1, 1e3, 1e6, and 1e9 for Hz, kHz, MHz, and GHz
- MATLAB -nojvm x2spinach focused repeated-pair probes showed order-independent jcoupling and exchange accumulation
- MATLAB -nojvm gissmo2spinach parsed examples/nmr_metabol/molecule_a.xml, molecule_b.xml, and molecule_c.xml