### PR TITLE
Add DOI references to NMR liquids headers

### DIFF
--- a/experiments/nmr_liquids/clip_hsqc.m
+++ b/experiments/nmr_liquids/clip_hsqc.m
@@ -1,4 +1,10 @@
-% CLIP-HSQC pulse sequence. Syntax:
+% CLIP-HSQC pulse sequence.
+%
+% References:
+%
+%             https://doi.org/10.1016/j.jmr.2008.03.009
+%
+% Syntax:
 %
 %             fid=clip_hsqc(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/coloc.m
+++ b/experiments/nmr_liquids/coloc.m
@@ -1,8 +1,10 @@
-% COLOC NMR pulse sequence from 
+% COLOC NMR pulse sequence.
+%
+% References:
 %
 %          https://doi.org/10.1016/0022-2364(84)90136-7
 %
-% implemented as shown in Figure 1b, without the dashed pulses during
+% Implemented as shown in Figure 1b, without the dashed pulses during
 % the delta(2) period. Delta(1) defaults to half of the maximum F1
 % evolution time implied by the sweep width, delta(2) must be specified.
 % Syntax:

--- a/experiments/nmr_liquids/cosy.m
+++ b/experiments/nmr_liquids/cosy.m
@@ -1,4 +1,11 @@
-% Phase-sensitive COSY pulse sequence. Syntax:
+% Phase-sensitive COSY pulse sequence.
+%
+% References:
+%
+%               https://doi.org/10.1063/1.432450
+%               https://doi.org/10.1016/0022-2364(82)90279-7
+%
+% Syntax:
 %
 %               fid=cosy(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/crazed.m
+++ b/experiments/nmr_liquids/crazed.m
@@ -1,6 +1,11 @@
 % CRAZED pulse sequence. Ideal analytical coherence-pathway version
-% of the sequence described by Warren & Co in
-% http://dx.doi.org/10.1126/science.8266096. Syntax:
+% of the sequence described by Warren et al.
+%
+% References:
+%
+%                https://doi.org/10.1126/science.8266096
+%
+% Syntax:
 %
 %                fid=crazed(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/ct_cosy.m
+++ b/experiments/nmr_liquids/ct_cosy.m
@@ -1,5 +1,12 @@
 % Constant-time COSY pulse sequence with analytical coherence selec-
-% tion from Figure 3a of (https://doi.org/10.1002/chem.201406283).
+% tion.
+%
+% References:
+%
+%             https://doi.org/10.1006/jmra.1994.1095
+%             https://doi.org/10.1080/00387010009350054
+%             https://doi.org/10.1002/chem.201406283
+%
 % The F1 trace is flipped at the end to preserve the conventional
 % indirect-dimension sign for the reversed-delay implementation.
 % Syntax:

--- a/experiments/nmr_liquids/ct_hsqc.m
+++ b/experiments/nmr_liquids/ct_hsqc.m
@@ -1,4 +1,11 @@
-% Constant-time phase-sensitive HSQC pulse sequence. Syntax:
+% Constant-time phase-sensitive HSQC pulse sequence.
+%
+% References:
+%
+%              https://doi.org/10.1016/0022-2364(92)90144-V
+%              https://doi.org/10.1007/BF00227470
+%
+% Syntax:
 %
 %              fid=ct_hsqc(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/dept.m
+++ b/experiments/nmr_liquids/dept.m
@@ -1,5 +1,10 @@
-% DEPT pulse sequence from the schematic in the paper by Doddrell, Pegg,
-% and Bendall (https://doi.org/10.1016/0022-2364(82)90286-4). Syntax: 
+% DEPT pulse sequence.
+%
+% References:
+%
+%                  https://doi.org/10.1016/0022-2364(82)90286-4
+%
+% Syntax:
 % 
 %                  fid=dept(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/deptq.m
+++ b/experiments/nmr_liquids/deptq.m
@@ -1,5 +1,10 @@
-% DEPTQ pulse sequence from Figure 1 of the paper by Burger and Bigler:
-% (https://doi.org/10.1006/jmre.1998.1595). Syntax: 
+% DEPTQ pulse sequence.
+%
+% References:
+%
+%                  https://doi.org/10.1006/jmre.1998.1595
+%
+% Syntax:
 % 
 %                  fid=deptq(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/dqf_cosy.m
+++ b/experiments/nmr_liquids/dqf_cosy.m
@@ -1,4 +1,11 @@
-% Phase-sensitive double-quantum filtered COSY pulse sequence. Syntax:
+% Phase-sensitive double-quantum filtered COSY pulse sequence.
+%
+% References:
+%
+%               https://doi.org/10.1016/0006-291X(83)91225-1
+%               https://doi.org/10.1021/ja00388a062
+%
+% Syntax:
 %
 %               fid=dqf_cosy(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/ecosy.m
+++ b/experiments/nmr_liquids/ecosy.m
@@ -1,4 +1,12 @@
-% Phase-sensitive E.COSY pulse sequence. Syntax:
+% Phase-sensitive E.COSY pulse sequence.
+%
+% References:
+%
+%               https://doi.org/10.1021/ja00308a042
+%               https://doi.org/10.1063/1.451421
+%               https://doi.org/10.1016/0022-2364(87)90102-8
+%
+% Syntax:
 %
 %               fid=ecosy(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/gcosy.m
+++ b/experiments/nmr_liquids/gcosy.m
@@ -1,4 +1,10 @@
-% Gradient-selected COSY pulse sequence. Syntax:
+% Gradient-selected COSY pulse sequence.
+%
+% References:
+%
+%               https://doi.org/10.1002/(SICI)1097-458X(199711)35:10%3C680::AID-OMR149%3E3.0.CO;2-%23
+%
+% Syntax:
 %
 %               fid=gcosy(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/hetcor.m
+++ b/experiments/nmr_liquids/hetcor.m
@@ -1,4 +1,10 @@
-% Magnitude-mode HETCOR pulse sequence. Syntax:
+% Magnitude-mode HETCOR pulse sequence.
+%
+% References:
+%
+%            https://doi.org/10.1016/0022-2364(81)90272-9
+%
+% Syntax:
 %
 %            fid=hetcor(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/hmbc.m
+++ b/experiments/nmr_liquids/hmbc.m
@@ -1,6 +1,9 @@
-% Magnitude-mode HMBC pulse sequence from 
+% Magnitude-mode HMBC pulse sequence.
 %
-%   A. Bax and M.F. Summers, J. Am. Chem. Soc., 108, 2093 (1986)
+% References:
+%
+%              https://doi.org/10.1021/ja00268a061
+%              https://doi.org/10.1016/0022-2364(88)90172-2
 %
 % Syntax:
 %

--- a/experiments/nmr_liquids/hmqc.m
+++ b/experiments/nmr_liquids/hmqc.m
@@ -1,4 +1,10 @@
-% Magnitude-mode HMQC pulse sequence. Syntax:
+% Magnitude-mode HMQC pulse sequence.
+%
+% References:
+%
+%              https://doi.org/10.1016/0022-2364(83)90241-X
+%
+% Syntax:
 %
 %              fid=hmqc(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/hoesy.m
+++ b/experiments/nmr_liquids/hoesy.m
@@ -1,4 +1,11 @@
-% Phase-sensitive heteronuclear NOESY pulse sequence. Syntax:
+% Phase-sensitive heteronuclear NOESY pulse sequence.
+%
+% References:
+%
+%            https://doi.org/10.1021/ja00353a071
+%            https://doi.org/10.1039/C8CP00911B
+%
+% Syntax:
 %
 %            fid=hoesy(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/hsqc.m
+++ b/experiments/nmr_liquids/hsqc.m
@@ -1,4 +1,11 @@
-% Phase-sensitive HSQC pulse sequence. Syntax:
+% Phase-sensitive HSQC pulse sequence.
+%
+% References:
+%
+%              https://doi.org/10.1016/0009-2614(80)80041-8
+%              https://doi.org/10.1002/cmr.a.10095
+%
+% Syntax:
 %
 %              fid=hsqc(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/inadequate.m
+++ b/experiments/nmr_liquids/inadequate.m
@@ -1,7 +1,13 @@
 % INADEQUATE pulse sequence. Selects double-quantum coherence from
 % coupled carbon pairs, then converts it back into observable single-
 % quantum magnetisation. At natural abundance 13C, this produces only
-% 13C pair subspectra. Syntax:
+% 13C pair subspectra.
+%
+% References:
+%
+%              https://doi.org/10.1021/ja00534a056
+%
+% Syntax:
 %
 %              fid=inadequate(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/inadequate_2d.m
+++ b/experiments/nmr_liquids/inadequate_2d.m
@@ -1,4 +1,11 @@
-% 2D INADEQUATE pulse sequence. Syntax:
+% 2D INADEQUATE pulse sequence.
+%
+% References:
+%
+%         https://doi.org/10.1021/ja00398a044
+%         https://doi.org/10.1016/0022-2364(81)90060-3
+%
+% Syntax:
 %
 %         fid=inadequate_2d(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/inept.m
+++ b/experiments/nmr_liquids/inept.m
@@ -1,6 +1,12 @@
 % Non-refocused INEPT pulse sequence. This returns the directly
 % acquired coupled antiphase spectrum rather than a refocused,
-% broadband-decoupled INEPT variant. Syntax:
+% broadband-decoupled INEPT variant.
+%
+% References:
+%
+%           https://doi.org/10.1021/ja00497a058
+%
+% Syntax:
 % 
 %           fid=inept(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/mqs.m
+++ b/experiments/nmr_liquids/mqs.m
@@ -1,4 +1,11 @@
-% 2D multiple-quantum NMR pulse sequence. Syntax:
+% 2D multiple-quantum NMR pulse sequence.
+%
+% References:
+%
+%           https://doi.org/10.1002/cphc.201800667
+%           https://doi.org/10.1039/d1cc03079e
+%
+% Syntax:
 %
 %           fid=mqs(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/mqs_refocus.m
+++ b/experiments/nmr_liquids/mqs_refocus.m
@@ -1,4 +1,11 @@
-% Multiple quantum correlation pulse sequence with refocusing. Syntax:
+% Multiple quantum correlation pulse sequence with refocusing.
+%
+% References:
+%
+%            https://doi.org/10.1063/1.432450
+%            https://doi.org/10.1016/0022-2364(80)90096-7
+%
+% Syntax:
 %
 %            fid=mqs_refocus(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/noesy.m
+++ b/experiments/nmr_liquids/noesy.m
@@ -1,4 +1,12 @@
-% Phase-sensitive homonuclear NOESY pulse sequence. Syntax:
+% Phase-sensitive homonuclear NOESY pulse sequence.
+%
+% References:
+%
+%             https://doi.org/10.1063/1.438208
+%             https://doi.org/10.1016/0006-291X(80)90695-6
+%             https://doi.org/10.1016/0022-2364(82)90279-7
+%
+% Syntax:
 %
 %             fid=noesy(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/noesyhsqc.m
+++ b/experiments/nmr_liquids/noesyhsqc.m
@@ -1,10 +1,11 @@
-% Phase-sensitive NOESY-HSQC sequence from
+% Phase-sensitive NOESY-HSQC sequence.
 %
-%         http://pubs.acs.org/doi/abs/10.1021/bi00441a004 
+% References:
 %
-% using the bidirectional propagation method described in
-%
-%          http://dx.doi.org/10.1016/j.jmr.2014.04.002
+%         https://doi.org/10.1021/bi00441a004
+%         https://doi.org/10.1016/0022-2364(90)90227-Z
+%         https://doi.org/10.1002/9780470034590.emrstm0563
+%         https://doi.org/10.1016/j.jmr.2014.04.002
 %
 % The sequence is hard-wired to {F1,F2,F3}={1H,15N,1H} with carbon
 % decoupled throughout. Syntax:

--- a/experiments/nmr_liquids/pansy_cosy.m
+++ b/experiments/nmr_liquids/pansy_cosy.m
@@ -1,7 +1,9 @@
-% Magnitude mode PANSY-COSY pulse sequence from Figure 1 in the 
-% paper by Kupce, Freeman, and John:
+% Magnitude mode PANSY-COSY pulse sequence.
 %
-%               http://dx.doi.org/10.1021/ja0634876
+% References:
+%
+%            https://doi.org/10.1021/ja0634876
+%            https://doi.org/10.1016/j.pnmrs.2021.03.001
 %
 % Syntax:
 %

--- a/experiments/nmr_liquids/pansy_triple.m
+++ b/experiments/nmr_liquids/pansy_triple.m
@@ -1,7 +1,9 @@
-% Triple-channel PANSY pulse sequence from Figure 1 in the 
-% paper by Kupce, Freeman, and John:
+% Triple-channel PANSY pulse sequence.
 %
-%            https://dx.doi.org/10.1021/ja0634876
+% References:
+%
+%       https://doi.org/10.1021/ja0634876
+%       https://doi.org/10.1007/128_2011_226
 %
 % Syntax:
 %

--- a/experiments/nmr_liquids/roesy.m
+++ b/experiments/nmr_liquids/roesy.m
@@ -1,5 +1,12 @@
 % Phase-sensitive homonuclear ROESY pulse sequence, assuming ideal
-% spin-lock. Syntax:
+% spin-lock.
+%
+% References:
+%
+%             https://doi.org/10.1021/ja00315a069
+%             https://doi.org/10.1016/0022-2364(85)90171-4
+%
+% Syntax:
 %
 %             fid=roesy(spin_system,parameters,H,R,K)
 %

--- a/experiments/nmr_liquids/tocsy.m
+++ b/experiments/nmr_liquids/tocsy.m
@@ -1,4 +1,12 @@
-% Amplitude-mode homonuclear TOCSY pulse sequence. Syntax:
+% Amplitude-mode homonuclear TOCSY pulse sequence.
+%
+% References:
+%
+%             https://doi.org/10.1016/0022-2364(83)90226-3
+%             https://doi.org/10.1021/ja00295a052
+%             https://doi.org/10.1016/0022-2364(85)90018-6
+%
+% Syntax:
 %
 %             fid=tocsy(spin_system,parameters,H,R,K)
 %


### PR DESCRIPTION
Summary:
- Added DOI-link reference blocks to all 27 experiments/nmr_liquids pulse sequence function headers.
- Used tmp/nmr_liquids_audit_20260518/reports and the filed audit literature notes to choose the citations.
- Kept changes header-only; no pulse sequence logic or examples were changed.

Validation:
- git diff --check -- experiments/nmr_liquids
- Header DOI block check over all 27 files
- DOI resolver HEAD check over 47 unique doi.org links
- MATLAB: matlab -nojvm -batch "run('/home/kuprov/.openclaw/workspace/tmp/nmr_liquids_header_citations_20260518/validate_header_citations.m')" -> NMR_LIQUIDS_HEADER_CHECKCODE_OK

