### PR TITLE
Harden field-swept EPR eigenfield integration

### DIFF
--- a/kernel/grids/voitlander.m
+++ b/kernel/grids/voitlander.m
@@ -121,7 +121,7 @@ spec_sub=trint(tf1,tf12,tf31,tm1,tm12,tm31,tw1,tw12,tw31,pd1,pd12,pd31,ti1,ti12,
 spec_dir=trint(tf1,tf2,tf3,tm1,tm2,tm3,tw1,tw2,tw3,pd1,pd2,pd3,ti1,ti2,ti3,r1,r2,r3,b_axis);
 
 % If the accuracy is insufficient, make a recursive call
-if sphtarea(r1,r2,r3)*norm(spec_dir-spec_sub,2)>parameters.int_tol
+if norm(spec_dir-spec_sub,2)>parameters.int_tol
 
     % Four triangles of the subdivision
     spec=voitlander(spin_system,parameters,r1,r12,r31,...

--- a/kernel/grids/voitlander.m
+++ b/kernel/grids/voitlander.m
@@ -162,10 +162,55 @@ spec=zeros(size(b_axis),'like',1i);
 
 % Find transitions present at all three vertices
 if isempty(ti1)||isempty(ti2)||isempty(ti3), return; end
-[ti12,idx1,idx2]=intersect(ti1,ti2,'rows','stable');
-[~,idx12,idx3]=intersect(ti12,ti3,'rows','stable');
-idx1=idx1(idx12); idx2=idx2(idx12);
-ntrans=numel(idx1);
+if size(ti1,2)>=3
+
+    % Find level pairs with roots at triangle vertices
+    pair_list=unique([ti1(:,1:2); ti2(:,1:2); ti3(:,1:2)],'rows','stable');
+    idx1=[]; idx2=[]; idx3=[];
+
+    % Match same-pair roots by nearest field continuation
+    for p=1:size(pair_list,1)
+
+        % Get candidate roots for this level pair
+        cand1=find((ti1(:,1)==pair_list(p,1))&(ti1(:,2)==pair_list(p,2)));
+        cand2=find((ti2(:,1)==pair_list(p,1))&(ti2(:,2)==pair_list(p,2)));
+        cand3=find((ti3(:,1)==pair_list(p,1))&(ti3(:,2)==pair_list(p,2)));
+        if isempty(cand1)||isempty(cand2)||isempty(cand3), continue; end
+
+        % Initialise local candidate masks
+        used1=false(size(cand1)); used2=false(size(cand2)); used3=false(size(cand3));
+
+        % Greedily match roots with the smallest field spread
+        while any(~used1)&&any(~used2)&&any(~used3)
+            best_span=Inf; best_pick=[0 0 0];
+            list1=find(~used1).'; list2=find(~used2).'; list3=find(~used3).';
+            for a=list1
+                for b=list2
+                    for c=list3
+                        field_vals=[tf1(cand1(a)) tf2(cand2(b)) tf3(cand3(c))];
+                        field_span=max(field_vals)-min(field_vals);
+                        if field_span<best_span
+                            best_span=field_span; best_pick=[a b c];
+                        end
+                    end
+                end
+            end
+            if ~isfinite(best_span), break; end
+            idx1(end+1)=cand1(best_pick(1)); %#ok<AGROW>
+            idx2(end+1)=cand2(best_pick(2)); %#ok<AGROW>
+            idx3(end+1)=cand3(best_pick(3)); %#ok<AGROW>
+            used1(best_pick(1))=true;
+            used2(best_pick(2))=true;
+            used3(best_pick(3))=true;
+        end
+    end
+    ntrans=numel(idx1);
+else
+    [ti12,idx1,idx2]=intersect(ti1,ti2,'rows','stable');
+    [~,idx12,idx3]=intersect(ti12,ti3,'rows','stable');
+    idx1=idx1(idx12); idx2=idx2(idx12);
+    ntrans=numel(idx1);
+end
 
 % Area of spherical triangle
 S=sphtarea(r1,r2,r3);

--- a/kernel/utilities/eigenfields.m
+++ b/kernel/utilities/eigenfields.m
@@ -57,7 +57,9 @@
 %
 %     tf     -  vector of transition fields in Tesla
 %
-%     tm     -  vector of transition moments
+%     tm     -  vector of field-swept transition weights,
+%               including transition moments and field-
+%               domain Jacobians
 %
 %     tw     -  vector of transition FWHMs in Tesla
 %
@@ -102,13 +104,14 @@ switch spin_system.bas.formalism
         E= zeros([size(Hz,1) numel(grid)]); % Level energies
         LP=zeros([size(Hz,1) numel(grid)]); % Level populations
         dE=zeros([size(Hz,1) numel(grid)]); % dE/dB derivatives
+        V=cell(1,numel(grid));              % Level eigenvectors
         T=cell(1,numel(grid));              % Transition moments
 
         % Populate initial grid
         for n=1:numel(grid)
 
             % Sorted (ascending) energies, dE/dB derivatives, transition moments, level pops
-            [E(:,n),~,dE(:,n),T{n},LP(:,n)]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,grid(n));
+            [E(:,n),V{n},dE(:,n),T{n},LP(:,n)]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,grid(n));
             
         end
         
@@ -120,6 +123,7 @@ switch spin_system.bas.formalism
             
             % Start at the leftmost point of the grid
             new_E=E(:,1); new_dE=dE(:,1); new_T=T(1);
+            new_V=V(1);
             new_grid=grid(1); new_conv=[]; new_LP=LP(:,1);
             
             % Inspect old grid intervals
@@ -147,8 +151,8 @@ switch spin_system.bas.formalism
                                     
                     % Get eigensystem information for the grid midpoints
                     midp1=grid(n-1)+(1/3)*dx; midp2=grid(n-1)+(2/3)*dx;
-                    [Em1,~,dEm1,Tm1,LPm1]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,midp1);
-                    [Em2,~,dEm2,Tm2,LPm2]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,midp2);
+                    [Em1,Vm1,dEm1,Tm1,LPm1]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,midp1);
+                    [Em2,Vm2,dEm2,Tm2,LPm2]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,midp2);
 
                     % Append midpoints to the new grid
                     new_grid((end+1):(end+2))=[midp1 midp2];
@@ -156,6 +160,7 @@ switch spin_system.bas.formalism
                     new_LP(:,(end+1):(end+2))=[LPm1 LPm2];
                     new_E(:,(end+1):(end+2))=[Em1 Em2];
                     new_T((end+1):(end+2))={Tm1 Tm2};
+                    new_V((end+1):(end+2))={Vm1 Vm2};
 
                     % Check prediction accuracy
                     if (norm(EmP1-Em1,1)<frq_gap_tol)&&...
@@ -178,21 +183,35 @@ switch spin_system.bas.formalism
                 new_dE(:,end+1)=dE(:,n);   %#ok<AGROW>
                 new_E(:,end+1)=E(:,n);     %#ok<AGROW>
                 new_T{end+1}=T{n};         %#ok<AGROW>
+                new_V{end+1}=V{n};         %#ok<AGROW>
                 new_LP(:,end+1)=LP(:,n);   %#ok<AGROW>
                 
             end
             
             % New grid becomes old
             E=new_E; dE=new_dE; grid=new_grid;
-            T=new_T; LP=new_LP; converged=new_conv;
+            T=new_T; V=new_V; LP=new_LP; converged=new_conv;
 
             % Complain and bomb out if the field grid becomes too large
             if numel(grid)>1e3, error('field grid construction failed'); end
             
         end
         
+        % Get the relative transition moment cut-off
+        tm_scale=0;
+        for n=1:numel(T)
+            tm_scale=max([tm_scale; T{n}(:)]);
+        end
+        tm_cutoff=parameters.tm_tol*tm_scale;
+
+        % Mark level pairs that are active anywhere on the converged grid
+        pair_active=false(size(E,1));
+        for n=1:numel(T)
+            pair_active=pair_active|(T{n}>tm_cutoff);
+        end
+
         % Get outputs started
-        tf=[]; tm=[]; tw=[]; pd=[]; ti=zeros(0,3);
+        tf=[]; tm=[]; tm_raw=[]; tw=[]; pd=[]; ti=zeros(0,3);
 
         % Initialise branch counters for each level pair
         pair_branch=zeros(size(E,1));
@@ -207,74 +226,81 @@ switch spin_system.bas.formalism
             interval_max=max(E(:,[n-1, n]),[],2);
             interval_min=min(E(:,[n-1, n]),[],2);
 
-            % Screen by energy and transition moment
+            % Screen by energy and grid-wide transition activity
             deltaE_upper=interval_max'-interval_min;
             deltaE_lower=interval_min'-interval_max;
-            promising_pairs=(omega<deltaE_upper)&(omega>deltaE_lower)&...
-                            (T{n-1}>parameters.tm_tol|T{n}>parameters.tm_tol);
+            promising_pairs=(omega<deltaE_upper)&...
+                            (omega>deltaE_lower)&pair_active;
             [source,destin]=find(promising_pairs);
+
+            % State overlap between field knots
+            if isempty(source), continue; end
+            state_ovlp=abs(V{n-1}'*V{n}).^2;
             
             % Loop over source-destination pairs
             for k=1:numel(source)
                 
-                % Source and destination lines
-                source_level=E(source(k),[n-1, n]);
-                source_line=[source_level(2)-source_level(1); source_level(1)];
-                destin_level=E(destin(k),[n-1, n]);
-                destin_line=[destin_level(2)-destin_level(1); destin_level(1)];
-                
+                % Get spline coefficients (x^3 -> x^0) for energies in this interval
+                source_spline=[dE(source(k),n-1)*dx E(source(k),n-1) ...
+                               dE(source(k),n)*dx   E(source(k),n)]*[ 1 -2  1  0;
+                                                                      2 -3  0  1;
+                                                                      1 -1  0  0;
+                                                                     -2  3  0  0];
+                destin_spline=[dE(destin(k),n-1)*dx E(destin(k),n-1) ...
+                               dE(destin(k),n)*dx   E(destin(k),n)]*[ 1 -2  1  0;
+                                                                      2 -3  0  1;
+                                                                      1 -1  0  0;
+                                                                     -2  3  0  0];
+
                 % Energies must be omega apart
-                destin_line(2)=destin_line(2)-omega;
+                destin_spline(4)=destin_spline(4)-omega;
 
-                % Use linear interpolation first
-                line_coeffs=destin_line-source_line;
-                alpha=-line_coeffs(2)/line_coeffs(1);
+                % Get the cubic equation coefficients
+                cubic_coeffs=destin_spline-source_spline;
+                poly_coeffs=cubic_coeffs;
+                poly_scale=max(abs(poly_coeffs));
+                if poly_scale==0, continue; end
+                poly_coeffs=poly_coeffs/poly_scale;
 
-                % Check level crossing location
-                if (alpha<-0.1)||(alpha>1.1)
-                    
-                    % Outside
-                    continue;
+                % Drop leading numerical zeros
+                lead_idx=find(abs(poly_coeffs)>sqrt(eps),1,'first');
+                if isempty(lead_idx), continue; end
+                poly_coeffs=poly_coeffs(lead_idx:end);
 
-                else
+                % Find all real roots inside the field interval
+                root_tol=1e-8;
+                root_list=roots(poly_coeffs);
+                root_list=root_list(abs(imag(root_list))<root_tol);
+                root_list=real(root_list);
+                root_list=root_list((root_list>=-root_tol)&...
+                                    (root_list<=1+root_tol));
+                root_list=min(max(root_list,0),1);
+                root_list=sort(root_list(:).');
+                if isempty(root_list), continue; end
+                root_list=root_list([true abs(diff(root_list))>root_tol]);
 
-                    % Get spline coefficients (x^3 -> x^0) for energies in this interval
-                    source_spline=[dE(source(k),n-1)*dx E(source(k),n-1) ...
-                                   dE(source(k),n)*dx   E(source(k),n)]*[ 1 -2  1  0; 
-                                                                          2 -3  0  1; 
-                                                                          1 -1  0  0; 
-                                                                         -2  3  0  0];
-                    destin_spline=[dE(destin(k),n-1)*dx E(destin(k),n-1) ...
-                                   dE(destin(k),n)*dx   E(destin(k),n)]*[ 1 -2  1  0; 
-                                                                          2 -3  0  1; 
-                                                                          1 -1  0  0; 
-                                                                         -2  3  0  0];
-                    % Energies must be omega apart
-                    destin_spline(4)=destin_spline(4)-omega;
+                % Differentiate the unscaled spline
+                deriv_coeffs=[3*cubic_coeffs(1) 2*cubic_coeffs(2) cubic_coeffs(3)];
 
-                    % Get and stabilise cubic equation coefficients
-                    cubic_coeffs=destin_spline-source_spline;
-                    cubic_coeffs=cubic_coeffs/max(abs(cubic_coeffs));
+                % Check state labelling stability
+                stable_states=(state_ovlp(source(k),source(k))>0.5)&&...
+                              (state_ovlp(destin(k),destin(k))>0.5);
 
-                    % Differentiate the spline and store coefficients as (x^2 -> x^0)
-                    deriv_coeffs=[3*cubic_coeffs(1) 2*cubic_coeffs(2) 1*cubic_coeffs(3)];
+                % Loop over all roots in this field interval
+                for q=1:numel(root_list)
 
-                    % One iteration of Newton's method to refine the root
-                    numer=cubic_coeffs(1)*alpha^3+cubic_coeffs(2)*alpha^2+...
-                          cubic_coeffs(3)*alpha  +cubic_coeffs(4);
-                    denom=deriv_coeffs(1)*alpha^2+deriv_coeffs(2)*alpha  +...
-                          deriv_coeffs(3);
-                    alpha=alpha-numer/denom;
+                    % Get the root coordinate
+                    alpha=root_list(q);
+                    if (alpha<=root_tol)&&(n>2), continue; end
 
-                end
-                    
-                % Check level crossing location
-                if (alpha<0)||(alpha>1)
-                    
-                    % Outside
-                    continue;
-
-                else
+                    % Compute the field-domain Jacobian
+                    gap_deriv=(deriv_coeffs(1)*alpha^2+...
+                               deriv_coeffs(2)*alpha+...
+                               deriv_coeffs(3))/dx;
+                    if (~isfinite(gap_deriv))||(abs(gap_deriv)<eps)
+                        continue;
+                    end
+                    field_jac=1/abs(gap_deriv);
 
                     % Interval edge transition moments
                     tm_left=T{n-1}(source(k),destin(k));
@@ -283,16 +309,36 @@ switch spin_system.bas.formalism
                     % Interval edge population differences
                     pd_left=LP(source(k),n-1)-LP(destin(k),n-1);
                     pd_right=LP(source(k),n)-LP(destin(k),n);
-                
+
+                    % Interpolate transition properties
+                    tm_base=(1-alpha)*tm_left+alpha*tm_right;
+                    pd_base=(1-alpha)*pd_left+alpha*pd_right;
+
+                    % Rediagonalise at unstable roots
+                    if ~stable_states
+                        reson_field=grid(n-1)+alpha*dx;
+                        [~,~,dE_root,T_root,LP_root]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,reson_field);
+                        tm_base=T_root(source(k),destin(k));
+                        pd_base=LP_root(source(k))-LP_root(destin(k));
+                        gap_deriv=dE_root(destin(k))-dE_root(source(k));
+                        if (~isfinite(gap_deriv))||(abs(gap_deriv)<eps)
+                            continue;
+                        end
+                        field_jac=1/abs(gap_deriv);
+                    end
+
                     % Update the branch count for this level pair
                     pair_branch(source(k),destin(k))=pair_branch(source(k),destin(k))+1;
 
-                    % Store interpolated transition moment
-                    tm(end+1)=(1-alpha)*tm_left+alpha*tm_right; %#ok<AGROW>
+                    % Store transition moment before field weighting
+                    tm_raw(end+1)=tm_base; %#ok<AGROW>
 
-                    % Store interpolated population difference
-                    pd(end+1)=(1-alpha)*pd_left+alpha*pd_right; %#ok<AGROW>
-                  
+                    % Store transition moment with field-domain weighting
+                    tm(end+1)=tm_base*field_jac; %#ok<AGROW>
+
+                    % Store population difference
+                    pd(end+1)=pd_base; %#ok<AGROW>
+
                     % Store the transition field
                     tf(end+1)=grid(n-1)+alpha*dx; %#ok<AGROW>
 
@@ -301,7 +347,7 @@ switch spin_system.bas.formalism
 
                     % Store transition identity
                     ti(end+1,:)=[source(k) destin(k) pair_branch(source(k),destin(k))]; %#ok<AGROW>
-                
+
                 end
                 
             end
@@ -311,12 +357,24 @@ switch spin_system.bas.formalism
     % Liouville space formalism
     case {'zeeman-liouv','sphten-liouv'}
         
+        % Set up the generalised eigenfield pencil
+        left_mat=omega*eye(size(Hc))-full(Hc);
+        right_mat=full(Hz);
+
         % Get all transitions
-        [uv,tf]=eig(omega*eye(size(Hc))-full(Hc),full(Hz),'vector');
+        [uv,tf]=eig(left_mat,right_mat,'vector');
         
         % Prune out unphysical results
-        hit_list=~isfinite(tf); tf(hit_list)=[];  
-        uv(:,hit_list)=[]; tf=real(tf);
+        uv_norm=sqrt(sum(abs(uv).^2,1));
+        resid=vecnorm(left_mat*uv-right_mat*(uv.*tf.'),2,1);
+        resid_scale=norm(left_mat,2)+norm(right_mat,2)*max(1,abs(tf(:).'));
+        complex_tf=abs(imag(tf(:).'))>1e-8*max(1,abs(real(tf(:).')));
+        hit_list=(~isfinite(real(tf(:).')))|...
+                 (~isfinite(imag(tf(:).')))|complex_tf|...
+                 (~isfinite(uv_norm))|(uv_norm<sqrt(eps))|...
+                 (resid>1e-8*resid_scale);
+        tf(hit_list)=[]; uv(:,hit_list)=[];
+        tf=real(tf);
         
         % Prune out-of-window transitions
         hit_list=(tf<min(parameters.window))|...
@@ -324,7 +382,8 @@ switch spin_system.bas.formalism
         uv(:,hit_list)=[]; tf(hit_list)=[];
 
         % Normalise dyadics
-        uv=uv./sqrt(diag(uv'*uv)');
+        uv_norm=sqrt(sum(abs(uv).^2,1));
+        uv=uv./uv_norm;
         
         % Compute transition moments
         tm=abs(Hmw'*uv).^2;
@@ -346,8 +405,15 @@ switch spin_system.bas.formalism
 end
 
 % Prune insignificant transition moments
-hit_list=(tm<parameters.tm_tol);
-tf(hit_list)=[]; tm(hit_list)=[]; 
+if isempty(tm)
+    hit_list=false(size(tm));
+elseif exist('tm_raw','var')
+    hit_list=(tm_raw<tm_cutoff);
+else
+    tm_cutoff=parameters.tm_tol*max(tm(:));
+    hit_list=(tm<tm_cutoff);
+end
+tf(hit_list)=[]; tm(hit_list)=[];
 tw(hit_list)=[]; pd(hit_list)=[]; ti(hit_list,:)=[];
 
 % Reshape into columns and sort
@@ -441,4 +507,3 @@ end
 % sing attention to faddishness, perversity, and the occult.
 %
 % Jack Vance, "The Dying Earth"
-

--- a/tests/kernel/test_dynamic_remaining_spectral_suite.m
+++ b/tests/kernel/test_dynamic_remaining_spectral_suite.m
@@ -70,6 +70,29 @@ result=test_close(result,'eigenfields transition width',tw,parameters.fwhm,1e-14
 result=test_close(result,'eigenfields population difference',pd,1,1e-14,1e-14,...
                   'Liouville-space population differences are currently unit placeholders');
 
+% Check two-root Hilbert-space resonance extraction in a curved level gap
+spin_system=local_minimal_system('zeeman-hilb',2);
+parameters=struct();
+parameters.mw_freq=1/(2*pi);
+parameters.window=[-0.8 0.8];
+parameters.pp_tol=1e-20;
+parameters.tm_tol=0;
+parameters.fwhm=0.01;
+parameters.orientation=[0 0 0];
+parameters.rspt_order=Inf;
+parameters.rho0=diag([1 0]);
+Iz=diag([-1 1]);
+Ic=[0 0.1;0.1 0];
+Qz=local_tiny_rank_one(2);
+Qc=local_tiny_rank_one(2);
+Hmw=[0 1;1 0];
+[tf,~,~,~,ti]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
+root_field=sqrt(0.25-0.01);
+result=test_close(result,'eigenfields two-root fields',tf,[-root_field; root_field],1e-8,1e-10,...
+                  'a symmetric avoided crossing must produce both resonance fields in the sweep window');
+result=test_true(result,'eigenfields two-root identities',isequal(ti,[1 2 1;1 2 2]),...
+                 'multiple roots of the same level pair must receive distinct branch identities');
+
 % Check one-dimensional gradient operator construction in Fokker-Planck space
 spin_system=local_created_system('zeeman-hilb',1);
 fp_par.dims=2;
@@ -137,6 +160,8 @@ result=test_close(result,'symmetry irrep dimension',spin_system.bas.irrep.dimens
 end
 
 
+
+
 function spin_system=local_created_system(formalism,magnet)
 
 % Build a quiet one-proton Spinach object in the requested formalism
@@ -189,4 +214,3 @@ if isempty(current_pool)
 end
 
 end
-

--- a/tests/kernel/test_dynamic_voitlander.m
+++ b/tests/kernel/test_dynamic_voitlander.m
@@ -79,5 +79,60 @@ result=test_close(result,'voitlander constant line',spec,reference,1e-10,1e-12,.
 result=test_true(result,'voitlander finite real spectrum',isreal(spec)&&all(isfinite(spec(:)))&&all(spec(:)>=0),...
                  'a positive population difference and transition moment must give a finite non-negative real spectrum');
 
+% Build a minimal two-level avoided crossing with two resonance roots
+spin_system.sys.output='hush';
+spin_system.sys.enable={};
+spin_system.sys.disable={};
+spin_system.bas.formalism='zeeman-hilb';
+spin_system.bas.basis=zeros(2,1);
+spin_system.comp.mults=2;
+spin_system.tols.liouv_zero=1e-12;
+spin_system.tols.prop_chop=1e-12;
+spin_system.tols.dense_matrix=0.5;
+spin_system.tols.small_matrix=10;
+parameters=struct();
+parameters.mw_freq=1/(2*pi);
+parameters.window=[-0.8 0.8];
+parameters.pp_tol=1e-20;
+parameters.tm_tol=0;
+parameters.fwhm=0.01;
+parameters.npoints=9;
+parameters.orientation=[0 0 0];
+parameters.rspt_order=Inf;
+parameters.rho0=diag([1 0]);
+parameters.int_tol=1e9;
+Iz=diag([-1 1]);
+Ic=[0 0.1;0.1 0];
+Qz=cell(1,1); Qz{1}=cell(3,3); Qz{1}{2,2}=sparse(1,1,realmin,2,2);
+Qc=Qz;
+Hmw=[0 1;1 0];
+
+% Get the two resonance roots and their generated branch labels
+[tf,tm,tw,pd,ti]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
+high_root=2;
+b_axis=tf(high_root)+linspace(-2*tw(high_root),2*tw(high_root),parameters.npoints);
+
+% Compare stable and locally renumbered branch identities
+ti_ref=ti(high_root,:);
+ti_local=[ti(high_root,1:2) 1];
+spec_ref=voitlander(spin_system,parameters,r1,r2,r3,...
+                    tf(high_root),tf,tf(high_root),...
+                    tm(high_root),tm,tm(high_root),...
+                    tw(high_root),tw,tw(high_root),...
+                    pd(high_root),pd,pd(high_root),...
+                    ti_ref,ti,ti_ref,...
+                    Ic,Iz,Qc,Qz,Hmw,b_axis);
+spec_local=voitlander(spin_system,parameters,r1,r2,r3,...
+                      tf(high_root),tf,tf(high_root),...
+                      tm(high_root),tm,tm(high_root),...
+                      tw(high_root),tw,tw(high_root),...
+                      pd(high_root),pd,pd(high_root),...
+                      ti_local,ti,ti_local,...
+                      Ic,Iz,Qc,Qz,Hmw,b_axis);
+
+% Check that local branch renumbering does not drop the continuous sheet
+result=test_close(result,'voitlander branch relabelling',spec_local,spec_ref,1e-12,1e-12,...
+                  'field-continuation matching must ignore local branch ordinal changes at window edges');
+
 end
 


### PR DESCRIPTION
Summary:
- Enumerate all real cubic resonance roots in each converged field interval and make transition-moment screening relative to the converged field grid.
- Apply field-domain Jacobian weighting and rediagonalise roots when endpoint state labelling is unstable.
- Reject complex or ill-conditioned Liouville-space eigenfield solutions instead of coercing them to real values.
- Match multiple roots of the same level pair in Voitlander integration by local field continuation, so sweep-window edge renumbering does not drop a continuous branch.
- Compare direct and subdivided Voitlander spectra in the same area-weighted units.
- Add two-root avoided-crossing and Voitlander branch-relabelling regressions.

Tests after latest follow-up commit:
- git diff --check
- MATLAB checkcode on touched files
- MATLAB: run_test('kernel/dynamic_remaining_spectral_suite'); run_test('kernel/dynamic_voitlander')

Earlier validation on this branch:
- MATLAB examples: fieldsweep_nitroxide, fieldsweep_triplet, fieldsweep_gd_dota, fieldsweep_porphyrin