### PR TITLE
Add diamond defect variants and EPR examples

### DIFF
--- a/etc/diamond_defects/diamond_n_inter.m
+++ b/etc/diamond_defects/diamond_n_inter.m
@@ -12,7 +12,7 @@
 %      .centre       - 'war9' or 'war10'
 %      .orientation  - '111', '110', or '100' crystal plane normal
 %                      aligned with the magnetic field
-%      .nitrogen     - must be '15N'
+%      .nitrogen     - '14N' or '15N'
 %
 % Outputs:
 %
@@ -31,11 +31,6 @@ end
 
 % Check consistency
 grumble(parameters);
-
-% Restrict to the verified isotope
-if ~strcmp(parameters.nitrogen,'15N')
-    error('WAR9/WAR10 parameters are only available here for 15N.');
-end
 
 % Build the common frame
 electron='E';
@@ -60,7 +55,15 @@ switch centre
 end
 
 % Add the nitrogen hyperfine tensor
-nucleus=struct('iso','15N','A',Amat);
+switch parameters.nitrogen
+    case '15N'
+        nucleus=struct('iso','15N','A',Amat);
+    case '14N'
+        scale=spin('14N')/spin('15N');
+        nucleus=struct('iso','14N','A',scale*Amat);
+    otherwise
+        error('parameters.nitrogen must be ''14N'' or ''15N''.');
+end
 
 % Build the Spinach structures
 switch parameters.orientation
@@ -103,6 +106,9 @@ if(~isfield(parameters,'nitrogen'))
 end
 if(~ischar(parameters.nitrogen))
     error('parameters.nitrogen must be a character string.');
+end
+if(~any(strcmp(parameters.nitrogen,{'14N','15N'})))
+    error('parameters.nitrogen must be ''14N'' or ''15N''.');
 end
 end
 

--- a/etc/diamond_defects/diamond_ni.m
+++ b/etc/diamond_defects/diamond_ni.m
@@ -21,7 +21,8 @@
 %                      aligned with the magnetic field
 %      .nickel       - '61Ni', 'none', or another nickel isotope;
 %                      required when .centre is 'w8'
-%      .include_13c  - logical flag enabling reported 13C hyperfine couplings
+%      .n_13c        - number of reported 13C hyperfine couplings
+%                      to include, from 0 to 4; applies only to W8
 %
 % Outputs:
 %
@@ -40,6 +41,11 @@ end
 
 % Check consistency
 grumble(parameters);
+
+% Set irrelevant carbon count to zero
+if ~strcmpi(parameters.centre,'w8')
+    parameters.n_13c=0;
+end
 
 % Set field-unit conversion constants
 hz_per_mt=abs(spin('E'))/(2*pi)*1e-3;
@@ -63,11 +69,11 @@ switch centre
         elseif ~strcmp(nickel,'none')
             nuclei{end+1}=struct('iso',nickel);
         end
-        if parameters.include_13c
+        if parameters.n_13c>0
             Cmat=((frame_111)*diag([0.340 0.340 1.339]*hz_per_mt)*(frame_111)');
             nuc_idx=numel(nuclei);
-            nuclei(nuc_idx+1:nuc_idx+4)={[]};
-            for n=1:4
+            nuclei(nuc_idx+1:nuc_idx+parameters.n_13c)={[]};
+            for n=1:parameters.n_13c
                 nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat);
             end
         end
@@ -173,7 +179,7 @@ function grumble(parameters)
 if ~isstruct(parameters)
     error('parameters must be a structure.');
 end
-required={'centre','orientation','include_13c'};
+required={'centre','orientation'};
 for n=1:numel(required)
     if ~isfield(parameters,required{n})
         error(['parameters.' required{n} ' field is required.']);
@@ -185,11 +191,21 @@ end
 if ~ischar(parameters.orientation)
     error('parameters.orientation must be a character string.');
 end
-if ~islogical(parameters.include_13c)||~isscalar(parameters.include_13c)
-    error('parameters.include_13c must be a scalar logical.');
+if isfield(parameters,'n_13c')&&(~isnumeric(parameters.n_13c)||~isscalar(parameters.n_13c)||...
+        ~isreal(parameters.n_13c)||parameters.n_13c~=round(parameters.n_13c))
+    error('parameters.n_13c must be an integer scalar.');
 end
 if strcmpi(parameters.centre,'w8')&&(~isfield(parameters,'nickel'))
     error('parameters.nickel field is required for W8 centre.');
+end
+if strcmpi(parameters.centre,'w8')&&(~isfield(parameters,'n_13c'))
+    error('parameters.n_13c field is required for W8 centre.');
+end
+if strcmpi(parameters.centre,'w8')&&(parameters.n_13c<0||parameters.n_13c>4)
+    error('parameters.n_13c must be between 0 and 4.');
+end
+if ~strcmpi(parameters.centre,'w8')&&isfield(parameters,'n_13c')&&parameters.n_13c~=0
+    error('parameters.n_13c is only supported for W8 centre.');
 end
 if isfield(parameters,'nickel')&&(~ischar(parameters.nickel))
     error('parameters.nickel must be a character string.');

--- a/etc/diamond_defects/diamond_ni.m
+++ b/etc/diamond_defects/diamond_ni.m
@@ -4,6 +4,9 @@
 %
 % W8 magnetic parameters from Ludwig and Woodbury, Phys. Rev. B 41,
 % 3905 (1990), https://doi.org/10.1103/PhysRevB.41.3905
+% The W8 quartet entry assumes zero ZFS: no ZFS parameters were
+% reported in the cited data, and off-central transitions are treated
+% as unresolved rather than explicitly modelled.
 % Other nickel-centre table values from Nadolinny et al., Crystals
 % 7, 237 (2017), https://doi.org/10.3390/cryst7080237
 %

--- a/etc/diamond_defects/diamond_nv0_es.m
+++ b/etc/diamond_defects/diamond_nv0_es.m
@@ -11,7 +11,9 @@
 %
 %      .orientation  - '111', '110', or '100' crystal plane normal
 %                      aligned with the magnetic field
-%      .nitrogen     - must be '15N'
+%      .nitrogen     - '14N' or '15N'; 14N hyperfine couplings
+%                      are scaled from 15N, with no NQI included
+%                      because none is reported for this state
 %
 % Outputs:
 %
@@ -40,7 +42,16 @@ gmat=((frame)*diag([2.0035 2.0035 2.0029])*(frame)');
 zfs=frame*zfs2mat(1685e6,0,0,0,0)*frame';
 
 % Add the nitrogen hyperfine tensor
-nucleus=struct('iso','15N','A',((frame)*diag([-23.8e6 -23.8e6 -35.7e6])*(frame)'));
+Amat=((frame)*diag([-23.8e6 -23.8e6 -35.7e6])*(frame)');
+switch parameters.nitrogen
+    case '15N'
+        nucleus=struct('iso','15N','A',Amat);
+    case '14N'
+        scale=spin('14N')/spin('15N');
+        nucleus=struct('iso','14N','A',scale*Amat);
+    otherwise
+        error('parameters.nitrogen must be ''14N'' or ''15N''.');
+end
 
 % Build the Spinach structures
 switch parameters.orientation
@@ -83,8 +94,8 @@ end
 if(~ischar(parameters.nitrogen))
     error('parameters.nitrogen must be a character string.');
 end
-if ~strcmp(parameters.nitrogen,'15N')
-    error('NV0 excited-state parameters are only available here for 15N.');
+if(~any(strcmp(parameters.nitrogen,{'14N','15N'})))
+    error('parameters.nitrogen must be ''14N'' or ''15N''.');
 end
 end
 

--- a/etc/diamond_defects/diamond_p.m
+++ b/etc/diamond_defects/diamond_p.m
@@ -13,7 +13,8 @@
 %                      'np6', 'np8', or 'np9'
 %      .orientation  - '111', '110', or '100' crystal plane normal
 %                      aligned with the magnetic field
-%      .include_13c - include reported 13C hyperfine couplings for MA1
+%      .include_13c  - include the reported 13C hyperfine coupling;
+%                      applies only to MA1 and defaults to false
 %
 % Outputs:
 %
@@ -28,6 +29,11 @@ function [sys,inter]=diamond_p(parameters)
 % Check input count
 if nargin~=1
     error('exactly one input argument is required.');
+end
+
+% Set carbon coupling default
+if isstruct(parameters)&&~isfield(parameters,'include_13c')
+    parameters.include_13c=false;
 end
 
 % Check consistency
@@ -145,11 +151,11 @@ end
 if ~ismember(parameters.orientation,{'111','110','100'})
     error('parameters.orientation must be ''111'', ''110'', or ''100''.');
 end
-if ~isfield(parameters,'include_13c')
-    error('parameters.include_13c field is required.');
+if(~islogical(parameters.include_13c)||~isscalar(parameters.include_13c))
+    error('parameters.include_13c must be a scalar logical.');
 end
-if(~islogical(parameters.include_13c))
-    error('parameters.include_13c must be logical.');
+if ~strcmpi(parameters.centre,'ma1')&&parameters.include_13c
+    error('parameters.include_13c is only supported for MA1 centre.');
 end
 end
 
@@ -159,4 +165,3 @@ end
 % indication of how skewed our perspective tends to be.
 %
 % Douglas Adams
-

--- a/etc/diamond_defects/diamond_siv0.m
+++ b/etc/diamond_defects/diamond_siv0.m
@@ -12,7 +12,8 @@
 %      .silicon      - '29Si', 'none', or another silicon isotope
 %      .orientation  - '111', '110', or '100' crystal plane normal
 %                      aligned with the magnetic field
-%      .include_13c  - include reported 13C hyperfine couplings
+%      .n_13c       - number of reported nearest-neighbour 13C
+%                     hyperfine couplings, between 0 and 6
 %
 % Outputs:
 %
@@ -50,11 +51,11 @@ elseif ~strcmp(silicon,'none')
 end
 
 % Add reported nearest-neighbour carbons
-if parameters.include_13c
+if parameters.n_13c>0
     Cmat=((frame)*diag([30.2e6 30.2e6 66.2e6])*(frame)');
     nuc_idx=numel(nuclei);
-    nuclei(nuc_idx+1:nuc_idx+6)={[]};
-    for n=1:6
+    nuclei(nuc_idx+1:nuc_idx+parameters.n_13c)={[]};
+    for n=1:parameters.n_13c
         nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat);
     end
 end
@@ -107,11 +108,12 @@ end
 if ~ischar(parameters.silicon)
     error('parameters.silicon must be a character string.');
 end
-if ~isfield(parameters,'include_13c')
-    error('parameters.include_13c field is missing.');
+if ~isfield(parameters,'n_13c')
+    error('parameters.n_13c field is missing.');
 end
-if (~islogical(parameters.include_13c))||(~isscalar(parameters.include_13c))
-    error('parameters.include_13c must be logical.');
+if (~isnumeric(parameters.n_13c))||(~isscalar(parameters.n_13c))||...
+   (parameters.n_13c<0)||(parameters.n_13c>6)||(mod(parameters.n_13c,1)~=0)
+    error('parameters.n_13c must be an integer between 0 and 6.');
 end
 end
 

--- a/etc/diamond_defects/diamond_ti.m
+++ b/etc/diamond_defects/diamond_ti.m
@@ -7,14 +7,14 @@
 %
 % Parameters:
 %
-%    parameters is a structure with the following required fields:
+%    parameters is a structure with the following fields:
 %
 %      .centre       - 'n3' or 'ok1'
 %      .orientation  - '111', '110', or '100' crystal plane normal
 %                      aligned with the magnetic field
 %      .titanium     - titanium isotope label, or 'none'
-%      .include_13c - include reported 13C hyperfine couplings for OK1,
-%                     true or false
+%      .n_13c        - number of reported 13C hyperfine couplings
+%                      to include, from 0 to 2; applies only to OK1
 %
 % Outputs:
 %
@@ -33,6 +33,11 @@ end
 
 % Check consistency
 grumble(parameters);
+
+% Set irrelevant carbon count to zero
+if ~strcmpi(parameters.centre,'ok1')
+    parameters.n_13c=0;
+end
 
 % Set field-unit conversion constants
 hz_per_mt=abs(spin('E'))/(2*pi)*1e-3;
@@ -70,11 +75,13 @@ if ~strcmp(titanium,'none')
 end
 
 % Add reported OK1 nearest-neighbour carbons
-if strcmp(centre,'ok1')&&parameters.include_13c
-    Cmat=((diamond_frame_xz([1 1 0],[1 -1 -1]))*diag([2.62 2.62 4.38]*hz_per_mt)*(diamond_frame_xz([1 1 0],[1 -1 -1]))');
-    nuclei{end+1}=struct('iso','13C','A',Cmat);
-    Cmat=((diamond_frame_xz([1 1 0],[-1 1 -1]))*diag([2.62 2.62 4.38]*hz_per_mt)*(diamond_frame_xz([1 1 0],[-1 1 -1]))');
-    nuclei{end+1}=struct('iso','13C','A',Cmat);
+if strcmp(centre,'ok1')&&parameters.n_13c>0
+    cframe{1}=diamond_frame_xz([1 1 0],[1 -1 -1]);
+    cframe{2}=diamond_frame_xz([1 1 0],[-1 1 -1]);
+    for n=1:parameters.n_13c
+        Cmat=((cframe{n})*diag([2.62 2.62 4.38]*hz_per_mt)*(cframe{n})');
+        nuclei{end+1}=struct('iso','13C','A',Cmat);
+    end
 end
 
 % Build the Spinach structures
@@ -126,11 +133,18 @@ end
 if ~ischar(parameters.titanium)
     error('parameters.titanium must be a character string.');
 end
-if ~isfield(parameters,'include_13c')
-    error('parameters.include_13c field is required.');
+if isfield(parameters,'n_13c')&&(~isnumeric(parameters.n_13c)||~isscalar(parameters.n_13c)||...
+        ~isreal(parameters.n_13c)||parameters.n_13c~=round(parameters.n_13c))
+    error('parameters.n_13c must be an integer scalar.');
 end
-if (~islogical(parameters.include_13c))||(~isscalar(parameters.include_13c))
-    error('parameters.include_13c must be a logical scalar.');
+if strcmpi(parameters.centre,'ok1')&&(~isfield(parameters,'n_13c'))
+    error('parameters.n_13c field is required for OK1 centre.');
+end
+if strcmpi(parameters.centre,'ok1')&&(parameters.n_13c<0||parameters.n_13c>2)
+    error('parameters.n_13c must be between 0 and 2.');
+end
+if ~strcmpi(parameters.centre,'ok1')&&isfield(parameters,'n_13c')&&parameters.n_13c~=0
+    error('parameters.n_13c is only supported for OK1 centre.');
 end
 end
 

--- a/etc/diamond_defects/diamond_vacancy.m
+++ b/etc/diamond_defects/diamond_vacancy.m
@@ -2,9 +2,12 @@
 %
 %          [sys,inter]=diamond_vacancy(parameters)
 %
-% Magnetic parameters from Kirui et al., Diam. Relat. Mater. 8,
-% 1569 (1999), https://doi.org/10.1016/S0925-9635(99)00037-0
-% and Iakoubovskii and Stesmans, Phys. Rev. B 66, 045406 (2002),
+% R4/W6 parameters from Twitchen et al., Phys. Rev. B 59, 12900
+% (1999), https://doi.org/10.1103/PhysRevB.59.12900; W29
+% parameters from Kirui et al., Diam. Relat. Mater. 8, 1569
+% (1999), https://doi.org/10.1016/S0925-9635(99)00037-0;
+% R5/O1/R6/R10/R11 parameters from Iakoubovskii and Stesmans,
+% Phys. Rev. B 66, 045406 (2002),
 % https://doi.org/10.1103/PhysRevB.66.045406; ZFS table values
 % cross-checked against Ball, PhD thesis, OIST Graduate University
 % (2021).
@@ -40,41 +43,58 @@ grumble(parameters);
 % Select the vacancy centre
 centre=lower(parameters.centre);
 
-% Set vacancy principal-axis frames
-frame_111=[-1/sqrt(2) -1/sqrt(6) 1/sqrt(3);...
-            1/sqrt(2) -1/sqrt(6) 1/sqrt(3);...
-            0          2/sqrt(6)  1/sqrt(3)];
+% Set R4/W6 principal-axis frame
+r4_x=[1;-1;0]/sqrt(2);
+r4_z=[sind(54.2)*cosd(45);sind(54.2)*sind(45);cosd(54.2)];
+r4_z=r4_z/norm(r4_z);
+r4_y=cross(r4_z,r4_x);
+r4_y=r4_y/norm(r4_y);
+frame_r4=[r4_x r4_y r4_z];
+
+% Set W29 principal-axis frame
+w29_x=[0;-1;1]/sqrt(2);
+w29_z=[0.619;-0.556;-0.556];
+w29_z=w29_z/norm(w29_z);
+w29_y=cross(w29_z,w29_x);
+w29_y=w29_y/norm(w29_y);
+frame_w29=[w29_x w29_y w29_z];
+
+% Set vacancy-chain principal-axis frame
 frame_110=[-1/sqrt(2) 0 1/sqrt(2);...
             1/sqrt(2) 0 1/sqrt(2);...
             0         1 0];
 switch centre
     case {'r4_w6','w6','r4'}
-        electron='E3'; giso=2.0022;
-        zfs=((frame_111)*diag([105 197 -303]*1e6)*(frame_111)');
+        electron='E3';
+        gmat=((frame_r4)*diag([2.0022 2.0026 2.0013])*(frame_r4)');
+        zfs=((frame_r4)*diag([105 197 -303]*1e6)*(frame_r4)');
     case 'w29'
-        electron='E4'; giso=2.0019;
-        zfs=((frame_111)*diag([297 156 -453]*1e6)*(frame_111)');
+        electron='E4';
+        gmat=((frame_w29)*diag([2.002 1.997 2.005])*(frame_w29)');
+        zfs=((frame_w29)*diag([297 156 -453]*1e6)*(frame_w29)');
     case 'r5'
-        electron='E3'; giso=2.0023;
+        electron='E3';
+        gmat=((frame_110)*diag([2.00275 2.00265 2.00205])*(frame_110)');
         zfs=((frame_110)*diag([283 244 -524]*1e6)*(frame_110)');
     case 'o1'
-        electron='E3'; giso=2.0023;
+        electron='E3';
+        gmat=((frame_110)*diag([2.00299 2.00273 2.00212])*(frame_110)');
         zfs=((frame_110)*diag([109 95 -205]*1e6)*(frame_110)');
     case 'r6'
-        electron='E3'; giso=2.0023;
+        electron='E3';
+        gmat=((frame_110)*diag([2.00299 2.00273 2.00212])*(frame_110)');
         zfs=((frame_110)*diag([62 59 -120]*1e6)*(frame_110)');
     case 'r10'
-        electron='E3'; giso=2.0023;
+        electron='E3';
+        gmat=((frame_110)*diag([2.00295 2.00269 2.00212])*(frame_110)');
         zfs=((frame_110)*diag([36 36 -73]*1e6)*(frame_110)');
     case 'r11'
-        electron='E3'; giso=2.0023;
+        electron='E3';
+        gmat=((frame_110)*diag([2.00301 2.00278 2.00])*(frame_110)');
         zfs=((frame_110)*diag([27 27 -53]*1e6)*(frame_110)');
     otherwise
         error('unknown vacancy centre.');
 end
-
-% Build the electron tensors
-gmat=eye(3)*giso;
 
 % Build the Spinach structures
 switch parameters.orientation
@@ -120,4 +140,3 @@ end
 % an attitude of humility.
 % 
 % C.S. Lewis
-

--- a/examples/quantum_tech/diamond_defects/diamond_co_epr_xw.m
+++ b/examples/quantum_tech/diamond_defects/diamond_co_epr_xw.m
@@ -1,16 +1,17 @@
-% Field-swept powder EPR spectra of a P1 centre
+% Field-swept powder EPR spectra of a Co centre
 % in diamond at X and W bands.
 %
 % alexey.bogdanov@weizmann.ac.il
 
-function diamond_p1_epr_xw()
+function diamond_co_epr_xw()
 
-% Set P1 model parameters.
-p1_params.orientation='111';
-p1_params.nitrogen='14N';
+% Set Co centre model parameters.
+co_params.orientation='111';
+co_params.centre='o4';
+%co_params.centre='nlo2';
 
 % Build the spin system.
-[sys,inter]=diamond_p1(p1_params);
+[sys,inter]=diamond_co(co_params);
 
 % Field sweep
 sys.magnet=1;
@@ -34,7 +35,7 @@ parameters.rspt_order=Inf;
 
 % Set X-band parameters
 parameters.mw_freq=9.5e9;
-parameters.window=[0.33 0.35];
+parameters.window=[0.2 0.45];
 
 % Run the X-band simulation
 [b_axis_x,spec_x]=fieldsweep(spin_system,parameters);
@@ -44,12 +45,12 @@ kfigure(); scale_figure([1.50 0.75]);
 subplot(1,2,1); plot(b_axis_x',spec_x');
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 X-band EPR');
+ktitle('Co O4 X-band EPR');
 xlim tight; ylim padded; kgrid;
 
 % Set W-band parameters
 parameters.mw_freq=94e9;
-parameters.window=[3.348 3.36];
+parameters.window=[2.6 4.2];
 
 % Run the W-band simulation
 [b_axis_w,spec_w]=fieldsweep(spin_system,parameters);
@@ -58,7 +59,7 @@ parameters.window=[3.348 3.36];
 subplot(1,2,2); plot(b_axis_w',spec_w');
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 W-band EPR');
+ktitle('Co O4 W-band EPR');
 xlim tight; ylim padded; kgrid;
 
 end

--- a/examples/quantum_tech/diamond_defects/diamond_gev0_epr_xw.m
+++ b/examples/quantum_tech/diamond_defects/diamond_gev0_epr_xw.m
@@ -1,16 +1,16 @@
-% Field-swept powder EPR spectra of a P1 centre
+% Field-swept powder EPR spectra of GeV0 centre
 % in diamond at X and W bands.
 %
 % alexey.bogdanov@weizmann.ac.il
 
-function diamond_p1_epr_xw()
+function diamond_gev0_epr_xw()
 
-% Set P1 model parameters.
-p1_params.orientation='111';
-p1_params.nitrogen='14N';
+% Set GeV0 centre model parameters.
+gev0_params.orientation='111';
+gev0_params.germanium='none';
 
 % Build the spin system.
-[sys,inter]=diamond_p1(p1_params);
+[sys,inter]=diamond_gev0(gev0_params);
 
 % Field sweep
 sys.magnet=1;
@@ -24,32 +24,35 @@ spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
 % Set common EPR parameters
-parameters.spins={'E'};
-parameters.grid=6;
+parameters.spins={'E3'};
+parameters.grid=20;
 parameters.fwhm=1e-4;
 parameters.int_tol=0.01;
 parameters.tm_tol=0.1;
-parameters.npoints=1024;
+parameters.npoints=2048;
 parameters.rspt_order=Inf;
 
 % Set X-band parameters
 parameters.mw_freq=9.5e9;
-parameters.window=[0.33 0.35];
+parameters.window=[0.05 0.45];
 
 % Run the X-band simulation
 [b_axis_x,spec_x]=fieldsweep(spin_system,parameters);
 
 % Plot the X-band spectrum
-kfigure(); scale_figure([1.50 0.75]);
+kfigure(); scale_figure([2.10 0.75]);
 subplot(1,2,1); plot(b_axis_x',spec_x');
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 X-band EPR');
+ktitle('GeV0 X-band EPR');
 xlim tight; ylim padded; kgrid;
 
 % Set W-band parameters
 parameters.mw_freq=94e9;
-parameters.window=[3.348 3.36];
+parameters.window=[3.25 3.46];
+parameters.grid=6;
+parameters.int_tol=0.01;
+parameters.tm_tol=0.1;
 
 % Run the W-band simulation
 [b_axis_w,spec_w]=fieldsweep(spin_system,parameters);
@@ -58,7 +61,7 @@ parameters.window=[3.348 3.36];
 subplot(1,2,2); plot(b_axis_w',spec_w');
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 W-band EPR');
+ktitle('GeV0 W-band EPR');
 xlim tight; ylim padded; kgrid;
 
 end

--- a/examples/quantum_tech/diamond_defects/diamond_n2vm_epr_xw.m
+++ b/examples/quantum_tech/diamond_defects/diamond_n2vm_epr_xw.m
@@ -1,16 +1,17 @@
-% Field-swept powder EPR spectra of a P1 centre
+% Field-swept powder EPR spectra of an N2V- centre
 % in diamond at X and W bands.
 %
 % alexey.bogdanov@weizmann.ac.il
 
-function diamond_p1_epr_xw()
+function diamond_n2vm_epr_xw()
 
-% Set P1 model parameters.
-p1_params.orientation='111';
-p1_params.nitrogen='14N';
+% Set N2V- centre parameters
+n2v_params.orientation='111';
+n2v_params.nitrogen='15N';
+n2v_params.include_13c=false;
 
-% Build the spin system.
-[sys,inter]=diamond_p1(p1_params);
+% Build the spin system
+[sys,inter]=diamond_n2vm(n2v_params);
 
 % Field sweep
 sys.magnet=1;
@@ -23,42 +24,43 @@ bas.approximation='none';
 spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
-% Set common EPR parameters
+% EPR sim parameters
 parameters.spins={'E'};
-parameters.grid=6;
-parameters.fwhm=1e-4;
-parameters.int_tol=0.01;
-parameters.tm_tol=0.1;
+parameters.grid=20;
+parameters.fwhm=0.00003;
+parameters.int_tol=0.1;
+parameters.tm_tol=0.01;
 parameters.npoints=1024;
 parameters.rspt_order=Inf;
 
 % Set X-band parameters
-parameters.mw_freq=9.5e9;
-parameters.window=[0.33 0.35];
+parameters.mw_freq=9.755e9;
+parameters.window=[0.347 0.349];
 
 % Run the X-band simulation
 [b_axis_x,spec_x]=fieldsweep(spin_system,parameters);
 
+
 % Plot the X-band spectrum
 kfigure(); scale_figure([1.50 0.75]);
-subplot(1,2,1); plot(b_axis_x',spec_x');
+subplot(1,2,1); plot(b_axis_x',[diff(spec_x'); 0]);
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 X-band EPR');
+ktitle('N2V$^{-}$ X-band EPR');
 xlim tight; ylim padded; kgrid;
 
 % Set W-band parameters
 parameters.mw_freq=94e9;
-parameters.window=[3.348 3.36];
+parameters.window=[3.351 3.355];
 
 % Run the W-band simulation
 [b_axis_w,spec_w]=fieldsweep(spin_system,parameters);
 
 % Plot the W-band spectrum
-subplot(1,2,2); plot(b_axis_w',spec_w');
+subplot(1,2,2); plot(b_axis_w',[diff(spec_w'); 0]);
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 W-band EPR');
+ktitle('N2V$^{-}$ W-band EPR');
 xlim tight; ylim padded; kgrid;
 
 end

--- a/examples/quantum_tech/diamond_defects/diamond_ni_epr_xw.m
+++ b/examples/quantum_tech/diamond_defects/diamond_ni_epr_xw.m
@@ -1,16 +1,17 @@
-% Field-swept powder EPR spectra of a P1 centre
+% Field-swept powder EPR spectra of Ni defects
 % in diamond at X and W bands.
 %
 % alexey.bogdanov@weizmann.ac.il
 
-function diamond_p1_epr_xw()
+function diamond_ni_epr_xw()
 
-% Set P1 model parameters.
-p1_params.orientation='111';
-p1_params.nitrogen='14N';
+% Set Ni NE1 centre model parameters.
+ni_params.centre='ne1';
+ni_params.orientation='111';
+ni_params.nickel='61Ni';
 
-% Build the spin system.
-[sys,inter]=diamond_p1(p1_params);
+% Build the spin system
+[sys,inter]=diamond_ni(ni_params);
 
 % Field sweep
 sys.magnet=1;
@@ -23,18 +24,18 @@ bas.approximation='none';
 spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
-% Set common EPR parameters
+% EPR sim parameters
 parameters.spins={'E'};
-parameters.grid=6;
-parameters.fwhm=1e-4;
-parameters.int_tol=0.01;
-parameters.tm_tol=0.1;
-parameters.npoints=1024;
+parameters.grid=20;
+parameters.fwhm=0.0001;
+parameters.int_tol=0.1;
+parameters.tm_tol=0.01;
+parameters.npoints=2048;
 parameters.rspt_order=Inf;
 
 % Set X-band parameters
 parameters.mw_freq=9.5e9;
-parameters.window=[0.33 0.35];
+parameters.window=[0.3 0.36];
 
 % Run the X-band simulation
 [b_axis_x,spec_x]=fieldsweep(spin_system,parameters);
@@ -44,12 +45,12 @@ kfigure(); scale_figure([1.50 0.75]);
 subplot(1,2,1); plot(b_axis_x',spec_x');
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 X-band EPR');
+ktitle('Ni NE1 X-band EPR');
 xlim tight; ylim padded; kgrid;
 
 % Set W-band parameters
 parameters.mw_freq=94e9;
-parameters.window=[3.348 3.36];
+parameters.window=[3.1 3.4];
 
 % Run the W-band simulation
 [b_axis_w,spec_w]=fieldsweep(spin_system,parameters);
@@ -58,7 +59,7 @@ parameters.window=[3.348 3.36];
 subplot(1,2,2); plot(b_axis_w',spec_w');
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 W-band EPR');
+ktitle('Ni NE1 W-band EPR');
 xlim tight; ylim padded; kgrid;
 
 end

--- a/examples/quantum_tech/diamond_defects/diamond_nvm_epr_xw.m
+++ b/examples/quantum_tech/diamond_defects/diamond_nvm_epr_xw.m
@@ -1,4 +1,4 @@
-% Field-swept powder EPR spectra of an NV centre 
+% Field-swept powder EPR spectra of an NV centre
 % in diamond at X and W bands.
 %
 % alexey.bogdanov@weizmann.ac.il

--- a/examples/quantum_tech/diamond_defects/diamond_siv0_epr_xw.m
+++ b/examples/quantum_tech/diamond_defects/diamond_siv0_epr_xw.m
@@ -1,16 +1,17 @@
-% Field-swept powder EPR spectra of a P1 centre
+% Field-swept powder EPR spectra of SiV0 centre
 % in diamond at X and W bands.
 %
 % alexey.bogdanov@weizmann.ac.il
 
-function diamond_p1_epr_xw()
+function diamond_siv0_epr_xw()
 
-% Set P1 model parameters.
-p1_params.orientation='111';
-p1_params.nitrogen='14N';
+% Set SiV0 centre model parameters.
+siv0_params.orientation='111';
+siv0_params.silicon='29Si';
+siv0_params.n_13c=0;
 
-% Build the spin system.
-[sys,inter]=diamond_p1(p1_params);
+% Build the spin system
+[sys,inter]=diamond_siv0(siv0_params);
 
 % Field sweep
 sys.magnet=1;
@@ -23,18 +24,18 @@ bas.approximation='none';
 spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
-% Set common EPR parameters
-parameters.spins={'E'};
-parameters.grid=6;
-parameters.fwhm=1e-4;
-parameters.int_tol=0.01;
-parameters.tm_tol=0.1;
-parameters.npoints=1024;
+% EPR sim parameters
+parameters.spins={'E3'};
+parameters.grid=20;
+parameters.fwhm=0.001;
+parameters.int_tol=0.1;
+parameters.tm_tol=0.01;
+parameters.npoints=2048;
 parameters.rspt_order=Inf;
 
 % Set X-band parameters
 parameters.mw_freq=9.5e9;
-parameters.window=[0.33 0.35];
+parameters.window=[0.1 0.5];
 
 % Run the X-band simulation
 [b_axis_x,spec_x]=fieldsweep(spin_system,parameters);
@@ -44,12 +45,12 @@ kfigure(); scale_figure([1.50 0.75]);
 subplot(1,2,1); plot(b_axis_x',spec_x');
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 X-band EPR');
+ktitle('SiV0 X-band EPR');
 xlim tight; ylim padded; kgrid;
 
 % Set W-band parameters
 parameters.mw_freq=94e9;
-parameters.window=[3.348 3.36];
+parameters.window=[3.2 3.5];
 
 % Run the W-band simulation
 [b_axis_w,spec_w]=fieldsweep(spin_system,parameters);
@@ -58,7 +59,7 @@ parameters.window=[3.348 3.36];
 subplot(1,2,2); plot(b_axis_w',spec_w');
 kxlabel('magnetic field, tesla');
 kylabel('intensity, a.u.');
-ktitle('P1 W-band EPR');
+ktitle('SiV0 W-band EPR');
 xlim tight; ylim padded; kgrid;
 
 end


### PR DESCRIPTION
## Summary

- restores the requested SiV0 `n_13c` API so users can select 0-6 nearest-neighbour `13C` hyperfine couplings explicitly instead of the previous all-or-nothing `include_13c` flag
- adds `14N` support for WAR9 and WAR10 in `diamond_n_inter.m`, using `spin('14N')/spin('15N')` to scale the reported `15N` hyperfine tensors
- keeps WAR9/WAR10 `14N` nuclear quadrupole interaction absent/zero, matching the Felton et al. simulation convention for the inferred `14N` spectra
- documents the W8 quartet-centre zero-ZFS assumption in `diamond_ni.m`
- changes W8 `13C` handling in `diamond_ni.m` from the previous all-or-nothing `include_13c` flag to `n_13c=0..4`
- documents that nickel `13C` hyperfine couplings apply only to W8 and softens validation so other nickel centres do not need a carbon option
- documents that phosphorus `13C` hyperfine coupling applies only to MA1, keeps the `include_13c` flag there, and defaults it to `false` for other phosphorus centres
- adds `14N` support to `diamond_nv0_es.m` by scaling the reported `15N` excited-state hyperfine tensor with `spin('14N')/spin('15N')`
- leaves NV0 excited-state `14N` NQI absent/zero and documents that no such NQI parameter is reported for this state in the cited source
- changes OK1 titanium `13C` handling in `diamond_ti.m` from binary `include_13c` to `n_13c=0..2`, with the field required only for OK1
- corrects `diamond_vacancy.m` references and tensors: R4/W6 is attributed to Twitchen et al. 1999, W29 to Kirui et al. 1999, and the implemented R5/O1/R6/R10/R11 subset to Iakoubovskii and Stesmans 2002
- replaces vacancy-family isotropic `g` approximations with anisotropic tensors, and uses the reported W29 principal-axis frame instead of the generic `[111]` frame

- adds X/W-band EPR example scripts for Co, GeV0, N2V-, Ni, SiV0, NV-, and P1 diamond defects under `examples/quantum_tech/diamond_defects`, copied from `staff_alexey_bogdanov/Diamond/examples` r42 with `diamond_ninter_epr_xw.m` deliberately left out until debugged

## Validation

- `git diff --check -- etc/diamond_defects/diamond_siv0.m etc/diamond_defects/diamond_n_inter.m`
- `matlab -nojvm -batch "addpath('/home/kuprov/.openclaw/workspace/tmp/alexey_diamond_defects_14n_20260519'); validate_diamond_defects_14n"`
- `matlab -nojvm -batch "repo='/home/kuprov/.openclaw/workspace/Spinach'; f=fullfile(repo,'etc','diamond_defects','diamond_ni.m'); tree=mtree(f,'-file'); assert(~isempty(tree)); messages=checkcode(f,'-id'); assert(~any(strcmp({messages.id},'NASGU'))); disp('DIAMOND_NI_DOC_VALIDATION_OK')"`
- `git diff --check -- etc/diamond_defects/diamond_ni.m etc/diamond_defects/diamond_p.m`
- `matlab -nojvm -batch "addpath('/home/kuprov/.openclaw/workspace/tmp/alexey_diamond_defects_13c_20260519'); validate_diamond_ni_p_13c"`
- `git diff --check -- etc/diamond_defects/diamond_nv0_es.m etc/diamond_defects/diamond_ni.m etc/diamond_defects/diamond_p.m`
- `matlab -nojvm -batch "addpath('/home/kuprov/.openclaw/workspace/tmp/alexey_diamond_defects_nv0_14n_20260519'); validate_nv0_es_14n"`
- `git diff --check -- etc/diamond_defects/diamond_ti.m`
- `matlab -nojvm -batch "addpath('/home/kuprov/.openclaw/workspace/tmp/alexey_diamond_ti_13c_20260519'); validate_diamond_ti_13c"`
- `git diff --check -- etc/diamond_defects/diamond_vacancy.m`
- `matlab -nojvm -batch "addpath('/home/kuprov/.openclaw/workspace/tmp/vacancy_reference_check'); validate_diamond_vacancy_reference"`
- `matlab -nojvm -batch "run('/home/kuprov/.openclaw/workspace/tmp/validate_spinach_diamond_examples_pr.m')"`
- `git -c core.whitespace=blank-at-eol,-blank-at-eof,space-before-tab diff --check -- examples/quantum_tech/diamond_defects`
