### PR TITLE
Add scaled field-sweep Jacobians

### DIFF
--- a/examples/esr_sol_swept/temperature_gd_dota.m
+++ b/examples/esr_sol_swept/temperature_gd_dota.m
@@ -42,8 +42,8 @@ for T=[100 10 1 0.1]
     parameters.grid=4;
     parameters.mw_freq=90e9;
     parameters.fwhm=2e-4;
-    parameters.int_tol=0.01;
-    parameters.tm_tol=0.01;
+    parameters.int_tol=0.1;
+    parameters.tm_tol=0.1;
     parameters.window=[3.05 3.4];
     parameters.npoints=4096;
     parameters.rspt_order=Inf;
@@ -60,5 +60,6 @@ for T=[100 10 1 0.1]
 
 end
 
-end
 
+
+end

--- a/experiments/fieldsweep.m
+++ b/experiments/fieldsweep.m
@@ -86,7 +86,7 @@ x=sin(bets).*cos(gams); y=sin(bets).*sin(gams); z=cos(bets);
 
 % Eigenfields at grid vertices
 vert=repmat(struct('xyz',zeros(3,1),'tf',[],'tm',[],...
-                  'tw',[],'pd',[],'ti',[]),grid_size,1);
+                  'tw',[],'pd',[],'ti',[],'tj',[]),grid_size,1);
 parfor n=1:grid_size %#ok<*PFBNS>
 
     % Localise parameters array, set the orientation, and create the vertex
@@ -95,7 +95,7 @@ parfor n=1:grid_size %#ok<*PFBNS>
     loc_vert.xyz=[x(n); y(n); z(n)];
     
     % Transition fields and moments
-    [loc_vert.tf,loc_vert.tm,loc_vert.tw,loc_vert.pd,loc_vert.ti]=...
+    [loc_vert.tf,loc_vert.tm,loc_vert.tw,loc_vert.pd,loc_vert.ti,loc_vert.tj]=...
         eigenfields(spin_system,loc_params,Iz,Qz,Ic,Qc,Hmw);
     vert(n)=loc_vert;
     

--- a/kernel/grids/voitlander.m
+++ b/kernel/grids/voitlander.m
@@ -28,6 +28,10 @@
 %     tri.vert(n).ti  - transition identity arrays at the triangle
 %                       corners, one row per transition
 %
+%     tri.vert(n).tj  - scaled field-sweep Jacobians at the triangle
+%                       corners, real column vectors, one element per
+%                       transition
+%
 %     Ic          - isotropic part of the coupling Hamiltonian,
 %                   a Hermitian matrix (set retention to 'couplings'
 %                   in assume.m and then call hamiltonian.m)
@@ -76,19 +80,19 @@ vert1=tri.vert(1); vert2=tri.vert(2); vert3=tri.vert(3);
 vert12=struct(); vert12.xyz=r12;
 [phi,elev]=cart2sph(r12(1),r12(2),r12(3));
 theta=pi/2-elev; loc_params=parameters; loc_params.orientation=[0 theta phi];
-[vert12.tf,vert12.tm,vert12.tw,vert12.pd,vert12.ti]=...
+[vert12.tf,vert12.tm,vert12.tw,vert12.pd,vert12.ti,vert12.tj]=...
     eigenfields(spin_system,loc_params,Iz,Qz,Ic,Qc,Hmw);
 
 vert23=struct(); vert23.xyz=r23;
 [phi,elev]=cart2sph(r23(1),r23(2),r23(3)); 
 theta=pi/2-elev; loc_params=parameters; loc_params.orientation=[0 theta phi];
-[vert23.tf,vert23.tm,vert23.tw,vert23.pd,vert23.ti]=...
+[vert23.tf,vert23.tm,vert23.tw,vert23.pd,vert23.ti,vert23.tj]=...
     eigenfields(spin_system,loc_params,Iz,Qz,Ic,Qc,Hmw);
 
 vert31=struct(); vert31.xyz=r31;
 [phi,elev]=cart2sph(r31(1),r31(2),r31(3));
 theta=pi/2-elev; loc_params=parameters; loc_params.orientation=[0 theta phi];
-[vert31.tf,vert31.tm,vert31.tw,vert31.pd,vert31.ti]=...
+[vert31.tf,vert31.tm,vert31.tw,vert31.pd,vert31.ti,vert31.tj]=...
     eigenfields(spin_system,loc_params,Iz,Qz,Ic,Qc,Hmw);
 
 % Assemble the subdivided triangles
@@ -199,6 +203,7 @@ for n=1:ntrans
     tran_mom=mean([vert1.tm(idx_a) vert2.tm(idx_b) vert3.tm(idx_c)]);
     pop_diff=mean([vert1.pd(idx_a) vert2.pd(idx_b) vert3.pd(idx_c)]);
     line_width=mean([vert1.tw(idx_a) vert2.tw(idx_b) vert3.tw(idx_c)]);
+    jac_weight=mean([vert1.tj(idx_a) vert2.tj(idx_b) vert3.tj(idx_c)]);
 
     % Find the relevant part of the axis
     b_mask=(b_axis>min_freq-3*line_width)&(b_axis<max_freq+3*line_width);
@@ -206,7 +211,7 @@ for n=1:ntrans
     % Convolutions of Lorentzians with triangles
     spec(b_mask)=spec(b_mask)+...
                  S*pop_diff*lorentzcon([vert1.tf(idx_a) vert2.tf(idx_b)...
-                                         vert3.tf(idx_c)],tran_mom,...
+                                         vert3.tf(idx_c)],tran_mom*jac_weight,...
                                         line_width,b_axis(b_mask));
                   
 end
@@ -218,10 +223,10 @@ function grumble(parameters,tri,Ic,Iz,Qc,Qz,b_axis)
 if (~isstruct(tri))||(~isfield(tri,'vert'))||(numel(tri.vert)~=3)
     error('tri.vert must be a three-element vertex structure array.');
 end
-vert_fields={'xyz','tf','tm','tw','pd','ti'};
+vert_fields={'xyz','tf','tm','tw','pd','ti','tj'};
 for n=1:numel(vert_fields)
     if ~isfield(tri.vert,vert_fields{n})
-        error('tri.vert entries must contain xyz, tf, tm, tw, pd, and ti fields.');
+        error('tri.vert entries must contain xyz, tf, tm, tw, pd, ti, and tj fields.');
     end
 end
 for n=1:3
@@ -250,10 +255,15 @@ for n=1:3
        (size(tri.vert(n).ti,1)~=numel(tri.vert(n).tf))
         error('tri.vert(n).ti must be a real array with one row per transition.');
     end
+    if (~isnumeric(tri.vert(n).tj))||(~isreal(tri.vert(n).tj))||...
+       (~iscolumn(tri.vert(n).tj))
+        error('tri.vert(n).tj must be a real column vector.');
+    end
     if (numel(tri.vert(n).tm)~=numel(tri.vert(n).tf))||...
        (numel(tri.vert(n).tw)~=numel(tri.vert(n).tf))||...
-       (numel(tri.vert(n).pd)~=numel(tri.vert(n).tf))
-        error('tri.vert(n).tf, tm, tw, pd, and ti sizes must agree.');
+       (numel(tri.vert(n).pd)~=numel(tri.vert(n).tf))||...
+       (numel(tri.vert(n).tj)~=numel(tri.vert(n).tf))
+        error('tri.vert(n).tf, tm, tw, pd, ti, and tj sizes must agree.');
     end
 end
 if (size(tri.vert(1).ti,2)~=size(tri.vert(2).ti,2))||...

--- a/kernel/grids/voitlander.m
+++ b/kernel/grids/voitlander.m
@@ -200,10 +200,16 @@ for n=1:ntrans
     % Get signal information
     min_freq=min([vert1.tf(idx_a) vert2.tf(idx_b) vert3.tf(idx_c)]);
     max_freq=max([vert1.tf(idx_a) vert2.tf(idx_b) vert3.tf(idx_c)]);
-    tran_mom=mean([vert1.tm(idx_a) vert2.tm(idx_b) vert3.tm(idx_c)]);
     pop_diff=mean([vert1.pd(idx_a) vert2.pd(idx_b) vert3.pd(idx_c)]);
     line_width=mean([vert1.tw(idx_a) vert2.tw(idx_b) vert3.tw(idx_c)]);
-    jac_weight=mean([vert1.tj(idx_a) vert2.tj(idx_b) vert3.tj(idx_c)]);
+
+    % Average finite vertex-wise intensity weights
+    tran_prod=[vert1.tm(idx_a)*vert1.tj(idx_a) ...
+               vert2.tm(idx_b)*vert2.tj(idx_b) ...
+               vert3.tm(idx_c)*vert3.tj(idx_c)];
+    tran_prod=tran_prod(isfinite(tran_prod));
+    if isempty(tran_prod), continue; end
+    tran_amp=mean(tran_prod);
 
     % Find the relevant part of the axis
     b_mask=(b_axis>min_freq-3*line_width)&(b_axis<max_freq+3*line_width);
@@ -211,7 +217,7 @@ for n=1:ntrans
     % Convolutions of Lorentzians with triangles
     spec(b_mask)=spec(b_mask)+...
                  S*pop_diff*lorentzcon([vert1.tf(idx_a) vert2.tf(idx_b)...
-                                         vert3.tf(idx_c)],tran_mom*jac_weight,...
+                                         vert3.tf(idx_c)],tran_amp,...
                                         line_width,b_axis(b_mask));
                   
 end

--- a/kernel/utilities/eigenfields.m
+++ b/kernel/utilities/eigenfields.m
@@ -3,7 +3,7 @@
 % of Hc+B*Hz is equal to the frequency provided, and the transition
 % moment across the specified operator Hmw is significant. Syntax:
 %
-%  [tf,tm,tw,pd,ti]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw)
+%  [tf,tm,tw,pd,ti,tj]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw)
 %
 % Parameters:
 %
@@ -65,11 +65,13 @@
 %
 %     ti     -  transition identity array, one row per transition
 %
+%     tj     -  vector of scaled field-sweep Jacobians
+%
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=eigenfields.m>
 
-function [tf,tm,tw,pd,ti]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw)
+function [tf,tm,tw,pd,ti,tj]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw)
 
 % Check consistency
 grumble(spin_system,parameters,Iz,Qz,Ic,Qc);
@@ -209,7 +211,7 @@ switch spin_system.bas.formalism
         end
 
         % Get outputs started
-        tf=[]; tm=[]; tw=[]; pd=[]; ti=zeros(0,3);
+        tf=[]; tm=[]; tw=[]; pd=[]; tj=[]; ti=zeros(0,3);
 
         % Initialise branch counters for each level pair
         pair_branch=zeros(size(E,1));
@@ -254,8 +256,8 @@ switch spin_system.bas.formalism
                 destin_spline(4)=destin_spline(4)-omega;
 
                 % Get the cubic equation coefficients
-                cubic_coeffs=destin_spline-source_spline;
-                poly_coeffs=cubic_coeffs;
+                gap_spline=destin_spline-source_spline;
+                poly_coeffs=gap_spline;
                 poly_scale=max(abs(poly_coeffs));
                 if poly_scale==0, continue; end
                 poly_coeffs=poly_coeffs/poly_scale;
@@ -300,12 +302,23 @@ switch spin_system.bas.formalism
                     tm_base=(1-alpha)*tm_left+alpha*tm_right;
                     pd_base=(1-alpha)*pd_left+alpha*pd_right;
 
+                    % Get the transition frequency slope
+                    jac_slope=polyval(polyder(gap_spline),alpha)/dx;
+
                     % Rediagonalise at unstable roots
                     if ~stable_states
                         reson_field=grid(n-1)+alpha*dx;
-                        [~,~,~,T_root,LP_root]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,reson_field);
+                        [~,~,dE_root,T_root,LP_root]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,reson_field);
                         tm_base=T_root(source(k),destin(k));
                         pd_base=LP_root(source(k))-LP_root(destin(k));
+                        jac_slope=dE_root(destin(k))-dE_root(source(k));
+                    end
+
+                    % Scale the field-sweep Jacobian to electron EPR order
+                    if jac_slope==0
+                        tj_base=Inf;
+                    else
+                        tj_base=abs(spin('E'))/abs(jac_slope);
                     end
 
                     % Update the branch count for this level pair
@@ -316,6 +329,9 @@ switch spin_system.bas.formalism
 
                     % Store population difference
                     pd(end+1)=pd_base; %#ok<AGROW>
+
+                    % Store scaled field-sweep Jacobian
+                    tj(end+1)=tj_base; %#ok<AGROW>
 
                     % Store the transition field
                     tf(end+1)=grid(n-1)+alpha*dx; %#ok<AGROW>
@@ -366,6 +382,10 @@ switch spin_system.bas.formalism
         % Compute transition moments
         tm=abs(Hmw'*uv).^2;
 
+        % Compute scaled field-sweep Jacobians
+        jac_slope=real(sum(conj(uv).*(right_mat*uv),1));
+        tj=abs(spin('E'))./abs(jac_slope);
+
         % Unit pop diffs for now
         pd=ones(size(tm));
 
@@ -392,13 +412,15 @@ else
     hit_list=(tm<tm_cutoff);
 end
 tf(hit_list)=[]; tm(hit_list)=[];
-tw(hit_list)=[]; pd(hit_list)=[]; ti(hit_list,:)=[];
+tw(hit_list)=[]; pd(hit_list)=[]; tj(hit_list)=[];
+ti(hit_list,:)=[];
 
 % Reshape into columns and sort
 [tf,idx]=sort(tf(:)); 
 tm=tm(:); tm=tm(idx);
 tw=tw(:); tw=tw(idx);
 pd=pd(:); pd=pd(idx);
+tj=tj(:); tj=tj(idx);
 ti=ti(idx,:);
 
 end

--- a/tests/kernel/test_dynamic_remaining_spectral_suite.m
+++ b/tests/kernel/test_dynamic_remaining_spectral_suite.m
@@ -60,7 +60,7 @@ Ic=zeros(2);
 Qz=local_tiny_rank_one(2);
 Qc=local_tiny_rank_one(2);
 Hmw=[1;0];
-[tf,tm,tw,pd]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
+[tf,tm,tw,pd,~,tj]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
 result=test_close(result,'eigenfields transition field',tf,10,1e-8,1e-12,...
                   'a 100 Hz transition under a 10 Hz/T Liouville pencil occurs at 10 T');
 result=test_close(result,'eigenfields transition moment',tm,1,1e-14,1e-14,...
@@ -69,6 +69,8 @@ result=test_close(result,'eigenfields transition width',tw,parameters.fwhm,1e-14
                   'Liouville-space eigenfields return the requested phenomenological FWHM');
 result=test_close(result,'eigenfields population difference',pd,1,1e-14,1e-14,...
                   'Liouville-space population differences are currently unit placeholders');
+result=test_close(result,'eigenfields scaled Jacobian',tj,abs(spin('E'))/(2*pi*10),1e-6,1e-12,...
+                  'the field-sweep Jacobian must be scaled by the free-electron angular gyromagnetic ratio');
 
 % Check two-root Hilbert-space resonance extraction in a curved level gap
 spin_system=local_minimal_system('zeeman-hilb',2);
@@ -86,12 +88,14 @@ Ic=[0 0.1;0.1 0];
 Qz=local_tiny_rank_one(2);
 Qc=local_tiny_rank_one(2);
 Hmw=[0 1;1 0];
-[tf,~,~,~,ti]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
+[tf,~,~,~,ti,tj]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
 root_field=sqrt(0.25-0.01);
 result=test_close(result,'eigenfields two-root fields',tf,[-root_field; root_field],1e-8,1e-10,...
                   'a symmetric avoided crossing must produce both resonance fields in the sweep window');
 result=test_true(result,'eigenfields two-root identities',isequal(ti,[1 2 1;1 2 2]),...
                  'multiple roots of the same level pair must receive distinct branch identities');
+result=test_close(result,'eigenfields two-root Jacobians',tj,abs(spin('E'))./(4*root_field)*[1;1],1e3,1e-12,...
+                  'symmetric roots must carry the same absolute field-sweep Jacobian');
 
 % Check one-dimensional gradient operator construction in Fokker-Planck space
 spin_system=local_created_system('zeeman-hilb',1);

--- a/tests/kernel/test_dynamic_voitlander.m
+++ b/tests/kernel/test_dynamic_voitlander.m
@@ -61,6 +61,13 @@ r1=[1;0;0];
 r2=[0;1;0];
 r3=[0;0;1];
 
+% Compute the first-level subdivision areas
+[r12,r23,r31]=sphtrsubd(r1,r2,r3);
+area_a=sphtarea(r1,r12,r31);
+area_b=sphtarea(r12,r2,r23);
+area_c=sphtarea(r31,r23,r3);
+area_d=sphtarea(r12,r23,r31);
+
 % Keep all field points inside the internal six-width support window
 b_axis=tf+linspace(-2*tw,2*tw,parameters.npoints);
 
@@ -83,6 +90,35 @@ result=test_close(result,'voitlander constant line',spec,reference,1e-10,1e-12,.
                   'subdivision of a constant transition must preserve total spherical-triangle area');
 result=test_true(result,'voitlander finite real spectrum',isreal(spec)&&all(isfinite(spec(:)))&&all(spec(:)>=0),...
                  'a positive population difference and transition moment must give a finite non-negative real spectrum');
+
+% Check that vertex-wise moment-Jacobian products are averaged directly
+tri_corr=tri;
+tri_corr.vert(1).tm=tm;
+tri_corr.vert(1).tj=4*tj;
+tri_corr.vert(2).tm=2*tm;
+tri_corr.vert(2).tj=2*tj;
+tri_corr.vert(3).tm=4*tm;
+tri_corr.vert(3).tj=tj;
+spec_corr=voitlander(spin_system,parameters,tri_corr,Ic,Iz,Qc,Qz,Hmw,b_axis);
+prod_area=2*area_a+2*area_b+2*area_c+area_d;
+line_shape=(tm*tj/(2*pi*line_width))./(1+((b_axis-tf)/line_width).^2);
+reference=prod_area*pd*line_shape;
+result=test_close(result,'voitlander vertex product amplitude',spec_corr,reference,1e-10,1e-12,...
+                  'triangle amplitudes must average per-vertex products instead of separate moment and Jacobian means');
+
+% Check that singular field-sweep Jacobian vertices are rejected safely
+tri_sing=tri;
+tri_sing.vert(1).tj=Inf;
+tri_sing.vert(2).tj=tj;
+tri_sing.vert(3).tj=2*tj;
+spec_sing=voitlander(spin_system,parameters,tri_sing,Ic,Iz,Qc,Qz,Hmw,b_axis);
+sing_area=area_a+area_b+(4/3)*area_c+area_d;
+line_shape=(tm*tj/(2*pi*line_width))./(1+((b_axis-tf)/line_width).^2);
+reference=sing_area*pd*line_shape;
+result=test_close(result,'voitlander finite Jacobian rejection',spec_sing,reference,1e-10,1e-12,...
+                  'non-finite per-vertex Jacobian products must not reach the Lorentzian convolution');
+result=test_true(result,'voitlander singular Jacobian finite spectrum',isreal(spec_sing)&&all(isfinite(spec_sing(:))),...
+                 'a singular Jacobian at one vertex must not contaminate the triangle integral');
 
 % Build a minimal two-level avoided crossing with two resonance roots
 spin_system.sys.output='hush';

--- a/tests/kernel/test_dynamic_voitlander.m
+++ b/tests/kernel/test_dynamic_voitlander.m
@@ -50,9 +50,11 @@ Iz=(Iz+Iz')/2;
 Hmw=(state(spin_system,'L+','E')+state(spin_system,'L-','E'))/2;
 
 % Find the isotropic transition at one orientation
-[tf,tm,tw,pd,ti]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
+[tf,tm,tw,pd,ti,tj]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
 result=test_true(result,'voitlander transition count',isscalar(tf),...
                  'an isolated isotropic electron has one allowed EPR transition in the selected field window');
+result=test_close(result,'voitlander scaled Jacobian',tj,spin_system.tols.freeg/2.0023,1e-10,1e-12,...
+                  'an isotropic electron field-sweep Jacobian must reduce to the free-g over effective-g ratio');
 
 % Define the positive octant spherical triangle
 r1=[1;0;0];
@@ -65,14 +67,15 @@ b_axis=tf+linspace(-2*tw,2*tw,parameters.npoints);
 % Package the triangle vertices
 tri.vert=struct('xyz',{r1,r2,r3},'tf',{tf,tf,tf},...
                 'tm',{tm,tm,tm},'tw',{tw,tw,tw},...
-                'pd',{pd,pd,pd},'ti',{ti,ti,ti});
+                'pd',{pd,pd,pd},'ti',{ti,ti,ti},...
+                'tj',{tj,tj,tj});
 
 % Integrate the triangle using the production routine
 spec=voitlander(spin_system,parameters,tri,Ic,Iz,Qc,Qz,Hmw,b_axis);
 
 % Build the analytic Lorentzian reference for a constant transition
 line_width=tw/2;
-line_shape=(tm/(2*pi*line_width))./(1+((b_axis-tf)/line_width).^2);
+line_shape=(tm*tj/(2*pi*line_width))./(1+((b_axis-tf)/line_width).^2);
 reference=sphtarea(r1,r2,r3)*pd*line_shape;
 
 % Check the returned spectrum against the constant-transition identity
@@ -110,7 +113,7 @@ Qc=Qz;
 Hmw=[0 1;1 0];
 
 % Get the two resonance roots and their generated branch labels
-[tf,tm,tw,pd,ti]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
+[tf,tm,tw,pd,ti,tj]=eigenfields(spin_system,parameters,Iz,Qz,Ic,Qc,Hmw);
 high_root=2;
 b_axis=tf(high_root)+linspace(-2*tw(high_root),2*tw(high_root),parameters.npoints);
 
@@ -122,13 +125,15 @@ tri_ref.vert=struct('xyz',{r1,r2,r3},...
                     'tm',{tm(high_root),tm,tm(high_root)},...
                     'tw',{tw(high_root),tw,tw(high_root)},...
                     'pd',{pd(high_root),pd,pd(high_root)},...
-                    'ti',{ti_ref,ti,ti_ref});
+                    'ti',{ti_ref,ti,ti_ref},...
+                    'tj',{tj(high_root),tj,tj(high_root)});
 tri_local.vert=struct('xyz',{r1,r2,r3},...
                       'tf',{tf(high_root),tf,tf(high_root)},...
                       'tm',{tm(high_root),tm,tm(high_root)},...
                       'tw',{tw(high_root),tw,tw(high_root)},...
                       'pd',{pd(high_root),pd,pd(high_root)},...
-                      'ti',{ti_local,ti,ti_local});
+                      'ti',{ti_local,ti,ti_local},...
+                      'tj',{tj(high_root),tj,tj(high_root)});
 spec_ref=voitlander(spin_system,parameters,tri_ref,Ic,Iz,Qc,Qz,Hmw,b_axis);
 spec_local=voitlander(spin_system,parameters,tri_local,Ic,Iz,Qc,Qz,Hmw,b_axis);
 


### PR DESCRIPTION
## Summary

- compute a separate dimensionless field-sweep Jacobian, `tj`, in `eigenfields.m` as `abs(spin('E'))/abs(d(Delta omega)/dB)`
- carry `tj` through `fieldsweep.m` triangle vertices and apply it in `voitlander.m` without changing raw transition moments
- extend regression coverage for Hilbert, Liouville, and Voitlander Jacobian behaviour
- relax the Gd-DOTA temperature example integration tolerances used by the field-swept Jacobian path

## Validation

- `git diff --check origin/main..HEAD`
- `QT_QPA_PLATFORM=offscreen matlab -nojvm -batch "fix_path('add'); addpath('tests'); run_test('dynamic_voitlander'); run_test('dynamic_remaining_spectral');"`
- `QT_QPA_PLATFORM=offscreen matlab -nojvm -batch "fix_path('add'); cd('examples/esr_sol_swept'); temperature_gd_dota;"`

## Notes

- The branch was rebased onto current `origin/main` before submission.
- `tm` remains the raw microwave transition moment; `tj` is the field-domain density-of-states multiplier.
