### PR TITLE
Fix optimal-control gradient and Hessian paths

### DIFF
--- a/kernel/optimcon/grape_liouv.m
+++ b/kernel/optimcon/grape_liouv.m
@@ -428,7 +428,7 @@ if n_outputs>2
                         aux_vec_b=[zero_state; fwd_traj(:,n-1)];
                         
                         % Propagate and extract derivative action
-                        aux_vec_b=step(ss_parfor,Left_DR,aux_vec_b,dt(n));
+                        aux_vec_b=step(ss_parfor,Left_DR,aux_vec_b,dt(n-1));
 
                         % Product rule: [P2]*[dP1]*rho part
                         grad_col(k)=grad_col(k)+bwd_traj(:,n)'*aux_vec_b(1:(end/2));

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -110,6 +110,41 @@ end
 report(spin_system,[pad('Equation of motion integrator',60) ...
                     spin_system.control.integrator]);
 
+% Process optimisation method
+if isfield(control,'method')
+
+    % Input validation
+    if (~ischar(control.method))||(~ismember(control.method,{'lbfgs','rbfgs',...
+                                                             'newton','goodwin'}))
+        error('control.method must be ''lbfgs'', ''rbfgs'', ''newton'', or ''goodwin''.');
+    end
+
+    % Absorb the method
+    spin_system.control.method=control.method;
+    control=rmfield(control,'method');
+
+    % Refuse to run Newton for trapezium integrator
+    if strcmp(spin_system.control.method,'newton')&&...
+       strcmp(spin_system.control.integrator,'trapezium')
+        error('Newton optimiser is not available for trapezium integrator.');
+    end
+
+    % Refuse to run Goodwin for trapezium integrator
+    if strcmp(spin_system.control.method,'goodwin')&&...
+       strcmp(spin_system.control.integrator,'trapezium')
+        error('Goodwin optimiser is not available for trapezium integrator.');
+    end
+
+else
+
+    % Default is LBFGS
+    spin_system.control.method='lbfgs';
+
+end
+
+% Inform the user
+report(spin_system,[pad('Optimisation method',60) spin_system.control.method]);
+
 % Process control operators
 if isfield(control,'operators')
 
@@ -388,11 +423,6 @@ end
 % Process distortion functions
 if isfield(control,'distortion')
 
-    % Disallow Newton-Raphson
-    if ismember(control.method,{'newton','goodwin'})
-        error('distortion handling not implemented for Newton-Raphson methods.');
-    end
-
     % Input validation
     if ~iscell(control.distortion)
         error('control.distortion must be a cell array of function handles.');
@@ -414,10 +444,10 @@ if isfield(control,'distortion')
                         int2str(size(spin_system.control.distortion,1))]);
 
     % Block methods that use exact Hessians
-    if ismember(control.method,{'newton','goodwin'})
+    if ismember(spin_system.control.method,{'newton','goodwin'})
         error('waveform distortions are only available with LBFGS optimiser.');
     end
-                    
+
 else
     
     % Only one function that does nothing
@@ -762,41 +792,6 @@ else
     report(spin_system,[pad('Freeze mask supplied',60) 'no']);
     
 end      
-
-% Process optimisation method
-if isfield(control,'method')
-
-    % Input validation
-    if (~ischar(control.method))||(~ismember(control.method,{'lbfgs','rbfgs',...
-                                                             'newton','goodwin'}))
-        error('control.method must be ''lbfgs'', ''rbfgs'', ''newton'', or ''goodwin''.');
-    end
-    
-    % Absorb the method
-    spin_system.control.method=control.method;
-    control=rmfield(control,'method');
-
-    % Refuse to run Newton for trapezium integrator
-    if strcmp(spin_system.control.method,'newton')&&...
-       strcmp(spin_system.control.integrator,'trapezium')
-        error('Newton optimiser is not available for trapezium integrator.');
-    end
-
-    % Refuse to run Goodwin for trapezium integrator
-    if strcmp(spin_system.control.method,'goodwin')&&...
-       strcmp(spin_system.control.integrator,'trapezium')
-        error('Goodwin optimiser is not available for trapezium integrator.');
-    end
-    
-else    
-
-    % Default is LBFGS
-    spin_system.control.method='lbfgs';
-    
-end
-
-% Inform the user
-report(spin_system,[pad('Optimisation method',60) spin_system.control.method]);
 
 % Process iteration limit
 if isfield(control,'max_iter')

--- a/kernel/optimcon/penalty.m
+++ b/kernel/optimcon/penalty.m
@@ -167,27 +167,44 @@ switch type
         end
         
         % Build the amplitude hole inventory
-        ch_map=(amp>cb); ch_wanted=cb.*ch_map;
+        ch_map=(amp>cb); ch_actual=amp.*ch_map; ch_wanted=cb.*ch_map;
         
-        % Preallocated new Cartesian bounds
-        b=zeros(size(wf));
+        % Keep inactive amplitudes away from the polar singularity
+        amp_safe=amp; amp_safe(~ch_map)=1;
         
-        % Transform to Cartesian representation
-        for n=1:size(wf,1)/2
-            [b(2*n-1,:),b(2*n,:)]=polar2cartesian(ch_wanted(n,:),phi(n,:));
+        % Compute the penalty
+        pen_term=sum(sum((ch_actual-ch_wanted).^2));
+        pen_term=pen_term/size(wf,2);
+
+        % Compute the gradient
+        if nargout>1
+            pen_dr=2*(ch_actual-ch_wanted);
+            pen_dr=pen_dr/size(wf,2);
+            pen_dp=zeros(size(amp));
+            for n=1:size(wf,1)/2
+                [~,~,pen_grad(2*n-1,:),pen_grad(2*n,:)]=...
+                    polar2cartesian(amp_safe(n,:),phi(n,:),pen_dr(n,:),pen_dp(n,:));
+            end
         end
         
-        % New Cartesian bounds from amplitude bounds
-        cb=b; cb(cb<=0)=max(max(wf))+1;
-        fb=b; fb(fb>=0)=min(min(wf))-1;
-        
-        % Call the SNS penalty with new bounds
-        if nargout==1
-            [pen_term]=penalty(wf,'SNS',fb,cb);
-        elseif nargout==2
-            [pen_term,pen_grad]=penalty(wf,'SNS',fb,cb);
-        elseif nargout==3
-            [pen_term,pen_grad,pen_hess]=penalty(wf,'SNS',fb,cb);
+        % Compute the Hessian
+        if nargout>2
+            pen_dp=zeros(size(amp));
+            pen_drp=zeros(size(wf,2));
+            pen_dpr=zeros(size(wf,2));
+            pen_dpp=zeros(size(wf,2));
+            for n=1:size(wf,1)/2
+                pen_drr=diag(2*ch_map(n,:)/size(wf,2));
+                [~,~,~,~,Dxx,Dxy,Dyx,Dyy]=...
+                    polar2cartesian(amp_safe(n,:),phi(n,:),pen_dr(n,:),pen_dp(n,:),...
+                                    pen_drr,pen_drp,pen_dpr,pen_dpp);
+                x_idx=2*n-1:size(wf,1):numel(wf);
+                y_idx=2*n:size(wf,1):numel(wf);
+                pen_hess(x_idx,x_idx)=Dxx;
+                pen_hess(x_idx,y_idx)=Dxy;
+                pen_hess(y_idx,x_idx)=Dyx;
+                pen_hess(y_idx,y_idx)=Dyy;
+            end
         end
        
     otherwise

--- a/kernel/optimcon/tgrape.m
+++ b/kernel/optimcon/tgrape.m
@@ -71,7 +71,7 @@ for n=1:nsteps
     % Add current controls
     for k=1:numel(controls)
         L_forw=L_forw+waveform(k,n)*controls{k};
-        L_back=L_back+waveform(k,nsteps+1-n)*controls{k};
+        L_back=L_back+waveform(k,nsteps+1-n)*controls{k}';
     end
 
     % Take time steps forwards and backwards

--- a/tests/kernel/test_optimcon_grape_one_spin.m
+++ b/tests/kernel/test_optimcon_grape_one_spin.m
@@ -60,6 +60,30 @@ result=test_close(result,'optimcon timing grid',spin_system.control.pulse_dt,pul
 result=test_true(result,'optimcon rectangle grid',spin_system.control.pulse_ntpts==numel(pulse_dt),...
                  'rectangle integration must use one waveform value per interval');
 
+% Check that distortions work when the optimiser method is defaulted
+control_default=rmfield(control,'method');
+control_default.distortion={@no_dist};
+spin_default=optimcon(local_spin_system(),control_default);
+result=test_true(result,'optimcon distortion default method',...
+                 strcmp(spin_default.control.method,'lbfgs'),...
+                 'missing control.method must default before distortion processing');
+result=test_true(result,'optimcon distortion supplied',numel(spin_default.control.distortion)==1,...
+                 'a supplied distortion function must be stored after default method processing');
+
+% Check that exact-Hessian methods remain incompatible with distortions
+control_hessian=control;
+control_hessian.method='newton';
+control_hessian.distortion={@no_dist};
+try
+    optimcon(local_spin_system(),control_hessian);
+    hessian_err='';
+catch err
+    hessian_err=err.message;
+end
+result=test_true(result,'optimcon distortion Hessian block',...
+                 contains(hessian_err,'waveform distortions'),...
+                 'distortions must still reject exact-Hessian optimisation methods');
+
 % Evaluate the GRAPE fidelity and gradient for a non-trivial waveform
 waveform=[7 11];
 [traj_data,fidelity,grad]=grape_hilb(spin_system,{drift},control.operators,...

--- a/tests/kernel/test_optimcon_support_paths.m
+++ b/tests/kernel/test_optimcon_support_paths.m
@@ -76,15 +76,34 @@ result=test_true(result,'penalty DNS Hessian shape',isequal(size(hess_dns),[nume
                  'DNS penalty Hessian must be square over waveform elements');
 
 % Check the amplitude spillout path on Cartesian controls
-amp_waveform=[0.5 2.0 -0.25;...
-              0.5 0.0  1.50];
+amp_waveform=[ 0.50  2.00 -0.25  0.20;...
+               0.50  0.50  1.50 -0.10;...
+              -0.40  0.20  1.20 -1.60;...
+               0.30 -0.10  0.90 -0.40];
 [pen_snsa,grad_snsa,hess_snsa]=penalty(amp_waveform,'SNSA',0,1);
+amp_snsa=[sqrt(amp_waveform(1,:).^2+amp_waveform(2,:).^2);...
+          sqrt(amp_waveform(3,:).^2+amp_waveform(4,:).^2)];
+spill_snsa=max(amp_snsa-1,0);
+pen_snsa_ref=sum(spill_snsa(:).^2)/size(amp_waveform,2);
+ch_map_snsa=(amp_snsa>1);
+rad_scale=zeros(size(amp_snsa));
+rad_scale(ch_map_snsa)=2*(amp_snsa(ch_map_snsa)-1)./...
+                       (amp_snsa(ch_map_snsa)*size(amp_waveform,2));
+grad_snsa_ref=zeros(size(amp_waveform));
+grad_snsa_ref(1,:)=rad_scale(1,:).*amp_waveform(1,:);
+grad_snsa_ref(2,:)=rad_scale(1,:).*amp_waveform(2,:);
+grad_snsa_ref(3,:)=rad_scale(2,:).*amp_waveform(3,:);
+grad_snsa_ref(4,:)=rad_scale(2,:).*amp_waveform(4,:);
+hess_snsa_ref=local_finite_hess(@(x)local_penalty_grad(x,size(amp_waveform),'SNSA',0,1),...
+                                amp_waveform(:));
 result=test_true(result,'penalty SNSA active',pen_snsa>0,...
                  'SNSA penalty must detect amplitudes above the ceiling');
-result=test_true(result,'penalty SNSA gradient shape',isequal(size(grad_snsa),size(amp_waveform)),...
-                 'SNSA penalty gradient must have waveform dimensions');
-result=test_true(result,'penalty SNSA Hessian shape',isequal(size(hess_snsa),[numel(amp_waveform) numel(amp_waveform)]),...
-                 'SNSA penalty Hessian must be square over waveform elements');
+result=test_close(result,'penalty SNSA term',pen_snsa,pen_snsa_ref,1e-14,1e-14,...
+                  'SNSA penalty value must match amplitude spillout beyond the ceiling');
+result=test_close(result,'penalty SNSA gradient',grad_snsa,grad_snsa_ref,1e-14,1e-14,...
+                  'SNSA penalty gradient must match the Cartesian radial projection');
+result=test_close(result,'penalty SNSA Hessian finite diff',hess_snsa,hess_snsa_ref,1e-6,1e-6,...
+                  'SNSA penalty Hessian must match centred finite differences of its gradient');
 
 % Check trapezium derivative matrices against centred finite differences
 S=pauli(2);
@@ -233,6 +252,32 @@ for n=1:numel(x)
     x_minus(n)=x_minus(n)-step_size;
     grad(n)=(fun(x_plus)-fun(x_minus))/(2*step_size);
 end
+
+end
+
+
+function hess=local_finite_hess(fun,x)
+
+% Compute a centred finite-difference Hessian
+step_size=1e-6;
+grad=fun(x);
+hess=zeros(numel(grad),numel(x));
+for n=1:numel(x)
+    x_plus=x;
+    x_minus=x;
+    x_plus(n)=x_plus(n)+step_size;
+    x_minus(n)=x_minus(n)-step_size;
+    hess(:,n)=(fun(x_plus)-fun(x_minus))/(2*step_size);
+end
+
+end
+
+
+function grad=local_penalty_grad(x,wf_size,type,fb,cb)
+
+% Evaluate only the penalty gradient for finite differences
+[~,grad]=penalty(reshape(x,wf_size),type,fb,cb);
+grad=grad(:);
 
 end
 


### PR DESCRIPTION
## Summary

- Fixes the trapezium GRAPE gradient for non-uniform `pulse_dt`.
- Fixes `tgrape.m` backward propagation for non-Hermitian control operators by using adjoint controls.
- Fixes the `SNSA` penalty Hessian by computing amplitude-space spillout derivatives directly and mapping them back to Cartesian controls with `polar2cartesian()`.
- Fixes `optimcon.m` setup ordering so `control.method` is validated or defaulted before distortion handling, and distortion checks read `spin_system.control.method`.
- Strengthens regression coverage for `SNSA` value, gradient, and Hessian checks, and for defaulted optimiser methods with waveform distortions.

## Validation

- `checkcode('kernel/optimcon/grape_liouv.m')`
- `checkcode('kernel/optimcon/tgrape.m')`
- `git diff --check`
- Focused finite-difference smoke test:
  - rectangle GRAPE gradient relerr `7.161e-11`
  - trapezium equal-`dt` GRAPE gradient relerr `5.499e-11`
  - trapezium non-uniform-`dt` GRAPE gradient relerr `2.929e-11`
  - non-Hermitian `tgrape` duration-gradient relerr `3.025e-11`
- `SNSA` compatibility and Hessian probe:
  - value/gradient against previous implementation error `2.082e-16`
  - Hessian finite-difference relerr `1.217e-10`
- New `optimcon.m` method/distortion regression:
  - defaulted `control.method` plus supplied distortion PASS
  - `newton` plus supplied distortion rejection PASS
- `run_tests('pattern','optimcon','verbose',true,'stop_on_fail',true)`
  - `optimcon/grape_one_spin` PASS
  - `optimcon/support_paths` PASS
  - `kernel/dynamic_optimcon_remaining` PASS
