### PR TITLE
Fix grumbler validation issues

### DIFF
--- a/etc/data_processing/autophase.m
+++ b/etc/data_processing/autophase.m
@@ -81,11 +81,12 @@ end
 
 % Consistency enforcement
 function grumble(spec,guess)
-if (~isnumeric(spec))||(~isvector(spec))
+if (~isnumeric(spec))||(~isvector(spec))||any(~isfinite(spec(:)))
     error('spec must be a vector.');
 end
-if (~isnumeric(guess))||(~isreal(guess))||(~isvector(guess))
-    error('guess must be a real vector.');
+if (~isnumeric(guess))||(~isreal(guess))||(~isrow(guess))||...
+   (numel(guess)<2)||any(~isfinite(guess(:)))
+    error('guess must be a real row vector with at least two elements.');
 end
 end
 
@@ -94,4 +95,3 @@ end
 % equal, they are not free.
 %
 % Alexander Solzhenitsyn
-

--- a/etc/data_processing/destreak.m
+++ b/etc/data_processing/destreak.m
@@ -36,7 +36,10 @@ if isstruct(spectrum)
         spectrum.(struct_fieldnames{n})=destreak(spectrum.(struct_fieldnames{n}));
                       
     end
-    
+
+    % Return processed structure
+    return
+
 elseif iscell(spectrum)
     
     % Loop over cells
@@ -46,7 +49,10 @@ elseif iscell(spectrum)
         spectrum{n}=destreak(spectrum{n});
         
     end
-    
+
+    % Return processed cell array
+    return
+
 end
 
 % Check consistency
@@ -91,4 +97,3 @@ end
 % If it flies, floats or fucks, you are better off renting it.
 %
 % Felix Dennis
-

--- a/etc/data_processing/lpredict.m
+++ b/etc/data_processing/lpredict.m
@@ -62,11 +62,12 @@ if (~isnumeric(x))||(~isreal(x))||(~iscolumn(x))
     error('x must be a real column vector.');
 end
 if (~isnumeric(npcoeffs))||(~isreal(npcoeffs))||...
-   (~isscalar(npcoeffs))||(npcoeffs<2)||(mod(npcoeffs,1)~=0)
+   (~isscalar(npcoeffs))||(~isfinite(npcoeffs))||(npcoeffs<2)||...
+   (mod(npcoeffs,1)~=0)||(npcoeffs>numel(x))
     error('npcoeffs must be a real integer greater than 1.');
 end
 if (~isnumeric(npredps))||(~isreal(npredps))||...
-   (~isscalar(npredps))||(npredps<1)||(mod(npredps,1)~=0)
+   (~isscalar(npredps))||(~isfinite(npredps))||(npredps<1)||(mod(npredps,1)~=0)
     error('npredps must be a positive real integer.');
 end
 end
@@ -75,4 +76,3 @@ end
 % among the well-to-do peasants.
 %
 % Mao Zedong
-

--- a/etc/estimators/guess_csa_pro.m
+++ b/etc/estimators/guess_csa_pro.m
@@ -42,10 +42,12 @@
 function CSAs=guess_csa_pro(aa_nums,pdb_ids,coords,options)
 
 % Set default peptide bond CSA options
-if ~isfield(options,'nh_csa'), options.nh_csa='tcb'; end
+if ~exist('options','var'), options=struct(); end
+if isempty(options), options=struct(); end
+if isstruct(options)&&(~isfield(options,'nh_csa')), options.nh_csa='tcb'; end
 
 % Check consistency
-grumble(aa_nums,pdb_ids,coords);
+grumble(aa_nums,pdb_ids,coords,options);
 
 % Preallocate CSA array
 CSAs=cell(numel(pdb_ids),1);
@@ -310,7 +312,7 @@ end
 end
 
 % Consistency enforcement
-function grumble(aa_nums,pdb_ids,coords)
+function grumble(aa_nums,pdb_ids,coords,options)
 if ~isnumeric(aa_nums)
     error('aa_nums must be a vector of integers.'); 
 end
@@ -323,6 +325,10 @@ end
 if (numel(aa_nums)~=numel(pdb_ids))||(numel(pdb_ids)~=numel(coords))
     error('the input parameters must have the same number of elements.');
 end
+if (~isstruct(options))||(~ischar(options.nh_csa))||...
+   (~ismember(options.nh_csa,{'tcb','bax','pol'}))
+    error('options.nh_csa must be ''tcb'', ''bax'', or ''pol''.');
+end
 end
 
 % "Where's the PCM solvent?"
@@ -330,4 +336,3 @@ end
 % A 3rd year project student,
 % rummaging through IK's sol-
 % vent cabinet.
-

--- a/etc/estimators/guess_csa_pro.m
+++ b/etc/estimators/guess_csa_pro.m
@@ -19,7 +19,7 @@
 %
 %       coords    - a cell array of coordinate vectors
 %
-%       options.nh_csa - 'tcb' (default) for Tjandra, Curtis,
+%       options.nh_csa - 'tcb' for Tjandra, Curtis,
 %                        and Bodenhausen, 'bax' for Cornilescu
 %                        and Bax, and 'pol' for Case, Polenova
 %                        and Gronenborn eigenvalues and orien-
@@ -40,11 +40,6 @@
 % <https://spindynamics.org/wiki/index.php?title=Guess_csa_pro.m>
 
 function CSAs=guess_csa_pro(aa_nums,pdb_ids,coords,options)
-
-% Set default peptide bond CSA options
-if ~exist('options','var'), options=struct(); end
-if isempty(options), options=struct(); end
-if isstruct(options)&&(~isfield(options,'nh_csa')), options.nh_csa='tcb'; end
 
 % Check consistency
 grumble(aa_nums,pdb_ids,coords,options);
@@ -325,7 +320,8 @@ end
 if (numel(aa_nums)~=numel(pdb_ids))||(numel(pdb_ids)~=numel(coords))
     error('the input parameters must have the same number of elements.');
 end
-if (~isstruct(options))||(~ischar(options.nh_csa))||...
+if (~isstruct(options))||(~isfield(options,'nh_csa'))||...
+   (~ischar(options.nh_csa))||...
    (~ismember(options.nh_csa,{'tcb','bax','pol'}))
     error('options.nh_csa must be ''tcb'', ''bax'', or ''pol''.');
 end

--- a/etc/molecules/fatty_acid.m
+++ b/etc/molecules/fatty_acid.m
@@ -57,6 +57,7 @@ end
 % Consistency enforcement
 function grumble(nprotons)
 if (~isnumeric(nprotons))||(~isreal(nprotons))||...
+   (~isscalar(nprotons))||(~isfinite(nprotons))||...
    (mod(nprotons,1)~=0)||(mod((nprotons-3)/2,1)~=0)||...
    ((nprotons-3)/2<1)
     error('(nprotons-3)/2 must be a positive integer.');
@@ -67,4 +68,3 @@ end
 % you have ugly people who are intelligent, like scientists.
 %
 % Jose Mourinho
-

--- a/etc/molecules/zfs_sampling.m
+++ b/etc/molecules/zfs_sampling.m
@@ -81,14 +81,16 @@ end
 % Consistency enforcement
 function grumble(npoints_d,npoints_e,tol)
 if (~isnumeric(npoints_d))||(~isreal(npoints_d))||...
+   (~isscalar(npoints_d))||(~isfinite(npoints_d))||...
    (npoints_d<5)||(mod(npoints_d,1)~=0)
     error('npoints_d must be a real integer greater than 5.');
 end
 if (~isnumeric(npoints_e))||(~isreal(npoints_e))||...
+   (~isscalar(npoints_e))||(~isfinite(npoints_e))||...
    (npoints_e<5)||(mod(npoints_e,1)~=0)
     error('npoints_e must be a real integer greater than 5.');
 end
-if (~isnumeric(tol))||(~isreal(tol))||(tol<0)
+if (~isnumeric(tol))||(~isreal(tol))||(~isscalar(tol))||(~isfinite(tol))||(tol<0)
     error('tol must be a positive real number much smaller than 1.');
 end
 end
@@ -97,4 +99,3 @@ end
 % then, like most cliches, that cliche is untrue.
 %
 % Stephen Fry
-

--- a/etc/textbook/rlx_dd_csa.m
+++ b/etc/textbook/rlx_dd_csa.m
@@ -121,24 +121,30 @@ end
 
 % Consistency enforcement
 function grumble(B0,tau_c,isotopes,deltas,coords)
-if (~isnumeric(B0))||(~isreal(B0))||(~isscalar(B0))
-    error('B0 must be a real number.');
+if (~isnumeric(B0))||(~isreal(B0))||(~isscalar(B0))||(~isfinite(B0))
+    error('B0 must be a finite real number.');
 end
 if (~isnumeric(tau_c))||(~isreal(tau_c))||...
-   (~isscalar(tau_c))||(tau_c<=0)
+   (~isscalar(tau_c))||(~isfinite(tau_c))||(tau_c<=0)
     error('tau_c must be a positive real number.');
 end
-if ~iscell(isotopes)
-    error('isotopes must be a cell array of character strings.');
+if (~iscell(isotopes))||(numel(isotopes)~=2)||any(~cellfun(@ischar,isotopes))
+    error('isotopes must be a two-element cell array of character strings.');
 end
-if ~iscell(deltas)
-    error('deltas must be a cell array of 3x3 matrices.');
+if (~iscell(deltas))||(numel(deltas)~=2)
+    error('deltas must be a two-element cell array of 3x3 matrices.');
 end
-if (~issymmetric(deltas{1}))||(~issymmetric(deltas{2}))
-    error('this function only supports symmetric shift tensors.');
+if (~isnumeric(deltas{1}))||(~isreal(deltas{1}))||(~isequal(size(deltas{1}),[3 3]))||...
+   any(~isfinite(deltas{1}(:)))||(~isnumeric(deltas{2}))||(~isreal(deltas{2}))||...
+   (~isequal(size(deltas{2}),[3 3]))||any(~isfinite(deltas{2}(:)))||...
+   (~issymmetric(deltas{1}))||(~issymmetric(deltas{2}))
+    error('this function only supports symmetric 3x3 shift tensors.');
 end
-if ~iscell(coords)
-    error('coords must be a cell array of 1x3 vectors.');
+if (~iscell(coords))||(numel(coords)~=2)||(~isnumeric(coords{1}))||...
+   (~isreal(coords{1}))||(~isrow(coords{1}))||(numel(coords{1})~=3)||...
+   any(~isfinite(coords{1}(:)))||(~isnumeric(coords{2}))||(~isreal(coords{2}))||...
+   (~isrow(coords{2}))||(numel(coords{2})~=3)||any(~isfinite(coords{2}(:)))
+    error('coords must be a two-element cell array of real 1x3 vectors.');
 end
 [~,mult_a]=spin(isotopes{1}); [~,mult_b]=spin(isotopes{2});
 if (mult_a~=2)||(mult_b~=2)
@@ -153,4 +159,3 @@ end
 %  users performed even worse than novice Word users."
 %
 % https://doi.org/10.1371/journal.pone.0125830
-

--- a/experiments/esr_dipolar/deer_3p_soft_deer.m
+++ b/experiments/esr_dipolar/deer_3p_soft_deer.m
@@ -137,6 +137,13 @@ if (~isnumeric(parameters.pulse_frq))||(~isreal(parameters.pulse_frq))||...
    (numel(parameters.pulse_frq)~=3)
     error('parameters.pulse_frq must have three real elements.');
 end
+if ~isfield(parameters,'offset')
+    error('receiver offset must be specified in parameters.offset field.');
+end
+if (~isnumeric(parameters.offset))||(~isreal(parameters.offset))||...
+   (~isscalar(parameters.offset))||(~isfinite(parameters.offset))
+    error('parameters.offset must be a finite real scalar.');
+end
 if ~isfield(parameters,'pulse_pwr')
     error('pulse powers must be specified in parameters.pulse_pwr field.');
 end
@@ -223,4 +230,3 @@ end
 % should not be bound by moral rules invented by their foes.
 %
 % Leo Tolstoy, about Ragnar Redbeard's "Might is Right"
-

--- a/experiments/esr_dipolar/deer_3p_soft_hole.m
+++ b/experiments/esr_dipolar/deer_3p_soft_hole.m
@@ -117,6 +117,13 @@ if (~isnumeric(parameters.pulse_frq))||(~isreal(parameters.pulse_frq))||...
    (numel(parameters.pulse_frq)~=3)
     error('parameters.pulse_frq must have three real elements.');
 end
+if ~isfield(parameters,'offset')
+    error('receiver offset must be specified in parameters.offset field.');
+end
+if (~isnumeric(parameters.offset))||(~isreal(parameters.offset))||...
+   (~isscalar(parameters.offset))||(~isfinite(parameters.offset))
+    error('parameters.offset must be a finite real scalar.');
+end
 if ~isfield(parameters,'pulse_pwr')
     error('pulse powers must be specified in parameters.pulse_pwr field.');
 end
@@ -188,4 +195,3 @@ end
 % noiselessly.
 %
 % J. Robert Oppenheimer
-

--- a/experiments/esr_dipolar/deer_4p_soft_deer.m
+++ b/experiments/esr_dipolar/deer_4p_soft_deer.m
@@ -155,6 +155,13 @@ if (~isnumeric(parameters.pulse_frq))||(~isreal(parameters.pulse_frq))||...
    (numel(parameters.pulse_frq)~=4)
     error('parameters.pulse_frq must have four real elements.');
 end
+if ~isfield(parameters,'offset')
+    error('receiver offset must be specified in parameters.offset field.');
+end
+if (~isnumeric(parameters.offset))||(~isreal(parameters.offset))||...
+   (~isscalar(parameters.offset))||(~isfinite(parameters.offset))
+    error('parameters.offset must be a finite real scalar.');
+end
 if ~isfield(parameters,'pulse_pwr')
     error('pulse powers must be specified in parameters.pulse_pwr field.');
 end
@@ -244,4 +251,3 @@ end
 % Can choose to write denouncements in verse.
 % 
 % Stanislaw Jerzy Lec, translated by IK
-

--- a/experiments/esr_dipolar/deer_4p_soft_hole.m
+++ b/experiments/esr_dipolar/deer_4p_soft_hole.m
@@ -120,6 +120,13 @@ if (~isnumeric(parameters.pulse_frq))||(~isreal(parameters.pulse_frq))||...
    (numel(parameters.pulse_frq)~=4)
     error('parameters.pulse_frq must have four real elements.');
 end
+if ~isfield(parameters,'offset')
+    error('receiver offset must be specified in parameters.offset field.');
+end
+if (~isnumeric(parameters.offset))||(~isreal(parameters.offset))||...
+   (~isscalar(parameters.offset))||(~isfinite(parameters.offset))
+    error('parameters.offset must be a finite real scalar.');
+end
 if ~isfield(parameters,'pulse_pwr')
     error('pulse powers must be specified in parameters.pulse_pwr field.');
 end
@@ -187,4 +194,3 @@ end
 % and the next. After a week, I decided religion wasn't for me.
 %
 % Fidel Castro
-

--- a/experiments/fieldsweep.m
+++ b/experiments/fieldsweep.m
@@ -131,7 +131,8 @@ if ~isfield(parameters,'grid')
     error('stoll grid rank must be specified in parameters.grid variable.');
 end
 if (~isnumeric(parameters.grid))||(~isscalar(parameters.grid))||...
-   (~isreal(parameters.grid))||(parameters.grid<=0)
+   (~isreal(parameters.grid))||(~isfinite(parameters.grid))||...
+   (parameters.grid<=0)||(mod(parameters.grid,1)~=0)
     error('parameters.grid must be a positive real integer.');
 end
 if ~isfield(parameters,'spins')
@@ -159,9 +160,9 @@ if ~isfield(parameters,'npoints')
     error('number of points should be specified in parameters.npoints variable.');
 end
 if (~isnumeric(parameters.npoints))||(~isscalar(parameters.npoints))||...
-   (~isreal(parameters.npoints))||(parameters.npoints<=0)||...
+   (~isreal(parameters.npoints))||(parameters.npoints<=1)||...
    (mod(parameters.npoints,1)~=0)
-    error('parameters.npoints must be a positive real integer.');
+    error('parameters.npoints must be a real integer greater than one.');
 end
 if ~isfield(parameters,'window')
     error('sweep window should be specified in parameters.window variable.');
@@ -174,8 +175,8 @@ if ~isfield(parameters,'tm_tol')
     error('transition moment tolerance must be specified in parameters.tm_tol variable.');
 end
 if (~isnumeric(parameters.tm_tol))||(~isscalar(parameters.tm_tol))||...
-   (~isreal(parameters.tm_tol))||(parameters.tm_tol<=0)
-    error('parameters.tm_tol must be a positive real scalar.');
+   (~isreal(parameters.tm_tol))||(parameters.tm_tol<0)
+    error('parameters.tm_tol must be a non-negative real scalar.');
 end
 if ~isfield(parameters,'rspt_order')
     error('perturbation theory order must be specified in parameters.rspt_order variable.');

--- a/experiments/hyperpol/masdnp.m
+++ b/experiments/hyperpol/masdnp.m
@@ -135,8 +135,10 @@ elseif (~isnumeric(parameters.max_rank))||(~isreal(parameters.max_rank))||...
 end
 if ~isfield(parameters,'rate')
     error('parameters.rate subfield must be present.');
-elseif (~isnumeric(parameters.rate))||(~isreal(parameters.rate))
-    error('parameters.rate must be a real number.');
+elseif (~isnumeric(parameters.rate))||(~isreal(parameters.rate))||...
+       (~isscalar(parameters.rate))||(~isfinite(parameters.rate))||...
+       (parameters.rate<=0)
+    error('parameters.rate must be a positive real scalar.');
 end
 if ~isfield(parameters,'axis')
     error('parameters.axis subfield must be present.');
@@ -199,4 +201,3 @@ end
 % everything you need. 
 %
 % Marcus Tullius Cicero
-

--- a/experiments/hyperpol/solid_effect.m
+++ b/experiments/hyperpol/solid_effect.m
@@ -190,19 +190,21 @@ end
 if numel(parameters.nuclear_frq)~=1
     error('parameters.nuclear_frq array should have exactly one element.');
 end
-if strcmp(parameters.calc_type,'time_dependence')
-    if ~isfield(parameters,'n_steps')
-        error('number of time steps should be specified in parameters.n_steps variable.');
-    end
-    if numel(parameters.n_steps)~=1
-        error('parameters.n_steps array should have exactly one element.');
-    end
-    if ~isfield(parameters,'time_step')
-        error('time step length should be specified in parameters.time_step variable.');
-    end
-    if numel(parameters.time_step)~=1
-        error('parameters.time_step array should have exactly one element.');
-    end
+if ~isfield(parameters,'n_steps')
+    error('number of time steps should be specified in parameters.n_steps variable.');
+end
+if (~isnumeric(parameters.n_steps))||(~isreal(parameters.n_steps))||...
+   (~isscalar(parameters.n_steps))||(~isfinite(parameters.n_steps))||...
+   (parameters.n_steps<1)||(mod(parameters.n_steps,1)~=0)
+    error('parameters.n_steps must be a positive real integer.');
+end
+if ~isfield(parameters,'time_step')
+    error('time step length should be specified in parameters.time_step variable.');
+end
+if (~isnumeric(parameters.time_step))||(~isreal(parameters.time_step))||...
+   (~isscalar(parameters.time_step))||(~isfinite(parameters.time_step))||...
+   (parameters.time_step<=0)
+    error('parameters.time_step must be a positive real scalar.');
 end
 end
 
@@ -213,4 +215,3 @@ end
 % our labs..."
 %
 % Incredulous voice from the audience: "Speak for yourself!"
-

--- a/experiments/imaging/basic_1d_hard.m
+++ b/experiments/imaging/basic_1d_hard.m
@@ -89,6 +89,13 @@ if (~isnumeric(parameters.npts))||(~isreal(parameters.npts))||...
    (mod(parameters.npts,1)~=0)
     error('parameters.npts must be a positive integer.');
 end
+if ~isfield(parameters,'sweep')
+    error('parameters.sweep field must be present.');
+end
+if (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
+   (~isscalar(parameters.sweep))||(parameters.sweep<=0)
+    error('parameters.sweep must be a positive real scalar.');
+end
 if ~isfield(parameters,'rho0')
     error('parameters.rho0 field must be present.');
 end
@@ -116,4 +123,3 @@ end
 % free. As a result, the wild cobra population further increased.
 %
 % Wikipedia
-

--- a/experiments/imaging/epi_2d.m
+++ b/experiments/imaging/epi_2d.m
@@ -131,6 +131,14 @@ end
 if (~iscell(G))||(numel(G)<2)
     error('the G argument must be a cell array with at least two gradient operators.');
 end
+if ~isfield(parameters,'npts')
+    error('parameters.npts field must be present.');
+end
+if (~isnumeric(parameters.npts))||(~isreal(parameters.npts))||...
+   (~isvector(parameters.npts))||any(parameters.npts<1)||...
+   any(mod(parameters.npts,1)~=0)
+    error('parameters.npts must be a vector of positive integers.');
+end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
@@ -203,4 +211,3 @@ end
 % The man is dangerous - he believes what he says.
 %
 % Count de Mirabeau, about Robespierre
-

--- a/experiments/imaging/epi_3d.m
+++ b/experiments/imaging/epi_3d.m
@@ -195,50 +195,147 @@ if (~all(size(H)==size(R)))||...
    (~all(size(K)==size(F)))
     error('H,R,K,F matrices must have the same dimension.');
 end
-if ~iscell(G)
-    error('the G argument must be a cell array.');
+if (~iscell(G))||(numel(G)<3)
+    error('the G argument must be a cell array with at least three gradient operators.');
+end
+if (~isnumeric(G{1}))||(~isnumeric(G{2}))||(~isnumeric(G{3}))
+    error('gradient operators must be numeric matrices.');
+end
+if ~isfield(parameters,'spins')
+    error('parameters.spins field must be present.');
+end
+if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
+    error('parameters.spins must be a cell array containing one spin name.');
+end
+if ~isfield(parameters,'rho0')
+    error('parameters.rho0 field must be present.');
+end
+if (~isnumeric(parameters.rho0))||(~iscolumn(parameters.rho0))||...
+   (size(parameters.rho0,1)~=size(H,1))
+    error('parameters.rho0 must be a state vector of the same dimension as H.');
+end
+if ~isfield(parameters,'coil')
+    error('parameters.coil field must be present.');
+end
+if (~isnumeric(parameters.coil))||(~iscolumn(parameters.coil))||...
+   (size(parameters.coil,1)~=size(H,1))
+    error('parameters.coil must be a state vector of the same dimension as H.');
+end
+if ~isfield(parameters,'npts')
+    error('parameters.npts field must be present.');
+end
+if (~isnumeric(parameters.npts))||(~isreal(parameters.npts))||...
+   (~isvector(parameters.npts))||(numel(parameters.npts)~=3)||...
+   any(~isfinite(parameters.npts))||any(parameters.npts<1)||...
+   any(mod(parameters.npts,1)~=0)
+    error('parameters.npts must be a vector of three positive integers.');
+end
+if ~isfield(parameters,'dims')
+    error('parameters.dims field must be present.');
+end
+if (~isnumeric(parameters.dims))||(~isreal(parameters.dims))||...
+   (~isvector(parameters.dims))||(numel(parameters.dims)~=3)||...
+   any(~isfinite(parameters.dims))||any(parameters.dims<=0)
+    error('parameters.dims must be a vector with three real numbers.');
+end
+if ~isfield(parameters,'image_size')
+    error('parameters.image_size field must be present.');
+end
+if (~isnumeric(parameters.image_size))||(~isreal(parameters.image_size))||...
+   (~isvector(parameters.image_size))||(numel(parameters.image_size)~=2)||...
+   any(~isfinite(parameters.image_size))||any(parameters.image_size<2)||...
+   any(mod(parameters.image_size,1)~=0)
+    error('parameters.image_size must be a vector of two integers greater than one.');
+end
+if ~isfield(parameters,'rf_frq_list')
+    error('parameters.rf_frq_list field must be present.');
+end
+if (~isnumeric(parameters.rf_frq_list))||(~isreal(parameters.rf_frq_list))||...
+   (~isvector(parameters.rf_frq_list))||any(~isfinite(parameters.rf_frq_list))
+    error('parameters.rf_frq_list must be a real vector.');
+end
+if ~isfield(parameters,'rf_amp_list')
+    error('parameters.rf_amp_list field must be present.');
+end
+if (~isnumeric(parameters.rf_amp_list))||(~isreal(parameters.rf_amp_list))||...
+   (~isvector(parameters.rf_amp_list))||any(~isfinite(parameters.rf_amp_list))
+    error('parameters.rf_amp_list must be a real vector.');
+end
+if ~isfield(parameters,'rf_dur_list')
+    error('parameters.rf_dur_list field must be present.');
+end
+if (~isnumeric(parameters.rf_dur_list))||(~isreal(parameters.rf_dur_list))||...
+   (~isvector(parameters.rf_dur_list))||any(~isfinite(parameters.rf_dur_list))||...
+   any(parameters.rf_dur_list<=0)
+    error('parameters.rf_dur_list must be a positive real vector.');
+end
+if ~isfield(parameters,'rf_phi')
+    error('parameters.rf_phi field must be present.');
+end
+if (~isnumeric(parameters.rf_phi))||(~isreal(parameters.rf_phi))||...
+   (~isscalar(parameters.rf_phi))||(~isfinite(parameters.rf_phi))
+    error('parameters.rf_phi must be a real scalar.');
+end
+if (numel(parameters.rf_frq_list)~=numel(parameters.rf_amp_list))||...
+   (numel(parameters.rf_amp_list)~=numel(parameters.rf_dur_list))
+    error('parameters.rf_frq_list, parameters.rf_amp_list, and parameters.rf_dur_list must have the same number of elements.');
 end
 if ~isfield(parameters,'t_echo')
     error('echo time must be specified in parameters.t_echo field.');
 end
 if (~isnumeric(parameters.t_echo))||(~isreal(parameters.t_echo))||...
-   (~isscalar(parameters.t_echo))||(parameters.t_echo<=0)
+   (~isscalar(parameters.t_echo))||(~isfinite(parameters.t_echo))||(parameters.t_echo<=0)
     error('parameters.t_echo must be a positive real scalar.');
-end
-if ~isfield(parameters,'ss_grad_dur')
-    error(' slice selection gradient duration must be specified in parameters.ss_grad_dur field.');
-end
-if (~isnumeric(parameters.ss_grad_dur))||(~isreal(parameters.ss_grad_dur))||...
-   (~isscalar(parameters.ss_grad_dur))||(parameters.ss_grad_dur<=0)
-    error('parameters.ss_grad_dur must be a positive real scalar.');
 end
 if ~isfield(parameters,'ro_grad_dur')
     error('the frequency encoding gradient duration must be specified in parameters.ro_grad_dur field.');
 end
 if (~isnumeric(parameters.ro_grad_dur))||(~isreal(parameters.ro_grad_dur))||...
-   (~isscalar(parameters.ro_grad_dur))||(parameters.ro_grad_dur<=0)
+   (~isscalar(parameters.ro_grad_dur))||(~isfinite(parameters.ro_grad_dur))||...
+   (parameters.ro_grad_dur<=0)
     error('parameters.ro_grad_dur must be a positive real scalar.');
 end
 if ~isfield(parameters,'pe_grad_dur')
     error('the phase encoding gradient duration must be specified in parameters.grad_dur field.');
 end
 if (~isnumeric(parameters.pe_grad_dur))||(~isreal(parameters.pe_grad_dur))||...
-   (~isscalar(parameters.pe_grad_dur))||(parameters.pe_grad_dur<=0)
+   (~isscalar(parameters.pe_grad_dur))||(~isfinite(parameters.pe_grad_dur))||...
+   (parameters.pe_grad_dur<=0)
     error('parameters.pe_grad_dur must be a positive real scalar.');
 end
 if ~isfield(parameters,'ro_grad_amp')
     error('readout gradient amplitude must be specified in parameters.ro_grad_amp field.');
 end
 if (~isnumeric(parameters.ro_grad_amp))||(~isreal(parameters.ro_grad_amp))||...
-   (~isscalar(parameters.ro_grad_amp))
+   (~isscalar(parameters.ro_grad_amp))||(~isfinite(parameters.ro_grad_amp))
     error('parameters.ro_grad_amp must be a real scalar.');
 end
 if ~isfield(parameters,'pe_grad_amp')
     error('phase encoding gradient amplitude must be specified in parameters.pe_grad_amp field.');
 end
 if (~isnumeric(parameters.pe_grad_amp))||(~isreal(parameters.pe_grad_amp))||...
-   (~isscalar(parameters.pe_grad_amp))
+   (~isscalar(parameters.pe_grad_amp))||(~isfinite(parameters.pe_grad_amp))
     error('parameters.pe_grad_amp must be a real scalar.');
+end
+if ~isfield(parameters,'ss_grad_amp')
+    error('slice selection gradient amplitude must be specified in parameters.ss_grad_amp field.');
+end
+if (~isnumeric(parameters.ss_grad_amp))||(~isreal(parameters.ss_grad_amp))||...
+   (~isscalar(parameters.ss_grad_amp))||(~isfinite(parameters.ss_grad_amp))
+    error('parameters.ss_grad_amp must be a real scalar.');
+end
+if isfield(parameters,'diff_g_amp')&&((~isnumeric(parameters.diff_g_amp))||...
+   (~isreal(parameters.diff_g_amp))||(~isvector(parameters.diff_g_amp))||...
+   (numel(parameters.diff_g_amp)~=3)||any(~isfinite(parameters.diff_g_amp)))
+    error('parameters.diff_g_amp must be a vector with three real numbers.');
+end
+if isfield(parameters,'diff_g_amp')&&(~isfield(parameters,'diff_g_dur'))
+    error('parameters.diff_g_dur field must be present when parameters.diff_g_amp is specified.');
+end
+if isfield(parameters,'diff_g_dur')&&((~isnumeric(parameters.diff_g_dur))||...
+   (~isreal(parameters.diff_g_dur))||(~isscalar(parameters.diff_g_dur))||...
+   (~isfinite(parameters.diff_g_dur))||(parameters.diff_g_dur<=0))
+    error('parameters.diff_g_dur must be a positive real scalar.');
 end
 end
 
@@ -247,4 +344,3 @@ end
 % ded from prison officers.
 %
 % Clive James
-

--- a/experiments/imaging/phase_enc_2d.m
+++ b/experiments/imaging/phase_enc_2d.m
@@ -133,6 +133,14 @@ end
 if (~iscell(G))||(numel(G)<2)
     error('the G argument must be a cell array with at least two gradient operators.');
 end
+if ~isfield(parameters,'npts')
+    error('parameters.npts field must be present.');
+end
+if (~isnumeric(parameters.npts))||(~isreal(parameters.npts))||...
+   (~isvector(parameters.npts))||any(parameters.npts<1)||...
+   any(mod(parameters.npts,1)~=0)
+    error('parameters.npts must be a vector of positive integers.');
+end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
@@ -211,4 +219,3 @@ end
 % to being, say, speech police.
 %
 % John Tooby
-

--- a/experiments/imaging/phase_enc_3d.m
+++ b/experiments/imaging/phase_enc_3d.m
@@ -210,13 +210,6 @@ if (~isnumeric(parameters.t_echo))||(~isreal(parameters.t_echo))||...
    (~isscalar(parameters.t_echo))||(parameters.t_echo<=0)
     error('parameters.t_echo must be a positive real scalar.');
 end
-if ~isfield(parameters,'ss_grad_dur')
-    error('slice selection gradient duration must be specified in parameters.ss_grad_dur field.');
-end
-if (~isnumeric(parameters.ss_grad_dur))||(~isreal(parameters.ss_grad_dur))||...
-   (~isscalar(parameters.ss_grad_dur))||(parameters.ss_grad_dur<=0)
-    error('parameters.ss_grad_dur must be a positive real scalar.');
-end
 if ~isfield(parameters,'ro_grad_dur')
     error('readout gradient duration must be specified in parameters.ro_grad_dur field.');
 end
@@ -263,4 +256,3 @@ end
 % fer what they must.
 %
 % Thucydides
-

--- a/experiments/imaging/spiral.m
+++ b/experiments/imaging/spiral.m
@@ -128,6 +128,32 @@ end
 if ~iscell(G)
     error('the G argument must be a cell array.');
 end
+if ~isfield(parameters,'spins')
+    error('parameters.spins field must be present.');
+end
+if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
+    error('parameters.spins must be a cell array containing one spin name.');
+end
+if ~isfield(parameters,'npts')
+    error('parameters.npts field must be present.');
+end
+if (~isnumeric(parameters.npts))||(~isreal(parameters.npts))||...
+   (~isvector(parameters.npts))||any(parameters.npts<1)||...
+   any(mod(parameters.npts,1)~=0)
+    error('parameters.npts must be a vector of positive integers.');
+end
+if ~isfield(parameters,'rho0')
+    error('parameters.rho0 field must be present.');
+end
+if ~isnumeric(parameters.rho0)
+    error('parameters.rho0 must be numeric.');
+end
+if ~isfield(parameters,'coil')
+    error('parameters.coil field must be present.');
+end
+if ~isnumeric(parameters.coil)
+    error('parameters.coil must be numeric.');
+end
 if ~isfield(parameters,'t_echo')
     error('echo time must be specified in parameters.t_echo field.');
 end
@@ -156,9 +182,16 @@ if (~isnumeric(parameters.grad_amp))||(~isreal(parameters.grad_amp))||...
    (~isscalar(parameters.grad_amp))
     error('parameters.grad_amp must be a real scalar.');
 end
+if ~isfield(parameters,'spiral_npts')
+    error('number of spiral points must be specified in parameters.spiral_npts field.');
+end
+if (~isnumeric(parameters.spiral_npts))||(~isreal(parameters.spiral_npts))||...
+   (~isscalar(parameters.spiral_npts))||(parameters.spiral_npts<1)||...
+   (mod(parameters.spiral_npts,1)~=0)
+    error('parameters.spiral_npts must be a positive real integer.');
+end
 end
 
 % According to a local legend at Oxford's Magdalen College, during the
 % the Second World War meat shortages, the College's deer were reclass-
 % ified as vegetables to avoid requisition by the Ministry of Food.
-

--- a/experiments/nmr_solids/mqmas.m
+++ b/experiments/nmr_solids/mqmas.m
@@ -58,7 +58,7 @@ rho=step(spin_system,L+parameters.pulse_amp(1)*Lx,...
 rho=coherence(spin_system,rho,{{parameters.spins{1},parameters.mq_order}});
 
 % Run the indirect dimension evolution
-rho_stack=evolution(spin_system,L,[],rho,1/parameters.rate,...
+rho_stack=evolution(spin_system,L,[],rho,1/parameters.sweep,...
                     parameters.npoints(1)-1,'trajectory');
                 
 % Run the second pulse
@@ -69,7 +69,7 @@ rho_stack=step(spin_system,L+parameters.pulse_amp(2)*Lx,...
 rho_stack=coherence(spin_system,rho_stack,{{parameters.spins{1},+1}});
 
 % Run the direct dimension evolution
-fid=evolution(spin_system,L,parameters.coil,rho_stack,1/parameters.rate,...
+fid=evolution(spin_system,L,parameters.coil,rho_stack,1/parameters.sweep,...
                             parameters.npoints(2)-1,'observable');
 
 end
@@ -174,4 +174,3 @@ end
 % Trust not the telly, trust the fridge.
 %
 % A Russian saying
-

--- a/experiments/nmr_solids/mqmas.m
+++ b/experiments/nmr_solids/mqmas.m
@@ -58,7 +58,7 @@ rho=step(spin_system,L+parameters.pulse_amp(1)*Lx,...
 rho=coherence(spin_system,rho,{{parameters.spins{1},parameters.mq_order}});
 
 % Run the indirect dimension evolution
-rho_stack=evolution(spin_system,L,[],rho,1/parameters.sweep,...
+rho_stack=evolution(spin_system,L,[],rho,1/parameters.rate,...
                     parameters.npoints(1)-1,'trajectory');
                 
 % Run the second pulse
@@ -69,7 +69,7 @@ rho_stack=step(spin_system,L+parameters.pulse_amp(2)*Lx,...
 rho_stack=coherence(spin_system,rho_stack,{{parameters.spins{1},+1}});
 
 % Run the direct dimension evolution
-fid=evolution(spin_system,L,parameters.coil,rho_stack,1/parameters.sweep,...
+fid=evolution(spin_system,L,parameters.coil,rho_stack,1/parameters.rate,...
                             parameters.npoints(2)-1,'observable');
 
 end
@@ -174,3 +174,4 @@ end
 % Trust not the telly, trust the fridge.
 %
 % A Russian saying
+

--- a/experiments/pseudocon/ipcs.m
+++ b/experiments/pseudocon/ipcs.m
@@ -494,6 +494,12 @@ end
 if ~ismember(parameters.equation,{'kuprov','poisson'})
     error('parameters.equation may be set to ''kuprov'' and ''poisson''.');
 end
+if ~isfield(parameters,'gpu')
+    error('GPU execution flag must be specified in parameters.gpu field.');
+end
+if (~islogical(parameters.gpu))||(~isscalar(parameters.gpu))
+    error('parameters.gpu must be a logical scalar.');
+end
 if ~isfield(parameters,'xyz')
     error('coordinates of PCS active nuclei must be provided in parameters.xyz field.');
 elseif (~isnumeric(parameters.xyz))||(~isreal(parameters.xyz))||(size(parameters.xyz,2)~=3)
@@ -563,4 +569,3 @@ end
 % I move on to the next thing.
 %
 % James Cameron
-

--- a/experiments/pseudocon/lpcs.m
+++ b/experiments/pseudocon/lpcs.m
@@ -103,25 +103,29 @@ end
 
 % Consistency enforcement
 function grumble(nxyz,mxyz,L,Ilm,chi)
-if (~isnumeric(nxyz))||(~isreal(nxyz))||(size(nxyz,2)~=3)
+if (~isnumeric(nxyz))||(~isreal(nxyz))||any(~isfinite(nxyz(:)))||(size(nxyz,2)~=3)
     error('nxyz must be an Nx3 array of atomic coordinates.');
 end
-if (~isnumeric(mxyz))||(size(mxyz,2)~=3)||(size(mxyz,1)~=1)||(~isreal(mxyz))
+if (~isnumeric(mxyz))||(size(mxyz,2)~=3)||(size(mxyz,1)~=1)||...
+   (~isreal(mxyz))||any(~isfinite(mxyz(:)))
     error('mxyz parameter should be a real row vector with three elements.');
 end
-if (~isnumeric(L))||(~isreal(L))
-    error('L must be a real vector.');
+if (~isnumeric(L))||(~isreal(L))||(~isvector(L))||any(~isfinite(L(:)))||...
+   any(L(:)<0)||any(mod(L(:),1)~=0)
+    error('L must be a vector of non-negative integers.');
 end
-if (~isnumeric(chi))||(~isreal(chi))
-    error('chi should be a real');
+if (~isnumeric(chi))||(~isreal(chi))||any(~isfinite(chi(:)))||...
+   (~isequal(size(chi),[3 3])&&(~isvector(chi)||numel(chi)~=5))
+    error('chi must be a real 3x3 matrix or a five-element vector.');
 end
 if (~iscell(Ilm))||(numel(Ilm)~=numel(L))
-    error('Ilm should be a vell array of the same size as L')
+    error('Ilm should be a cell array of the same size as L.');
 end
 for n=1:numel(L)
     l=L(n);
-    if (size(Ilm{n})~=(2*l+1))
-        error('Ilm{n} should have 2*L(n)+1 elements')
+    if (~isnumeric(Ilm{n}))||(~isreal(Ilm{n}))||any(~isfinite(Ilm{n}(:)))||...
+       (numel(Ilm{n})~=(2*l+1))
+        error('Ilm{n} should be a real vector with 2*L(n)+1 elements.');
     end
 end
 end
@@ -131,4 +135,3 @@ end
 % thing that was tested and found working, is working.
 %
 % Unknown source
-

--- a/experiments/pseudocon/pcs_combi_fit.m
+++ b/experiments/pseudocon/pcs_combi_fit.m
@@ -165,6 +165,14 @@ end
 if ~isfield(parameters,'spin_groups')
     error('parameters.spin_groups field is missing.');
 end
+if ~isfield(parameters,'nel')
+    error('parameters.nel field is missing.');
+end
+if (~isnumeric(parameters.nel))||(~isreal(parameters.nel))||...
+   (~isscalar(parameters.nel))||(~isfinite(parameters.nel))||...
+   (parameters.nel<1)||(mod(parameters.nel,1)~=0)
+    error('parameters.nel must be a positive real integer.');
+end
 if ~isfield(parameters,'d_shifts')
     error('parameters.d_shifts field is missing.');
 end
@@ -183,4 +191,3 @@ end
 % process of digestion?
 %
 % Oliver Heaviside
-

--- a/experiments/spen/idosyzs.m
+++ b/experiments/spen/idosyzs.m
@@ -193,5 +193,7 @@ if ~isfield(parameters,'delta_sml')
 elseif numel(parameters.delta_sml)~=1
     error('parameters.delta_sml array should have exactly one element.');
 end
+if parameters.delta_big<=parameters.delta_sml+parameters.rf_dur
+    error('parameters.delta_big must exceed parameters.delta_sml+parameters.rf_dur.');
 end
-
+end

--- a/experiments/spen/psyche.m
+++ b/experiments/spen/psyche.m
@@ -143,30 +143,117 @@ end
 if ~iscell(G)
     error('the G must be a 1x3 cell array.');
 end
+if numel(G)~=3
+    error('G must contain three gradient operators.');
+end
+if (~isnumeric(G{1}))||(~isnumeric(G{2}))||(~isnumeric(G{3}))
+    error('gradient operators must be numeric matrices.');
+end
 if ~isfield(parameters,'g_amp')
     error('the gradient amplitude should be specified in parameters.g_amp variable.');
-elseif numel(parameters.g_amp)~=1
-    error('parameters.g_amp array should have exactly one element.');
+elseif (~isnumeric(parameters.g_amp))||(~isreal(parameters.g_amp))||...
+       (numel(parameters.g_amp)~=1)||(~isfinite(parameters.g_amp))
+    error('parameters.g_amp must be a finite real scalar.');
 end
 if ~isfield(parameters,'dims')
     error('sample dimension should be specified in parameters.dims variable.');
-elseif numel(parameters.dims)~=1
-    error('parameters.dims array should have exactly one element.');
+elseif (~isnumeric(parameters.dims))||(~isreal(parameters.dims))||...
+       (numel(parameters.dims)~=1)||(~isfinite(parameters.dims))||(parameters.dims<=0)
+    error('parameters.dims must be a positive real scalar.');
 end
 if ~isfield(parameters,'npts')
     error('number of spin packets should be specified in parameters.npts variable.');
-elseif numel(parameters.npts)~=1
-    error('parameters.npts array should have exactly one element.');
+elseif (~isnumeric(parameters.npts))||(~isreal(parameters.npts))||...
+       (numel(parameters.npts)~=1)||(~isfinite(parameters.npts))||...
+       (parameters.npts<1)||(mod(parameters.npts,1)~=0)
+    error('parameters.npts must be a positive integer scalar.');
 end
 if ~isfield(parameters,'spins')
     error('working spins should be specified in parameters.spins variable.');
-elseif numel(parameters.spins)~=1
-    error('parameters.spins cell array should have exactly one element.');
+elseif (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||...
+       (~ischar(parameters.spins{1}))
+    error('parameters.spins must be a one-element cell array of character strings.');
 end
 if ~isfield(parameters,'diff')
     error('the diffusion coefficient should specified in parameters.diff variable.');
-elseif numel(parameters.diff)~=1
-    error('parameters.diff array should have exactly one element.');
+elseif (~isnumeric(parameters.diff))||(~isreal(parameters.diff))||...
+       (numel(parameters.diff)~=1)||(~isfinite(parameters.diff))||(parameters.diff<0)
+    error('parameters.diff must be a non-negative real scalar.');
+end
+if ~isfield(parameters,'rho0')
+    error('initial state should be specified in parameters.rho0 variable.');
+elseif (~isnumeric(parameters.rho0))||(~iscolumn(parameters.rho0))||...
+       (size(parameters.rho0,1)~=size(H,1))
+    error('parameters.rho0 must be a state vector of the same dimension as H.');
+end
+if ~isfield(parameters,'coil')
+    error('detection state should be specified in parameters.coil variable.');
+elseif (~isnumeric(parameters.coil))||(~iscolumn(parameters.coil))||...
+       (size(parameters.coil,1)~=size(H,1))
+    error('parameters.coil must be a state vector of the same dimension as H.');
+end
+if ~isfield(parameters,'npoints')
+    error('point counts should be specified in parameters.npoints variable.');
+elseif (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+       (numel(parameters.npoints)~=2)||any(~isfinite(parameters.npoints))||...
+       any(parameters.npoints<2)||any(mod(parameters.npoints,1)~=0)
+    error('parameters.npoints must contain two integer elements greater than 1.');
+end
+if ~isfield(parameters,'pulsenpoints')
+    error('chirp pulse point count should be specified in parameters.pulsenpoints variable.');
+elseif (~isnumeric(parameters.pulsenpoints))||(~isreal(parameters.pulsenpoints))||...
+       (numel(parameters.pulsenpoints)~=1)||(~isfinite(parameters.pulsenpoints))||...
+       (parameters.pulsenpoints<1)||(mod(parameters.pulsenpoints,1)~=0)
+    error('parameters.pulsenpoints must be a positive integer scalar.');
+end
+if ~isfield(parameters,'duration')
+    error('pulse duration should be specified in parameters.duration variable.');
+elseif (~isnumeric(parameters.duration))||(~isreal(parameters.duration))||...
+       (numel(parameters.duration)~=1)||(~isfinite(parameters.duration))||(parameters.duration<=0)
+    error('parameters.duration must be a positive real scalar.');
+end
+if ~isfield(parameters,'bandwidth')
+    error('pulse bandwidth should be specified in parameters.bandwidth variable.');
+elseif (~isnumeric(parameters.bandwidth))||(~isreal(parameters.bandwidth))||...
+       (numel(parameters.bandwidth)~=1)||(~isfinite(parameters.bandwidth))||(parameters.bandwidth<=0)
+    error('parameters.bandwidth must be a positive real scalar.');
+end
+if ~isfield(parameters,'smfactor')
+    error('chirp smoothing factor should be specified in parameters.smfactor variable.');
+elseif (~isnumeric(parameters.smfactor))||(~isreal(parameters.smfactor))||...
+       (numel(parameters.smfactor)~=1)||(~isfinite(parameters.smfactor))
+    error('parameters.smfactor must be a finite real scalar.');
+end
+if ~isfield(parameters,'chirptype')
+    error('chirp type should be specified in parameters.chirptype variable.');
+elseif (~ischar(parameters.chirptype))||(~ismember(parameters.chirptype,{'wurst','wurst-adaptive',...
+                                                                        'smoothed','smoothed-adaptive',...
+                                                                        'saltire','saltire-adaptive'}))
+    error('parameters.chirptype must be a supported chirp pulse type.');
+end
+if ~isfield(parameters,'beta')
+    error('flip angle should be specified in parameters.beta variable.');
+elseif (~isnumeric(parameters.beta))||(~isreal(parameters.beta))||...
+       (numel(parameters.beta)~=1)||(~isfinite(parameters.beta))
+    error('parameters.beta must be a finite real scalar.');
+end
+if ~isfield(parameters,'timestep1')
+    error('first evolution timestep should be specified in parameters.timestep1 variable.');
+elseif (~isnumeric(parameters.timestep1))||(~isreal(parameters.timestep1))||...
+       (numel(parameters.timestep1)~=1)||(~isfinite(parameters.timestep1))||(parameters.timestep1<=0)
+    error('parameters.timestep1 must be a positive real scalar.');
+end
+if ~isfield(parameters,'timestep2')
+    error('second evolution timestep should be specified in parameters.timestep2 variable.');
+elseif (~isnumeric(parameters.timestep2))||(~isreal(parameters.timestep2))||...
+       (numel(parameters.timestep2)~=1)||(~isfinite(parameters.timestep2))||(parameters.timestep2<=0)
+    error('parameters.timestep2 must be a positive real scalar.');
+end
+if ~isfield(parameters,'delta')
+    error('diffusion delay should be specified in parameters.delta variable.');
+elseif (~isnumeric(parameters.delta))||(~isreal(parameters.delta))||...
+       (numel(parameters.delta)~=1)||(~isfinite(parameters.delta))||(parameters.delta<0)
+    error('parameters.delta must be a non-negative real scalar.');
 end
 end
 
@@ -176,4 +263,3 @@ end
 % ting risk is no virtue.
 %
 % Neil Armstrong
-

--- a/experiments/spen/psycosy.m
+++ b/experiments/spen/psycosy.m
@@ -153,45 +153,93 @@ end
 if ~iscell(G)
     error('the G must be a 1x3 cell array.');
 end
+if numel(G)~=3
+    error('G must contain three gradient operators.');
+end
+if (~isnumeric(G{1}))||(~isnumeric(G{2}))||(~isnumeric(G{3}))
+    error('gradient operators must be numeric matrices.');
+end
 if ~isfield(parameters,'gamp')
     error('the gradient amplitude should be specified in parameters.gamp variable.');
-elseif numel(parameters.gamp)~=1
-    error('parameters.gamp array should have exactly one element.');
+elseif (~isnumeric(parameters.gamp))||(~isreal(parameters.gamp))||...
+       (numel(parameters.gamp)~=1)||(~isfinite(parameters.gamp))
+    error('parameters.gamp must be a finite real scalar.');
 end
 if ~isfield(parameters,'spins')
     error('working spins should be specified in parameters.spins variable.');
-elseif numel(parameters.spins)~=1
-    error('parameters.spins cell array should have exactly one element.');
+elseif (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||...
+       (~ischar(parameters.spins{1}))
+    error('parameters.spins must be a one-element cell array of character strings.');
+end
+if ~isfield(parameters,'rho0')
+    error('initial state should be specified in parameters.rho0 variable.');
+elseif (~isnumeric(parameters.rho0))||(~iscolumn(parameters.rho0))||...
+       (size(parameters.rho0,1)~=size(H,1))
+    error('parameters.rho0 must be a state vector of the same dimension as H.');
+end
+if ~isfield(parameters,'coil')
+    error('detection state should be specified in parameters.coil variable.');
+elseif (~isnumeric(parameters.coil))||(~iscolumn(parameters.coil))||...
+       (size(parameters.coil,1)~=size(H,1))
+    error('parameters.coil must be a state vector of the same dimension as H.');
+end
+if ~isfield(parameters,'sweep')
+    error('sweep width should be specified in parameters.sweep variable.');
+elseif (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
+       (numel(parameters.sweep)~=1)||(~isfinite(parameters.sweep))||(parameters.sweep<=0)
+    error('parameters.sweep must be a positive real scalar.');
+end
+if ~isfield(parameters,'npoints')
+    error('point counts should be specified in parameters.npoints variable.');
+elseif (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+       (numel(parameters.npoints)~=2)||any(~isfinite(parameters.npoints))||...
+       any(parameters.npoints<2)||any(mod(parameters.npoints,1)~=0)
+    error('parameters.npoints must contain two integer elements greater than 1.');
+end
+if ~isfield(parameters,'tmix')
+    error('mixing time should be specified in parameters.tmix variable.');
+elseif (~isnumeric(parameters.tmix))||(~isreal(parameters.tmix))||...
+       (numel(parameters.tmix)~=1)||(~isfinite(parameters.tmix))||(parameters.tmix<0)
+    error('parameters.tmix must be a non-negative real scalar.');
 end
 if ~isfield(parameters,'sal_ang')
     error('saltire flip angle should be specified in parameters.sal_ang variable.');
-elseif numel(parameters.sal_ang)~=1
-    error('parameters.sal_ang array should have exactly one element.');
+elseif (~isnumeric(parameters.sal_ang))||(~isreal(parameters.sal_ang))||...
+       (numel(parameters.sal_ang)~=1)||(~isfinite(parameters.sal_ang))
+    error('parameters.sal_ang must be a finite real scalar.');
 end
 if ~isfield(parameters,'sal_dur')
     error('saltire duration should be specified in parameters.sal_dur variable.');
-elseif numel(parameters.sal_dur)~=1
-    error('parameters.sal_dur array should have exactly one element.');
+elseif (~isnumeric(parameters.sal_dur))||(~isreal(parameters.sal_dur))||...
+       (numel(parameters.sal_dur)~=1)||(~isfinite(parameters.sal_dur))||(parameters.sal_dur<=0)
+    error('parameters.sal_dur must be a positive real scalar.');
 end
 if ~isfield(parameters,'sal_del')
     error('gradient duration should be specified in parameters.sal_del variable.');
-elseif numel(parameters.sal_del)~=1
-    error('parameters.sal_del array should have exactly one element.');
+elseif (~isnumeric(parameters.sal_del))||(~isreal(parameters.sal_del))||...
+       (numel(parameters.sal_del)~=1)||(~isfinite(parameters.sal_del))||...
+       (parameters.sal_del<=2*parameters.sal_dur)
+    error('parameters.sal_del must be a real scalar greater than twice parameters.sal_dur.');
 end
 if ~isfield(parameters,'sal_swp')
     error('saltire sweep width should be specified in parameters.sal_swp variable.');
-elseif numel(parameters.sal_swp)~=1
-    error('parameters.sal_swp array should have exactly one element.');
+elseif (~isnumeric(parameters.sal_swp))||(~isreal(parameters.sal_swp))||...
+       (numel(parameters.sal_swp)~=1)||(~isfinite(parameters.sal_swp))||(parameters.sal_swp<=0)
+    error('parameters.sal_swp must be a positive real scalar.');
 end
 if ~isfield(parameters,'sal_npt')
     error('saltire point count should be specified in parameters.sal_npt variable.');
-elseif numel(parameters.sal_npt)~=1
-    error('parameters.sal_npt array should have exactly one element.');
+elseif (~isnumeric(parameters.sal_npt))||(~isreal(parameters.sal_npt))||...
+       (numel(parameters.sal_npt)~=1)||(~isfinite(parameters.sal_npt))||...
+       (parameters.sal_npt<1)||(mod(parameters.sal_npt,1)~=0)
+    error('parameters.sal_npt must be a positive integer scalar.');
 end
 if ~isfield(parameters,'sal_smf')
-    error('saltire smoothing factor should be specified in parameters.sal_swp variable.');
-elseif numel(parameters.sal_smf)~=1
-    error('parameters.sal_smf array should have exactly one element.');
+    error('saltire smoothing factor should be specified in parameters.sal_smf variable.');
+elseif (~isnumeric(parameters.sal_smf))||(~isreal(parameters.sal_smf))||...
+       (numel(parameters.sal_smf)~=1)||(~isfinite(parameters.sal_smf))||...
+       (parameters.sal_smf<0)||(parameters.sal_smf>50)
+    error('parameters.sal_smf must be a real scalar between 0 and 50.');
 end
 end
 
@@ -202,4 +250,3 @@ end
 % beings of their humanity.
 % 
 % Seth Lloyd
-

--- a/experiments/spin_chem/rydmr_exp.m
+++ b/experiments/spin_chem/rydmr_exp.m
@@ -133,6 +133,12 @@ end
 if spin_system.inter.magnet~=1
     error('unit magnet specification (sys.magnet=1) is required for field sweep experiments.');
 end
+if ~isfield(parameters,'needs')
+    error('parameters.needs must be specified.');
+end
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+    error('parameters.needs must be a cell array of character strings.');
+end
 if ~ismember('zeeman_op',parameters.needs)
     error('this function requires a separate Zeeman operator, add ''zeeman_op'' to parameters.needs'); 
 end
@@ -145,7 +151,8 @@ end
 if ~isfield(parameters,'rates')
     error('singlet recombination rates must be supplied in parameters.rates variable.');
 end
-if (~isnumeric(parameters.rates))||(~isreal(parameters.rates))||any(parameters.rates<0)
+if (~isnumeric(parameters.rates))||(~isreal(parameters.rates))||...
+   any(parameters.rates<=0)
     error('parameters.rates must be a vector of positive real numbers.');
 end
 if ~isfield(parameters,'electrons')
@@ -169,4 +176,3 @@ end
 % fools.
 %
 % Douglas Adams
-

--- a/interfaces/comsol/conc_plot.m
+++ b/interfaces/comsol/conc_plot.m
@@ -37,19 +37,11 @@
 
 function conc_plot(spin_system,conc,obs)
 
-% Initialise empty observables
-if ~exist('obs','var'), obs=[]; end
-
 % Check consistency
 grumble(spin_system,conc,obs);
 
 % Decide the colours
-if isempty(obs)
-    
-    % Neutral grey if no observables supplied
-    RGB=0.5*ones(spin_system.mesh.vor.ncells,3);
-
-elseif size(obs,2)==1
+if size(obs,2)==1
 
     % One observable: assume phase and map into middle hues
     RGB=hsv2rgb(wrapTo2Pi(obs)/(2*pi),...
@@ -178,9 +170,9 @@ if (~isnumeric(conc))||(~isreal(conc))||(~iscolumn(conc))||...
    any(~isfinite(conc))||(numel(conc)~=spin_system.mesh.vor.ncells)
     error('conc must be a column vector with one real value per Voronoi cell.');
 end
-if (~isempty(obs))&&((~isnumeric(obs))||(~isreal(obs))||...
+if (~isnumeric(obs))||(~isreal(obs))||...
    any(~isfinite(obs(:)))||(size(obs,1)~=spin_system.mesh.vor.ncells)||...
-   (size(obs,2)<1)||(size(obs,2)>3))
+   (size(obs,2)<1)||(size(obs,2)>3)
     error('obs must have one, two, or three real columns and one row per Voronoi cell.');
 end
 end

--- a/interfaces/comsol/conc_plot.m
+++ b/interfaces/comsol/conc_plot.m
@@ -37,8 +37,14 @@
 
 function conc_plot(spin_system,conc,obs)
 
+% Initialise empty observables
+if ~exist('obs','var'), obs=[]; end
+
+% Check consistency
+grumble(spin_system,conc,obs);
+
 % Decide the colours
-if ~exist('obs','var')
+if isempty(obs)
     
     % Neutral grey if no observables supplied
     RGB=0.5*ones(spin_system.mesh.vor.ncells,3);
@@ -70,9 +76,6 @@ else
     error('incorrect number of colour mapped observables.');
 
 end
-
-% Check consistency
-grumble(spin_system,conc);
 
 % Loop over cells
 V=zeros(0,3); patch_idx=0; FRGB=ones(0,3);
@@ -155,16 +158,30 @@ patch('Faces',F,'Vertices',V,'FaceColor','flat',...
 end
 
 % Consistency enforcement
-function grumble(spin_system,conc)
+function grumble(spin_system,conc,obs)
 if ~isfield(spin_system,'mesh')
     error('mesh information is missing from the spin_system structure.');
 end
 if ~isfield(spin_system.mesh,'vor')
     error('Voronoi tessellation information is missing from spin_system.mesh structure.');
 end
+if (~isfield(spin_system.mesh,'zext'))||(~isnumeric(spin_system.mesh.zext))||...
+   (~isreal(spin_system.mesh.zext))||(numel(spin_system.mesh.zext)~=2)||...
+   any(~isfinite(spin_system.mesh.zext))
+    error('spin_system.mesh.zext must be a real two-element vector.');
+end
+if (~isfield(spin_system.mesh.vor,'ncells'))||(~isfield(spin_system.mesh.vor,'cells'))||...
+   (~isfield(spin_system.mesh.vor,'vertices'))||(~isfield(spin_system.mesh.vor,'max_cell_size'))
+    error('Voronoi tessellation information is incomplete.');
+end
 if (~isnumeric(conc))||(~isreal(conc))||(~iscolumn(conc))||...
-   (numel(conc)~=spin_system.mesh.vor.ncells)
+   any(~isfinite(conc))||(numel(conc)~=spin_system.mesh.vor.ncells)
     error('conc must be a column vector with one real value per Voronoi cell.');
+end
+if (~isempty(obs))&&((~isnumeric(obs))||(~isreal(obs))||...
+   any(~isfinite(obs(:)))||(size(obs,1)~=spin_system.mesh.vor.ncells)||...
+   (size(obs,2)<1)||(size(obs,2)>3))
+    error('obs must have one, two, or three real columns and one row per Voronoi cell.');
 end
 end
 
@@ -172,4 +189,3 @@ end
 %
 % Vikings, about Christians,
 % in The Northman (2022)
-

--- a/interfaces/g2spinach.m
+++ b/interfaces/g2spinach.m
@@ -92,6 +92,7 @@
 function [sys,inter]=g2spinach(props,particles,references,options)
 
 % Set default options
+if ~exist('references','var'), references=[]; end
 if ~exist('options','var'), options=[]; end
 
 % Check consistency
@@ -272,7 +273,7 @@ end
 if ~iscell(nuclei)
     error('the second argument must have the form {{''H'',''1H''},{''C'',''13C''},...}');
 end
-if (~isnumeric(references))||(numel(nuclei)~=numel(references))
+if (~isempty(references))&&((~isnumeric(references))||(numel(nuclei)~=numel(references)))
     error('references must be a numerical array with the same number of entries as nuclei.');
 end
 end
@@ -286,4 +287,3 @@ end
 %
 % A sign, first reported in 1955
 % at an IBM computing facility
-

--- a/interfaces/g2spinach.m
+++ b/interfaces/g2spinach.m
@@ -92,7 +92,6 @@
 function [sys,inter]=g2spinach(props,particles,references,options)
 
 % Set default options
-if ~exist('references','var'), references=[]; end
 if ~exist('options','var'), options=[]; end
 
 % Check consistency
@@ -273,7 +272,7 @@ end
 if ~iscell(nuclei)
     error('the second argument must have the form {{''H'',''1H''},{''C'',''13C''},...}');
 end
-if (~isempty(references))&&((~isnumeric(references))||(numel(nuclei)~=numel(references)))
+if (~isnumeric(references))||(numel(nuclei)~=numel(references))
     error('references must be a numerical array with the same number of entries as nuclei.');
 end
 end

--- a/interfaces/gaussian/gparse.m
+++ b/interfaces/gaussian/gparse.m
@@ -382,6 +382,9 @@ end
 
 % Consistency enforcement
 function grumble(filename,options)
+if (~ischar(filename))||isempty(filename)
+    error('filename must be a non-empty character string.');
+end
 if ~exist(filename,'file')
     error('the file specified was not found.');
 end
@@ -396,4 +399,3 @@ end
 % Moral indignation is jealousy with a halo.
 % 
 % H.G. Wells
-

--- a/interfaces/gissmo/gissmo2spinach.m
+++ b/interfaces/gissmo/gissmo2spinach.m
@@ -190,6 +190,9 @@ end
 
 % Consistency enforcement
 function grumble(filename)
+if (~ischar(filename))||isempty(filename)
+    error('filename must be a non-empty character string.');
+end
 if ~exist(filename,'file')
     error('the file specified was not found.');
 end
@@ -200,4 +203,3 @@ end
 % are identical. 
 %
 % Enoch Powell
-

--- a/interfaces/orca/ocparse.m
+++ b/interfaces/orca/ocparse.m
@@ -72,6 +72,9 @@ end
 
 % Consistency enforcement
 function grumble(filename,pad_factor)
+if (~ischar(filename))||isempty(filename)
+    error('filename must be a non-empty character string.');
+end
 if ~exist(filename,'file')
     error('the file specified as not found.');
 end
@@ -89,4 +92,3 @@ end
 % means that 'my ignorance is just as good as your knowledge'. 
 %
 % Isaac Asimov
-

--- a/interfaces/pdb_bmrb/read_pdb_pro.m
+++ b/interfaces/pdb_bmrb/read_pdb_pro.m
@@ -85,6 +85,7 @@ if ~ischar(pdb_file_name)
     error('pdb_file_name must be a character string.');
 end
 if (~isnumeric(mod_id))||(~isreal(mod_id))||...
+   (~isscalar(mod_id))||(~isfinite(mod_id))||...
    (mod_id<1)||(mod(mod_id,1)~=0)
     error('mod_id must be a positive real integer.');
 end
@@ -105,4 +106,3 @@ end
 % General Director of Hell's Music - Wagner!
 %
 % J.L. Klein, "Geschichte des Dramas", 1871.
-

--- a/interfaces/spinjet/awg_interface.m
+++ b/interfaces/spinjet/awg_interface.m
@@ -69,7 +69,7 @@ switch awg_cmd
         % Compile the definitions file defined in cmd_input
         py_run(spin_system,'Xepr_plsspel_deffile',cmd_input);
         
-    case {'ompile_pspel_exp'}
+    case {'compile_pspel_exp'}
         
         % Compile the experiment file defined in cmd_input
         py_run(spin_system,'Xepr_plsspel_expfile',cmd_input);
@@ -113,7 +113,7 @@ end
 if ismember(awg_cmd,{'acquire_data'}) && numel(cmd_input)~=3
     error('cmd_input should contain 3 strings when acquire_data is used')
 end
-if ismember(awg_cmd,{'modify_pspel_defs'}) && (numel(cmd_input)<2 || mod(numel(cmd_inputs),2)~=0)
+if ismember(awg_cmd,{'modify_pspel_defs'}) && (numel(cmd_input)<2 || mod(numel(cmd_input),2)~=0)
     error('must provide input cell array of even number of elements to modify definitions')
 end
 if ismember(awg_cmd,{'compile_pspel_exp'}) && numel(cmd_input)~=1
@@ -138,4 +138,3 @@ end
 % If you want to help a fool - you are a fool too.
 %
 % A Russian saying
-

--- a/interfaces/spinjet/py_run.m
+++ b/interfaces/spinjet/py_run.m
@@ -86,11 +86,12 @@ if isempty(spin_system)||(~isfield(spin_system,'sys'))||...
     error('spinach root directory must be supplied within spin_system.sys.root')
 end
 if isempty(py_script_str)||(~ischar(py_script_str))
-   if ~exist([spin_system.sys.root_dir filesep 'interfaces' filesep 'spinjet' filesep ...
-                                               'Xepr_python' filesep py_script_str '.py'],'file') 
-       error([spin_system.sys.root_dir filesep 'interfaces' filesep 'spinjet' filesep ...
-                                               'Xepr_python' filesep py_script_str '.py does not exist']);
-   end
+   error('py_script_str must be a non-empty character string.');
+end
+if ~exist([spin_system.sys.root_dir filesep 'interfaces' filesep 'spinjet' filesep ...
+                                            'Xepr_python' filesep py_script_str '.py'],'file')
+    error([spin_system.sys.root_dir filesep 'interfaces' filesep 'spinjet' filesep ...
+                                            'Xepr_python' filesep py_script_str '.py does not exist']);
 end
 if ~iscell(python_inputs)
     error(['python_inputs should be a cell array of all inputs to python script ' py_script_str '.py'])
@@ -117,4 +118,3 @@ end
 % specimen No. 1256.
 %
 % Richard Gordon
-

--- a/interfaces/spinxml/parsexml.m
+++ b/interfaces/spinxml/parsexml.m
@@ -101,6 +101,9 @@ end
 
 % Consistency enforcement
 function grumble(filename)
+if (~ischar(filename))||isempty(filename)
+    error('filename must be a non-empty character string.');
+end
 if ~exist(filename,'file')
     error('the file specified as not found.');
 end
@@ -132,4 +135,3 @@ end
 % pens, then this is the end of this affair and it goes not further."
 %
 % (IK still thinks that Bloch equations belong to classical physics.)
-

--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -861,6 +861,9 @@ end
 
 % Consistency enforcement
 function grumble(filename,shielding_refs)
+if (~ischar(filename))||isempty(filename)
+    error('filename must be a non-empty character string.');
+end
 if ~exist(filename,'file')
     error('the specified file was not found.');
 end
@@ -887,4 +890,3 @@ end
 % annoyance to those of us who do.
 %
 % Isaac Asimov
-

--- a/kernel/cache/cacheman.m
+++ b/kernel/cache/cacheman.m
@@ -73,6 +73,15 @@ function grumble(spin_system)
 if (~isfield(spin_system,'sys'))||(~isfield(spin_system.sys,'scratch'))
     error('the spin_system object does not specify scratch location.');
 end
+if (~ischar(spin_system.sys.scratch))||isempty(spin_system.sys.scratch)
+    error('scratch location must be a character string.');
+end
+if (~isfield(spin_system,'tols'))||(~isfield(spin_system.tols,'cache_mem'))||...
+   (~isnumeric(spin_system.tols.cache_mem))||(~isreal(spin_system.tols.cache_mem))||...
+   (~isscalar(spin_system.tols.cache_mem))||(~isfinite(spin_system.tols.cache_mem))||...
+   (spin_system.tols.cache_mem<0)
+    error('spin_system.tols.cache_mem must be a finite non-negative real scalar.');
+end
 if ~exist(spin_system.sys.scratch,'dir')
     report(spin_system,'expected scratch directory location:');
     report(spin_system,spin_system.sys.scratch);
@@ -91,4 +100,3 @@ end
 % unced "Eee-sing", is almost universally mispronounced "Eye-sing".
 %
 % Barry Simon
-

--- a/kernel/coherence.m
+++ b/kernel/coherence.m
@@ -101,7 +101,7 @@ end
 if ~isnumeric(rho)
     error('the state vector(s) must be numeric.');
 end
-if mod(numel(rho),size(spin_system.bas.basis))~=0
+if mod(numel(rho),size(spin_system.bas.basis,1))~=0
     error('the number of elements in rho must be a multiple of the dimension of the spin state space.');
 end
 if ~iscell(spec)
@@ -139,4 +139,3 @@ end
 % you're doing?
 %
 % Ayn Rand, "Atlas Shrugged"
-

--- a/kernel/contexts/crystal.m
+++ b/kernel/contexts/crystal.m
@@ -157,7 +157,11 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -192,7 +196,9 @@ if ~ischar(assumptions)
 end
 
 % Active spins
-if isempty(parameters.spins)
+if ~isfield(parameters,'spins')
+    error('working spins must be specified in parameters.spins field.');
+elseif isempty(parameters.spins)
     error('parameters.spins variable cannot be empty.');
 elseif ~iscell(parameters.spins)
     error('parameters.spins variable must be a cell array.');
@@ -245,4 +251,3 @@ end
 % greatest kind of courage. I mean, what we really want.
 %
 % Ayn Rand, "The Fountainhead"
-

--- a/kernel/contexts/crystal.m
+++ b/kernel/contexts/crystal.m
@@ -157,11 +157,7 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -251,3 +247,4 @@ end
 % greatest kind of courage. I mean, what we really want.
 %
 % Ayn Rand, "The Fountainhead"
+

--- a/kernel/contexts/crystal.m
+++ b/kernel/contexts/crystal.m
@@ -76,6 +76,9 @@ function answer=crystal(spin_system,pulse_sequence,parameters,assumptions)
 % Show the banner
 banner(spin_system,'sequence_banner'); 
 
+% Check spin specification
+grumble(spin_system,pulse_sequence,parameters,assumptions,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -170,7 +173,16 @@ end
 end
 
 % Consistency checking
-function grumble(spin_system,pulse_sequence,parameters,assumptions)
+function grumble(spin_system,pulse_sequence,parameters,assumptions,spins_only)
+
+if (nargin==5)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins must be specified in parameters.spins field.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
 
 % Orientation
 if ~isfield(parameters,'orientation')

--- a/kernel/contexts/doublerot.m
+++ b/kernel/contexts/doublerot.m
@@ -343,7 +343,11 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -425,7 +429,9 @@ if ~ischar(assumptions)
 end
 
 % Active spins
-if isempty(parameters.spins)
+if ~isfield(parameters,'spins')
+    error('working spins must be specified in parameters.spins field.');
+elseif isempty(parameters.spins)
     error('parameters.spins variable cannot be empty.');
 elseif ~iscell(parameters.spins)
     error('parameters.spins variable must be a cell array.');
@@ -475,4 +481,3 @@ end
 % Show me a hero and I'll write you a tragedy.
 %
 % F. Scott Fitzgerald
-

--- a/kernel/contexts/doublerot.m
+++ b/kernel/contexts/doublerot.m
@@ -105,6 +105,9 @@ function [answer,sph_grid]=doublerot(spin_system,pulse_sequence,...
 % Show the banner
 banner(spin_system,'sequence_banner');
 
+% Check spin specification
+grumble(spin_system,pulse_sequence,parameters,assumptions,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -358,7 +361,16 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,pulse_sequence,parameters,assumptions)
+function grumble(spin_system,pulse_sequence,parameters,assumptions,spins_only)
+
+if (nargin==5)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins must be specified in parameters.spins field.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
 
 % Formalism 
 if ~ismember(spin_system.bas.formalism,{'zeeman-liouv','sphten-liouv'})

--- a/kernel/contexts/doublerot.m
+++ b/kernel/contexts/doublerot.m
@@ -343,11 +343,7 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -481,3 +477,4 @@ end
 % Show me a hero and I'll write you a tragedy.
 %
 % F. Scott Fitzgerald
+

--- a/kernel/contexts/floquet.m
+++ b/kernel/contexts/floquet.m
@@ -292,7 +292,11 @@ if ~isfield(parameters,'decouple')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -359,7 +363,9 @@ elseif strcmp(parameters.grid,'single_crystal')
 end
 
 % Active spins
-if isempty(parameters.spins)
+if ~isfield(parameters,'spins')
+    error('working spins must be specified in parameters.spins field.');
+elseif isempty(parameters.spins)
     error('parameters.spins variable cannot be empty.');
 elseif ~iscell(parameters.spins)
     error('parameters.spins variable must be a cell array.');
@@ -391,4 +397,3 @@ end
 % easier to ask forgiveness than it is to get permission.
 %
 % Rear Admiral Grace Hopper
-

--- a/kernel/contexts/floquet.m
+++ b/kernel/contexts/floquet.m
@@ -83,6 +83,9 @@ function [answer,sph_grid]=floquet(spin_system,pulse_sequence,...
 % Show the banner
 banner(spin_system,'sequence_banner'); 
 
+% Check spin specification
+grumble(spin_system,pulse_sequence,parameters,assumptions,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -307,7 +310,16 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,pulse_sequence,parameters,assumptions)
+function grumble(spin_system,pulse_sequence,parameters,assumptions,spins_only)
+
+if (nargin==5)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins must be specified in parameters.spins field.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
 
 % Rotating frames
 if isfield(parameters,'rframes')

--- a/kernel/contexts/floquet.m
+++ b/kernel/contexts/floquet.m
@@ -292,11 +292,7 @@ if ~isfield(parameters,'decouple')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -397,3 +393,4 @@ end
 % easier to ask forgiveness than it is to get permission.
 %
 % Rear Admiral Grace Hopper
+

--- a/kernel/contexts/gridfree.m
+++ b/kernel/contexts/gridfree.m
@@ -219,7 +219,11 @@ end
 function parameters=defaults(spin_system,parameters)
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -288,7 +292,9 @@ if ~ischar(assumptions)
 end
 
 % Active spins
-if isempty(parameters.spins)
+if ~isfield(parameters,'spins')
+    error('working spins must be specified in parameters.spins field.');
+elseif isempty(parameters.spins)
     error('parameters.spins variable cannot be empty.');
 elseif ~iscell(parameters.spins)
     error('parameters.spins variable must be a cell array.');
@@ -316,4 +322,3 @@ end
 % field, and live.
 %
 % Mark Twain
-

--- a/kernel/contexts/gridfree.m
+++ b/kernel/contexts/gridfree.m
@@ -79,6 +79,9 @@ function answer=gridfree(spin_system,pulse_sequence,parameters,assumptions)
 % Show the banner
 banner(spin_system,'sequence_banner'); 
 
+% Check spin specification
+grumble(spin_system,pulse_sequence,parameters,assumptions,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -231,7 +234,16 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,pulse_sequence,parameters,assumptions)
+function grumble(spin_system,pulse_sequence,parameters,assumptions,spins_only)
+
+if (nargin==5)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins must be specified in parameters.spins field.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
 
 % Rotating frames
 if isfield(parameters,'rframes')

--- a/kernel/contexts/gridfree.m
+++ b/kernel/contexts/gridfree.m
@@ -219,11 +219,7 @@ end
 function parameters=defaults(spin_system,parameters)
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -322,3 +318,4 @@ end
 % field, and live.
 %
 % Mark Twain
+

--- a/kernel/contexts/liquid.m
+++ b/kernel/contexts/liquid.m
@@ -150,7 +150,11 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'needs')
     report(spin_system,'parameters.needs field not set, assumpting empty.');
@@ -230,4 +234,3 @@ end
 % he has committed a sacrilege.
 %
 % Ayn Rand, "The Fountainhead"
-

--- a/kernel/contexts/liquid.m
+++ b/kernel/contexts/liquid.m
@@ -150,11 +150,7 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'needs')
     report(spin_system,'parameters.needs field not set, assumpting empty.');
@@ -234,3 +230,4 @@ end
 % he has committed a sacrilege.
 %
 % Ayn Rand, "The Fountainhead"
+

--- a/kernel/contexts/liquid.m
+++ b/kernel/contexts/liquid.m
@@ -71,6 +71,9 @@ function answer=liquid(spin_system,pulse_sequence,parameters,assumptions)
 % Show the banner
 banner(spin_system,'sequence_banner'); 
 
+% Check spin specification
+grumble(spin_system,pulse_sequence,parameters,assumptions,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -159,7 +162,16 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,pulse_sequence,parameters,assumptions)
+function grumble(spin_system,pulse_sequence,parameters,assumptions,spins_only)
+
+if (nargin==5)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins must be specified in parameters.spins field.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
 
 % Pulse sequence
 if ~isa(pulse_sequence,'function_handle')

--- a/kernel/contexts/powder.m
+++ b/kernel/contexts/powder.m
@@ -320,11 +320,7 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -436,3 +432,4 @@ end
 % No. Altruism says: Yes.
 %
 % Ayn Rand
+

--- a/kernel/contexts/powder.m
+++ b/kernel/contexts/powder.m
@@ -320,7 +320,11 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -359,7 +363,9 @@ if ~ischar(assumptions)
 end
 
 % Active spins
-if isempty(parameters.spins)
+if ~isfield(parameters,'spins')
+    error('working spins must be specified in parameters.spins field.');
+elseif isempty(parameters.spins)
     error('parameters.spins variable cannot be empty.');
 elseif ~iscell(parameters.spins)
     error('parameters.spins variable must be a cell array.');
@@ -430,4 +436,3 @@ end
 % No. Altruism says: Yes.
 %
 % Ayn Rand
-

--- a/kernel/contexts/powder.m
+++ b/kernel/contexts/powder.m
@@ -102,6 +102,9 @@ function [answer,sph_grid]=powder(spin_system,pulse_sequence,...
 % Show the banner
 banner(spin_system,'sequence_banner'); 
 
+% Check spin specification
+grumble(spin_system,pulse_sequence,parameters,assumptions,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -337,7 +340,16 @@ end
 end
 
 % Consistency checking
-function grumble(spin_system,pulse_sequence,parameters,assumptions)
+function grumble(spin_system,pulse_sequence,parameters,assumptions,spins_only)
+
+if (nargin==5)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins must be specified in parameters.spins field.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
 
 % Spherical grid
 if ~isfield(parameters,'grid')

--- a/kernel/contexts/singlerot.m
+++ b/kernel/contexts/singlerot.m
@@ -104,6 +104,9 @@ function [answer,sph_grid]=singlerot(spin_system,pulse_sequence,...
 % Show the banner
 banner(spin_system,'sequence_banner'); 
 
+% Check spin specification
+grumble(spin_system,pulse_sequence,parameters,assumptions,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -398,7 +401,16 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,pulse_sequence,parameters,assumptions)
+function grumble(spin_system,pulse_sequence,parameters,assumptions,spins_only)
+
+if (nargin==5)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins must be specified in parameters.spins field.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
 
 % Option combination restrictions
 if isfield(parameters,'rho0')&&isfield(parameters,'needs')&&...

--- a/kernel/contexts/singlerot.m
+++ b/kernel/contexts/singlerot.m
@@ -383,11 +383,7 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -516,3 +512,4 @@ end
 % told that this is not correct and asked to amend it.
 % 
 % IK's contract at Southampton University, 2014
+

--- a/kernel/contexts/singlerot.m
+++ b/kernel/contexts/singlerot.m
@@ -383,7 +383,11 @@ if ~isfield(parameters,'rframes')
 end
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'verbose')
     report(spin_system,'parameters.verbose field not set, silencing array operations.');
@@ -453,7 +457,9 @@ if ~ischar(assumptions)
 end
 
 % Active spins
-if isempty(parameters.spins)
+if ~isfield(parameters,'spins')
+    error('working spins must be specified in parameters.spins field.');
+elseif isempty(parameters.spins)
     error('parameters.spins variable cannot be empty.');
 elseif ~iscell(parameters.spins)
     error('parameters.spins variable must be a cell array.');
@@ -510,4 +516,3 @@ end
 % told that this is not correct and asked to amend it.
 % 
 % IK's contract at Southampton University, 2014
-

--- a/kernel/create.m
+++ b/kernel/create.m
@@ -2035,13 +2035,13 @@ end
 if isfield(inter,'damp_rate')
 
     % Enforce isotropic damping if damp_rate is specified
-    if ~ismember('damp',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('damp',inter.relaxation))
         error('inter.damp_rate can only be specified with damp relaxation theory.');
     end
 
     % Check type
     if (~isnumeric(inter.damp_rate))||(~isreal(inter.damp_rate))||...
-       ((~isscalar(inter.damp_rate))&&(~all(size(inter.damp_rate)==3)))
+       ((~isscalar(inter.damp_rate))&&(~isequal(size(inter.damp_rate),[3 3])))
         error('inter.damp_rate must be a real scalar or a 3x3 matrix.');
     end
     
@@ -2110,7 +2110,7 @@ if isfield(inter,'r1_rates')
     end
     
     % Enforce T1,T2 theory if inter.r1_rates rates are specified
-    if ~ismember('t1_t2',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('t1_t2',inter.relaxation))
         error('inter.r1_rates may only be specified with T1,T2 relaxation theory.');
     end
     
@@ -2174,7 +2174,7 @@ if isfield(inter,'r2_rates')
     end
     
     % Enforce T1,T2 theory if inter.r2_rates rates are specified
-    if ~ismember('t1_t2',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('t1_t2',inter.relaxation))
         error('inter.r2_rates may only be specified with T1,T2 relaxation theory.');
     end
     
@@ -2195,7 +2195,7 @@ if isfield(inter,'lind_r1_rates')
     end
     
     % Enforce Lindblad theory if inter.lind_r1_rates rates are specified
-    if ~ismember('lindblad',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('lindblad',inter.relaxation))
         error('inter.lind_r1_rates can only be specified with Lindblad relaxation theory.');
     end
     
@@ -2216,7 +2216,7 @@ if isfield(inter,'lind_r2_rates')
     end
     
     % Enforce Lindblad theory if inter.lind_r2_rates rates are specified
-    if ~ismember('lindblad',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('lindblad',inter.relaxation))
         error('inter.lind_r2_rates can only be specified with Lindblad relaxation theory.');
     end
     
@@ -2236,7 +2236,7 @@ if isfield(inter,'weiz_r1e')
     end
     
     % Enforce Weizmann theory if inter.weiz_r1e is specified
-    if ~ismember('weizmann',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('weizmann',inter.relaxation))
         error('inter.weiz_r1e can only be specified with Weizmann DNP relaxation theory.');
     end
     
@@ -2256,7 +2256,7 @@ if isfield(inter,'nott_r1e')
     end
     
     % Enforce Nottingham theory if inter.weiz_r1e is specified
-    if ~ismember('nottingham',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('nottingham',inter.relaxation))
         error('inter.nott_r1e can only be specified with Nottingham DNP relaxation theory.');
     end
     
@@ -2276,7 +2276,7 @@ if isfield(inter,'weiz_r2e')
     end
     
     % Enforce Weizmann theory if inter.weiz_r2e is specified
-    if ~ismember('weizmann',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('weizmann',inter.relaxation))
         error('inter.weiz_r2e can only be specified with Weizmann DNP relaxation theory.');
     end
     
@@ -2296,7 +2296,7 @@ if isfield(inter,'nott_r2e')
     end
     
     % Enforce Nottingham theory if inter.weiz_r1e is specified
-    if ~ismember('nottingham',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('nottingham',inter.relaxation))
         error('inter.nott_r2e can only be specified with Nottingham DNP relaxation theory.');
     end
     
@@ -2316,7 +2316,7 @@ if isfield(inter,'weiz_r1n')
     end
     
     % Enforce Weizmann theory if inter.weiz_r1n is specified
-    if ~ismember('weizmann',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('weizmann',inter.relaxation))
         error('inter.weiz_r1n can only be specified with Weizmann DNP relaxation theory.');
     end
     
@@ -2336,7 +2336,7 @@ if isfield(inter,'nott_r1n')
     end
     
     % Enforce Nottingham theory if inter.weiz_r1n is specified
-    if ~ismember('nottingham',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('nottingham',inter.relaxation))
         error('inter.nott_r1n can only be specified with Nottingham DNP relaxation theory.');
     end
     
@@ -2356,7 +2356,7 @@ if isfield(inter,'weiz_r2n')
     end
     
     % Enforce Weizmann theory if inter.weiz_r2n is specified
-    if ~ismember('weizmann',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('weizmann',inter.relaxation))
         error('inter.weiz_r2n can only be specified with Weizmann DNP relaxation theory.');
     end
     
@@ -2376,7 +2376,7 @@ if isfield(inter,'nott_r2n')
     end
     
     % Enforce Nottingham theory if inter.weiz_r1e is specified
-    if ~ismember('nottingham',inter.relaxation)
+    if (~isfield(inter,'relaxation'))||(~ismember('nottingham',inter.relaxation))
         error('inter.nott_r2n can only be specified with Nottingham DNP relaxation theory.');
     end
     
@@ -2396,7 +2396,7 @@ if isfield(inter,'weiz_r1d')
     end
     
     % Enforce Weizmann theory if inter.weiz_r1d rates are specified
-    if ~strcmp(inter.relaxation,'weizmann')
+    if (~isfield(inter,'relaxation'))||(~ismember('weizmann',inter.relaxation))
         error('inter.weiz_r1d can only be specified with Weizmann DNP relaxation theory.');
     end
     
@@ -2416,7 +2416,7 @@ if isfield(inter,'weiz_r2d')
     end
     
     % Enforce Weizmann theory if R2d rates are specified
-    if ~strcmp(inter.relaxation,'weizmann')
+    if (~isfield(inter,'relaxation'))||(~ismember('weizmann',inter.relaxation))
         error('inter.weiz_r2d can only be specified with Weizmann DNP relaxation theory.');
     end
     
@@ -2588,4 +2588,3 @@ end
 % the soil for those who did not.
 %
 % Benjamin Franklin
-

--- a/kernel/grids/gaussleg.m
+++ b/kernel/grids/gaussleg.m
@@ -54,15 +54,15 @@ end
 
 % Consistency enforcement
 function grumble(a,b,n)
-if (~isnumeric(a))||(~isreal(a))||(~isfinite(a))||(numel(a)~=1)
+if (~isnumeric(a))||(~isreal(a))||(numel(a)~=1)||(~isfinite(a))
     error('a must be a finite real number.');
 end
-if (~isnumeric(b))||(~isreal(b))||(~isfinite(b))||(numel(b)~=1)
+if (~isnumeric(b))||(~isreal(b))||(numel(b)~=1)||(~isfinite(b))
     error('b must be a finite real number.');
 end
 if a>=b, error('a must be smaller than b.'); end
-if (~isnumeric(n))||(~isreal(n))||(~isfinite(n))||...
-   (numel(b)~=1)||(n<1)||mod(n,1)
+if (~isnumeric(n))||(~isreal(n))||(numel(n)~=1)||...
+   (~isfinite(n))||(n<1)||mod(n,1)
     error('n must be a positive real integer.');
 end
 if n>40, error('n>40 is unreasonable - subdivide the interval.'); end
@@ -72,4 +72,3 @@ end
 % drinks all wells are poisoned.
 %
 % Friedrich Nietzsche
-

--- a/kernel/grids/one_vcell_solidangle.m
+++ b/kernel/grids/one_vcell_solidangle.m
@@ -25,7 +25,11 @@
 function S=one_vcell_solidangle(v,centre)
 
 % Check consistency
-grumble(v,centre);
+if nargin<2
+    grumble(v);
+else
+    grumble(v,centre);
+end
 
 % Straightforward math
 if nargin<2
@@ -54,11 +58,21 @@ end
 
 % Consistency enforcement
 function grumble(v,centre)
+if (~isnumeric(v))||(~isreal(v))||(size(v,1)~=3)||any(~isfinite(v(:)))
+    error('v must be a finite real 3 x n array.');
+end
 if any(abs(sum(v.^2,1)-1)>1e-6)
     error('v must contain unit vectors.');
 end
-if abs(norm(centre,2)-1)>1e-6
-    error('centre muslt be a unit vector.');
+if nargin>1
+    if (~isnumeric(centre))||(~isreal(centre))||(~iscolumn(centre))||...
+       (numel(centre)~=3)||any(~isfinite(centre(:)))
+        error('centre must be a finite real three-element column vector.');
+    end
+    if abs(norm(centre,2)-1)>1e-6
+        error('centre must be a unit vector.');
+    end
+end
 end
 end
 
@@ -67,4 +81,3 @@ end
 % giddy elation and black despair.
 %
 % Steven G. Krantz
-

--- a/kernel/grids/one_vcell_solidangle.m
+++ b/kernel/grids/one_vcell_solidangle.m
@@ -74,7 +74,6 @@ if nargin>1
     end
 end
 end
-end
 
 % Being a mathematician is a bit like being a manic 
 % depressive: you spend your life alternating between

--- a/kernel/grids/vcell_solidangle.m
+++ b/kernel/grids/vcell_solidangle.m
@@ -27,7 +27,11 @@
 function S=vcell_solidangle(P,K,xyz)
 
 % Check consistency
-grumble(P);
+if nargin<3
+    grumble(P,K);
+else
+    grumble(P,K,xyz);
+end
 
 % Adapt to the input
 if nargin<3
@@ -39,9 +43,31 @@ end
 end
 
 % Consistency enforcement
-function grumble(P)
+function grumble(P,K,xyz)
+if (~isnumeric(P))||(~isreal(P))||(size(P,1)~=3)||any(~isfinite(P(:)))
+    error('P must be a finite real 3 x n array.');
+end
 if any(abs(sum(P.^2,1)-1)>1e-6)
     error('P must contain unit vectors.');
+end
+if ~iscell(K)
+    error('K must be a cell array of vertex index lists.');
+end
+for n=1:numel(K)
+    if (~isnumeric(K{n}))||(~isreal(K{n}))||isempty(K{n})||...
+       any(~isfinite(K{n}(:)))||any(mod(K{n}(:),1)~=0)||...
+       any(K{n}(:)<1)||any(K{n}(:)>size(P,2))
+        error('K must contain positive integer indices into P.');
+    end
+end
+if nargin>2
+    if (~isnumeric(xyz))||(~isreal(xyz))||(size(xyz,1)~=3)||...
+       (size(xyz,2)~=numel(K))||any(~isfinite(xyz(:)))
+        error('xyz must be a finite real 3 x numel(K) array.');
+    end
+    if any(abs(sum(xyz.^2,1)-1)>1e-6)
+        error('xyz must contain unit vectors.');
+    end
 end
 end
 
@@ -56,4 +82,3 @@ end
 % of embourgeoisement if the law was changed.
 %
 % Toby Young
-

--- a/kernel/grids/voitlander.m
+++ b/kernel/grids/voitlander.m
@@ -282,13 +282,76 @@ end
 
 % Consistency enforcement
 function grumble(parameters,tri,Ic,Iz,Qc,Qz,Hmw)
-
-% Talos, please write a grumbler
-
+if (~isfield(parameters,'b_axis'))||(~isnumeric(parameters.b_axis))||...
+   (~isreal(parameters.b_axis))||(~isvector(parameters.b_axis))||...
+   any(~isfinite(parameters.b_axis(:)))
+    error('parameters.b_axis must be a finite real vector.');
+end
+if (~isfield(parameters,'int_tol'))||(~isnumeric(parameters.int_tol))||...
+   (~isreal(parameters.int_tol))||(numel(parameters.int_tol)~=1)||...
+   (~isfinite(parameters.int_tol))||(parameters.int_tol<=0)
+    error('parameters.int_tol must be a positive real scalar.');
+end
+if (~isstruct(tri))||(numel(tri)~=3)
+    error('triangle must be a three-element structure array.');
+end
+for n=1:3
+    if (~isfield(tri(n),'xyz'))||(~isnumeric(tri(n).xyz))||...
+       (~isreal(tri(n).xyz))||(~iscolumn(tri(n).xyz))||...
+       (numel(tri(n).xyz)~=3)||any(~isfinite(tri(n).xyz(:)))||...
+       (abs(norm(tri(n).xyz,2)-1)>1e-6)
+        error('triangle vertices must have unit-vector xyz fields.');
+    end
+    if (~isfield(tri(n),'tf'))||(~isnumeric(tri(n).tf))||...
+       (~isreal(tri(n).tf))||any(~isfinite(tri(n).tf(:)))
+        error('triangle vertices must have finite real tf fields.');
+    end
+    if (~isfield(tri(n),'tm'))||(~isnumeric(tri(n).tm))||...
+       (~isreal(tri(n).tm))||any(~isfinite(tri(n).tm(:)))||...
+       any(tri(n).tm(:)<0)
+        error('triangle vertices must have finite non-negative real tm fields.');
+    end
+    if (~isfield(tri(n),'tw'))||(~isnumeric(tri(n).tw))||...
+       (~isreal(tri(n).tw))||any(~isfinite(tri(n).tw(:)))||...
+       any(tri(n).tw(:)<=0)
+        error('triangle vertices must have finite positive real tw fields.');
+    end
+    if (~isfield(tri(n),'pd'))||(~isnumeric(tri(n).pd))||...
+       (~isreal(tri(n).pd))||any(~isfinite(tri(n).pd(:)))
+        error('triangle vertices must have finite real pd fields.');
+    end
+    if (~isfield(tri(n),'tj'))||(~isnumeric(tri(n).tj))||...
+       (~isreal(tri(n).tj))||any(~isfinite(tri(n).tj(:)))
+        error('triangle vertices must have finite real tj fields.');
+    end
+    if (~isfield(tri(n),'ti'))||(~isnumeric(tri(n).ti))||...
+       any(~isfinite(tri(n).ti(:)))
+        error('triangle vertices must have finite numeric ti fields.');
+    end
+    ntrans=numel(tri(n).tf);
+    if (numel(tri(n).tm)~=ntrans)||(numel(tri(n).tw)~=ntrans)||...
+       (numel(tri(n).pd)~=ntrans)||(numel(tri(n).tj)~=ntrans)||...
+       (size(tri(n).ti,1)~=ntrans)
+        error('transition data counts must match at each triangle vertex.');
+    end
+end
+if (~isnumeric(Ic))||(~isnumeric(Iz))||(~isnumeric(Hmw))||...
+   (size(Ic,1)~=size(Ic,2))||(size(Iz,1)~=size(Iz,2))||...
+   (size(Hmw,1)~=size(Hmw,2))||(~isequal(size(Ic),size(Iz),size(Hmw)))
+    error('Ic, Iz, and Hmw must be numeric square matrices of equal size.');
+end
+if (~iscell(Qc))||(~iscell(Qz))||(~isequal(size(Qc),size(Qz)))
+    error('Qc and Qz must be cell arrays of equal size.');
+end
+for n=1:numel(Qc)
+    if (~isnumeric(Qc{n}))||(~isnumeric(Qz{n}))||...
+       (~isequal(size(Qc{n}),size(Ic)))||(~isequal(size(Qz{n}),size(Iz)))
+        error('Qc and Qz elements must match Ic and Iz dimensions.');
+    end
+end
 end
 
 % "How many divisions?"
 %
 % Joseph Stalin, when told that
 % Vatican was a powerful entity
-

--- a/kernel/kinetics/flow_gen.m
+++ b/kernel/kinetics/flow_gen.m
@@ -133,6 +133,11 @@ end
 if ~isfield(parameters,'diff')
     error('diffusion coefficient must be specified in parameters.diff variable.');
 end
+if (~isnumeric(parameters.diff))||(~isreal(parameters.diff))||...
+   (~isscalar(parameters.diff))||(~isfinite(parameters.diff))||...
+   (parameters.diff<0)
+    error('parameters.diff must be a finite non-negative real scalar.');
+end
 end
 
 % A disbelieving production team on a BBC Radio 4 arts programme
@@ -145,4 +150,3 @@ end
 % use a split infinitive".
 %
 % https://www.spectator.co.uk/article/the-art-of-swearing/
-

--- a/kernel/optimcon/grape_hilb.m
+++ b/kernel/optimcon/grape_hilb.m
@@ -57,7 +57,7 @@ function [traj_data,fidelity,grad] = grape_hilb(spin_system,drifts,controls,...
                                                 fidelity_type) %#ok<*PFBNS>
 
 % Check consistency
-grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ);
+grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ,fidelity_type);
 
 % Hush up the output
 shut_up.sys.output='hush';
@@ -209,15 +209,18 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ)
+function grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ,fidelity_type)
 if ~ismember(spin_system.bas.formalism,{'zeeman-hilb'})
     error('this function requires a density matrix based formalism.');
 end
 if (~isnumeric(rho_init))||(~ismatrix(rho_init))||(size(rho_init,1)~=size(rho_init,2))
     error('rho_init must be a square matrix.');
 end
-if (~isnumeric(rho_targ))||(~ismatrix(rho_init))||(size(rho_targ,1)~=size(rho_targ,2))
-    error('rho_targ must be a square vector.');
+if (~isnumeric(rho_targ))||(~ismatrix(rho_targ))||(size(rho_targ,1)~=size(rho_targ,2))
+    error('rho_targ must be a square matrix.');
+end
+if (~ischar(fidelity_type))||(~ismember(fidelity_type,{'real','imag','square'}))
+    error('fidelity_type must be ''real'', ''imag'', or ''square''.');
 end
 if ~iscell(drifts)
     error('drifts must be a cell array of matrices.');
@@ -279,4 +282,3 @@ end
 %
 % Dumas concludes: "This is the ultimate monument to journalism. It need not
 % do anything else, for it won't do anything better."
-

--- a/kernel/optimcon/grape_liouv.m
+++ b/kernel/optimcon/grape_liouv.m
@@ -65,7 +65,7 @@ function [traj_data,fidelity,grad,hess]=grape_liouv(spin_system,drifts,controls,
                                                     waveform,rho_init,rho_targ,...
                                                     fidelity_type) %#ok<*PFBNS>
 % Check consistency
-grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ);
+grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ,fidelity_type);
     
 % Count the outputs
 n_outputs=nargout();
@@ -786,7 +786,7 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ)
+function grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ,fidelity_type)
 if ~ismember(spin_system.bas.formalism,{'sphten-liouv',...
                                         'zeeman-liouv',...
                                         'zeeman-wavef'})
@@ -795,8 +795,11 @@ end
 if (~isnumeric(rho_init))||(~iscolumn(rho_init))
     error('rho_init must be a column vector.');
 end
-if (~isnumeric(rho_targ))||(~iscolumn(rho_init))
+if (~isnumeric(rho_targ))||(~iscolumn(rho_targ))
     error('rho_targ must be a column vector.');
+end
+if (~ischar(fidelity_type))||(~ismember(fidelity_type,{'real','imag','square'}))
+    error('fidelity_type must be ''real'', ''imag'', or ''square''.');
 end
 if ~iscell(drifts)
     error('drifts must be a cell array of matrices.');
@@ -845,4 +848,3 @@ end
 % likely to be heroic exceptions.
 %
 % Nathaniel Branden
-

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -1339,10 +1339,13 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,control) %#ok<INUSD> 
-
-% Add further sanity checks here
-
+function grumble(spin_system,control)
+if ~isstruct(spin_system)
+    error('spin_system must be a Spinach data structure.');
+end
+if ~isstruct(control)
+    error('control must be a structure.');
+end
 end
 
 % Whenever anyone accuses some person of being 'unfeeling' he means that
@@ -1351,5 +1354,4 @@ end
 % is the opposite of charity.
 %
 % Ayn Rand, "Atlas Shrugged"
-
 

--- a/kernel/optimcon/tgrape.m
+++ b/kernel/optimcon/tgrape.m
@@ -44,7 +44,7 @@
 function [fidelity,grad]=tgrape(spin_system,drift,controls,waveform,...
                                 dt_grid,time_unit,rho_init,rho_targ)
 % Check consistency
-grumble(spin_system,drift,controls,waveform,dt_grid,rho_init,rho_targ);
+grumble(spin_system,drift,controls,waveform,dt_grid,time_unit,rho_init,rho_targ);
     
 % Count the time steps
 nsteps=size(waveform,2);
@@ -114,7 +114,7 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,drift,controls,waveform,dt_grid,rho_init,rho_targ)
+function grumble(spin_system,drift,controls,waveform,dt_grid,time_unit,rho_init,rho_targ)
 if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
     error('optimal control module requires Lioville space formalism.');
 end
@@ -149,6 +149,10 @@ end
 if (~isnumeric(dt_grid))||(~isreal(dt_grid))||(~iscolumn(dt_grid))
     error('dt_grid must be a real row vector.');
 end
+if (~isnumeric(time_unit))||(~isreal(time_unit))||(numel(time_unit)~=1)||...
+   (~isfinite(time_unit))||(time_unit<=0)
+    error('time_unit must be a positive real scalar.');
+end
 if numel(dt_grid)~=size(waveform,2)
     error('numel(dt_grid) must be equal to the number waveform columns.');
 end
@@ -160,4 +164,3 @@ end
 % can't make it; but once it's been made they'll talk different!"
 %
 % Karl Popper, "Unended Quest"
-

--- a/kernel/optimcon/wrappers/grape_phase.m
+++ b/kernel/optimcon/wrappers/grape_phase.m
@@ -36,7 +36,10 @@
 function [traj_data,fidelity,gradient,hessian]=grape_phase(phi_profile,spin_system)
 
 % Check consistency
-grumble(spin_system,spin_system.control.amplitudes,phi_profile);
+grumble(spin_system,phi_profile);
+
+% Extract the amplitude profile
+amplitudes=spin_system.control.amplitudes;
 
 % Count penalty terms
 npenterms=numel(spin_system.control.penalties);
@@ -44,7 +47,7 @@ npenterms=numel(spin_system.control.penalties);
 % Transform into Cartesian coordinates
 waveform_xy=zeros(2*size(phi_profile,1),size(phi_profile,2));
 for n=1:size(phi_profile,1)
-    [waveform_xy(2*n-1,:),waveform_xy(2*n,:)]=polar2cartesian(spin_system.control.amplitudes(n,:),phi_profile(n,:));
+    [waveform_xy(2*n-1,:),waveform_xy(2*n,:)]=polar2cartesian(amplitudes(n,:),phi_profile(n,:));
 end
 
 % Translate the freeze mask to Cartesians
@@ -148,10 +151,14 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,amp_profile,phi_profile)
+function grumble(spin_system,phi_profile)
 if ~isfield(spin_system,'control')
     error('control data missing from spin_system, run optimcon() first.');
 end
+if ~isfield(spin_system.control,'amplitudes')
+    error('control amplitude profile missing from spin_system.control.amplitudes.');
+end
+amp_profile=spin_system.control.amplitudes;
 if mod(numel(spin_system.control.operators),2)~=0
     error('phase-amplitude optimisations must have an even number of controls.');
 end
@@ -197,4 +204,3 @@ end
 % more to add, but rather when there is nothing more to take away.
 %
 % Antoine de Saint-Exupery
-

--- a/kernel/overloads/@cell/minus.m
+++ b/kernel/overloads/@cell/minus.m
@@ -61,9 +61,11 @@ end
 if (~iscell(B))&&(~isnumeric(B))
     error('B must be either numeric or a cell array.');
 end
+if iscell(A)&&iscell(B)&&(~isequal(size(A),size(B)))
+    error('cell arrays must have the same topology.');
+end
 end
 
 % I can, therefore I am.
 %
 % Simone Weil
-

--- a/kernel/overloads/@cell/plus.m
+++ b/kernel/overloads/@cell/plus.m
@@ -61,6 +61,9 @@ end
 if (~iscell(B))&&(~isnumeric(B))
     error('B must be either numeric or a cell array.');
 end
+if iscell(A)&&iscell(B)&&(~isequal(size(A),size(B)))
+    error('cell arrays must have the same topology.');
+end
 end
 
 % I came into the room, which was half dark, and presently spotted Lord
@@ -74,4 +77,3 @@ end
 % now considering tonight, radium." Behold! The old boy beamed upon me.
 % 
 % Ernest Rutherford
-

--- a/kernel/overloads/@cell/times.m
+++ b/kernel/overloads/@cell/times.m
@@ -29,7 +29,11 @@ if iscell(A)&&isnumeric(B)
     
     % Multiply every cell from the left
     for n=1:numel(A)
-        A{n}=A{n}*B(n);
+        if isscalar(B)
+            A{n}=A{n}*B;
+        else
+            A{n}=A{n}*B(n);
+        end
     end
     C=A;
     
@@ -37,7 +41,11 @@ elseif isnumeric(A)&&iscell(B)
     
     % Multiply every cell from the right
     for n=1:numel(B)
-        B{n}=A(n)*B{n};
+        if isscalar(A)
+            B{n}=A*B{n};
+        else
+            B{n}=A(n)*B{n};
+        end
     end
     C=B;
     
@@ -58,7 +66,13 @@ end
 if (~iscell(B))&&(~isnumeric(B))
     error('B must be either numeric or a cell array.');
 end
-if ~all(size(A)==size(B),'all')
+if iscell(A)&&iscell(B)
+    error('both arguments cannot be cell arrays.');
+end
+if iscell(A)&&isnumeric(B)&&(~isscalar(B))&&(~isequal(size(A),size(B)))
+    error('the array of scalars and the cell array must have the same dimensions.');
+end
+if isnumeric(A)&&iscell(B)&&(~isscalar(A))&&(~isequal(size(A),size(B)))
     error('the array of scalars and the cell array must have the same dimensions.');
 end
 end
@@ -67,4 +81,3 @@ end
 % by their intentions rather than their results.
 %
 % Milton Friedman
-

--- a/kernel/overloads/@rcv/rcv.m
+++ b/kernel/overloads/@rcv/rcv.m
@@ -147,12 +147,43 @@ end
 
 % Consistency enforcement
 function grumble(varargin)
-
-% Needs some thought
-
+if nargin==1
+    if (~isa(varargin{1},'rcv'))&&((~isnumeric(varargin{1}))||(~ismatrix(varargin{1})))
+        error('single input must be a numeric matrix or an RCV sparse matrix.');
+    end
+elseif nargin==2
+    if (~isnumeric(varargin{1}))||(~isreal(varargin{1}))||(~isscalar(varargin{1}))||...
+       (~isfinite(varargin{1}))||(varargin{1}<0)||(mod(varargin{1},1)~=0)||...
+       (~isnumeric(varargin{2}))||(~isreal(varargin{2}))||(~isscalar(varargin{2}))||...
+       (~isfinite(varargin{2}))||(varargin{2}<0)||(mod(varargin{2},1)~=0)
+        error('matrix dimensions must be non-negative integer scalars.');
+    end
+elseif nargin==5
+    if (~isnumeric(varargin{1}))||(~isreal(varargin{1}))||any(~isfinite(varargin{1}(:)))||...
+       (~isnumeric(varargin{2}))||(~isreal(varargin{2}))||any(~isfinite(varargin{2}(:)))||...
+       (~isnumeric(varargin{3}))
+        error('row indices, column indices, and values must be numeric arrays.');
+    end
+    if (numel(varargin{1})~=numel(varargin{2}))||...
+       (numel(varargin{2})~=numel(varargin{3}))
+        error('row indices, column indices, and values must have the same number of elements.');
+    end
+    if (~isnumeric(varargin{4}))||(~isreal(varargin{4}))||(~isscalar(varargin{4}))||...
+       (~isfinite(varargin{4}))||(varargin{4}<0)||(mod(varargin{4},1)~=0)||...
+       (~isnumeric(varargin{5}))||(~isreal(varargin{5}))||(~isscalar(varargin{5}))||...
+       (~isfinite(varargin{5}))||(varargin{5}<0)||(mod(varargin{5},1)~=0)
+        error('matrix dimensions must be non-negative integer scalars.');
+    end
+    if any(varargin{1}(:)<1)||any(varargin{1}(:)>varargin{4})||...
+       any(varargin{2}(:)<1)||any(varargin{2}(:)>varargin{5})||...
+       any(mod(varargin{1}(:),1)~=0)||any(mod(varargin{2}(:),1)~=0)
+        error('row and column indices must be positive integers within matrix dimensions.');
+    end
+else
+    error('incorrect number of input arguments.');
+end
 end
 
 % There are weeks when decades happen.
 %
 % Vladimir Lenin
-

--- a/kernel/overloads/@rcv/size.m
+++ b/kernel/overloads/@rcv/size.m
@@ -47,8 +47,9 @@ if ~isa(A,'rcv')
     error('the first argument must be an RCV sparse matrix.');
 end
 if nargin==2
-    if (~isscalar(dim))||(~isnumeric(dim))
-        error('dimension index must be a numeric scalar.');
+    if (~isscalar(dim))||(~isnumeric(dim))||(~isreal(dim))||...
+       (~isfinite(dim))||(dim<1)||(mod(dim,1)~=0)
+        error('dimension index must be a positive integer scalar.');
     end
 end
 end
@@ -57,4 +58,3 @@ end
 % because I have a long attention span.
 %
 % Charlie Munger
-

--- a/kernel/overloads/@ttclass/amensolve.m
+++ b/kernel/overloads/@ttclass/amensolve.m
@@ -431,6 +431,9 @@ if ~all(szy(:,2)==ones(d,1))
     error('The right-hand-side should be a vector.')
 end
 if exist('x0','var')
+    if ~isa(x0,'ttclass')
+        error('Initial guess should be ttclass.');
+    end
     if A.ncores~=x0.ncores
         error('Dimensions of matrix and initial guess do not match.');
     end
@@ -568,4 +571,3 @@ end
 % Tread softly because you tread on my dreams.
 %
 % W.B. Yeats (1865-1939)
-

--- a/kernel/plotting/axis_1d.m
+++ b/kernel/plotting/axis_1d.m
@@ -158,7 +158,7 @@ end
 if (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))
     error('elements of parameters.sweep must be real numbers.');
 end
-if numel(parameters.sweep)>2
+if isempty(parameters.sweep)||(numel(parameters.sweep)>2)
     error('parameters.sweep should have one or two elements.');
 end
 if numel(parameters.sweep)==2
@@ -217,4 +217,3 @@ end
 % cal, sadomasochistic, capriciously malevolent bully.
 %
 % Richard Dawkins, "The God Delusion"
-

--- a/kernel/plotting/crop_2d.m
+++ b/kernel/plotting/crop_2d.m
@@ -109,6 +109,12 @@ end
 if (~iscell(crop_ranges))||(numel(crop_ranges)~=2)
     error('crop_ranges must be a cell array with two vectors.');
 end
+for n=1:2
+    if (~isnumeric(crop_ranges{n}))||(~isreal(crop_ranges{n}))||...
+       (numel(crop_ranges{n})~=2)||any(~isfinite(crop_ranges{n}(:)))
+        error('crop_ranges elements must be finite real two-element vectors.');
+    end
+end
 if (crop_ranges{1}(1)>=crop_ranges{1}(2))||(crop_ranges{2}(1)>=crop_ranges{2}(2))
     error('the vectors in the crop_ranges array must have their elements in ascending order.');
 end
@@ -120,4 +126,3 @@ end
 % price increase for dysprosium in 2011.
 %
 % EPSRC reviewer, on one of IK's grant applications
-

--- a/kernel/plotting/mri_2d_plot.m
+++ b/kernel/plotting/mri_2d_plot.m
@@ -121,12 +121,19 @@ end
 % Consistency enforcement
 function grumble(mri,parameters,method)
 if ~ischar(method), error('method must be a character string.'); end
-if ismember(method,{'image','phantom'})
+if ~ismember(method,{'image','phantom','k-space'})
+    error('method must be ''image'', ''phantom'', or ''k-space''.');
+end
+if ismember(method,{'image','phantom','k-space'})
     if (~isnumeric(mri))||(~isreal(mri))||(~ismatrix(mri))
         error('mri must be a real matrix.');
     end
 end
 if ismember(method,{'image','k-space'})
+    if (~isfield(parameters,'spins'))||(~iscell(parameters.spins))||...
+       (numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
+        error('parameters.spins must be a one-element cell array of character strings.');
+    end
     if ~isfield(parameters,'ro_grad_amp')
         error('readout gradient amplitude should be specified in parameters.ro_grad_amp variable.');
     end
@@ -139,16 +146,22 @@ if ismember(method,{'image','k-space'})
     if ~isfield(parameters,'pe_grad_dur') 
         error('phase encoding duration gradient should be specified in parameters.pe_grad_dur variable.');
     end
-    if numel(parameters.ro_grad_amp)~=1
+    if (~isnumeric(parameters.ro_grad_amp))||(~isreal(parameters.ro_grad_amp))||...
+       (numel(parameters.ro_grad_amp)~=1)||(~isfinite(parameters.ro_grad_amp))
         error('parameters.ro_grad_amp should have exactly one element.');
     end    
-    if numel(parameters.ro_grad_dur)~=1
+    if (~isnumeric(parameters.ro_grad_dur))||(~isreal(parameters.ro_grad_dur))||...
+       (numel(parameters.ro_grad_dur)~=1)||(~isfinite(parameters.ro_grad_dur))||...
+       (parameters.ro_grad_dur<=0)
         error('parameters.ro_grad_dur should have exactly one element.');
     end   
-    if numel(parameters.pe_grad_amp)~=1 
+    if (~isnumeric(parameters.pe_grad_amp))||(~isreal(parameters.pe_grad_amp))||...
+       (numel(parameters.pe_grad_amp)~=1)||(~isfinite(parameters.pe_grad_amp))
         error('parameters.pe_grad_amp should have exactly one element.');
     end
-    if numel(parameters.pe_grad_dur)~=1  
+    if (~isnumeric(parameters.pe_grad_dur))||(~isreal(parameters.pe_grad_dur))||...
+       (numel(parameters.pe_grad_dur)~=1)||(~isfinite(parameters.pe_grad_dur))||...
+       (parameters.pe_grad_dur<=0)
         error('parameters.pe_grad_dur should have exactly one element.');
     end
 end
@@ -163,4 +176,3 @@ end
 % everybody and everything."
 %
 % From Charles Darwin's diaries
-

--- a/kernel/plotting/plot_1d.m
+++ b/kernel/plotting/plot_1d.m
@@ -80,11 +80,7 @@ end
 function parameters=defaults(spin_system,parameters)
 if (~isfield(parameters,'offset'))&&isfield(parameters,'sweep')&&isscalar(parameters.sweep)
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=0;
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'axis_units')
     report(spin_system,'parameters.axis_units field not set, assuming ppm.');
@@ -136,6 +132,8 @@ if ~ischar(parameters.axis_units)
 end
 if ~isfield(parameters,'spins')
     error('working spins should be specified in parameters.spins variable.');
+elseif isempty(parameters.spins)
+    error('parameters.spins variable cannot be empty.');
 end
 if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)
     error('parameters.spins must be a cell array with exactly one element.');
@@ -154,3 +152,4 @@ end
 % The only sin on earth is to do things badly.
 %
 % Ayn Rand
+

--- a/kernel/plotting/plot_1d.m
+++ b/kernel/plotting/plot_1d.m
@@ -81,7 +81,7 @@ end
 
 % Default parameters
 function parameters=defaults(spin_system,parameters)
-if (~isfield(parameters,'offset'))&&isfield(parameters,'sweep')&&isscalar(parameters.sweep)
+if (~isfield(parameters,'offset'))&&isscalar(parameters.sweep)
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
     parameters.offset=zeros(size(parameters.spins));
 end
@@ -165,4 +165,3 @@ end
 % The only sin on earth is to do things badly.
 %
 % Ayn Rand
-

--- a/kernel/plotting/plot_1d.m
+++ b/kernel/plotting/plot_1d.m
@@ -78,9 +78,13 @@ end
 
 % Default parameters
 function parameters=defaults(spin_system,parameters)
-if (~isfield(parameters,'offset'))&&isscalar(parameters.sweep)
+if (~isfield(parameters,'offset'))&&isfield(parameters,'sweep')&&isscalar(parameters.sweep)
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=0;
+    end
 end
 if ~isfield(parameters,'axis_units')
     report(spin_system,'parameters.axis_units field not set, assuming ppm.');
@@ -150,4 +154,3 @@ end
 % The only sin on earth is to do things badly.
 %
 % Ayn Rand
-

--- a/kernel/plotting/plot_1d.m
+++ b/kernel/plotting/plot_1d.m
@@ -37,6 +37,9 @@
 
 function plot_1d(spin_system,spectrum,parameters,varargin)
 
+% Check spin specification
+grumble(spin_system,spectrum,parameters,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -96,7 +99,17 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,spectrum,parameters)
+function grumble(spin_system,spectrum,parameters,spins_only)
+
+if (nargin==4)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins should be specified in parameters.spins variable.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
+
 if (~isnumeric(spectrum))
     error('spectrum must be a numeric array.');
 end

--- a/kernel/plotting/plot_2d.m
+++ b/kernel/plotting/plot_2d.m
@@ -182,11 +182,7 @@ end
 function parameters=defaults(spin_system,parameters)
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'axis_units')
     report(spin_system,'parameters.axis_units field not set, assuming ppm.');
@@ -219,6 +215,8 @@ if ~ischar(parameters.axis_units)
 end
 if ~isfield(parameters,'spins')
     error('working spins should be specified in parameters.spins variable.');
+elseif isempty(parameters.spins)
+    error('parameters.spins variable cannot be empty.');
 end
 if ~iscell(parameters.spins)
     error('parameters.spins should be a cell array of character strings.');
@@ -256,3 +254,4 @@ end
 % promotion.
 %
 % Albert Camus 
+

--- a/kernel/plotting/plot_2d.m
+++ b/kernel/plotting/plot_2d.m
@@ -182,7 +182,11 @@ end
 function parameters=defaults(spin_system,parameters)
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'axis_units')
     report(spin_system,'parameters.axis_units field not set, assuming ppm.');
@@ -252,4 +256,3 @@ end
 % promotion.
 %
 % Albert Camus 
-

--- a/kernel/plotting/plot_2d.m
+++ b/kernel/plotting/plot_2d.m
@@ -67,6 +67,9 @@ function [axis_f1,axis_f2,spectrum]=plot_2d(spin_system,spectrum,...
                                             parameters,ncont,delta,...
                                             k,ncol,m,signs)
 
+% Check spin specification
+grumble(spin_system,spectrum,parameters,ncont,delta,k,ncol,m,signs,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -191,7 +194,17 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,spectrum,parameters,ncont,delta,k,ncol,m,signs) %#ok<INUSL>
+function grumble(spin_system,spectrum,parameters,ncont,delta,k,ncol,m,signs,spins_only) %#ok<INUSL>
+
+if (nargin==10)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins should be specified in parameters.spins variable.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
+
 if (~isnumeric(spectrum))||(~ismatrix(spectrum))
     error('spectrum must be a matrix.');
 end
@@ -253,5 +266,5 @@ end
 % dreadful of deaths, whereas those who kill him risk nothing except
 % promotion.
 %
-% Albert Camus 
+% Albert Camus
 

--- a/kernel/plotting/plot_3d.m
+++ b/kernel/plotting/plot_3d.m
@@ -174,6 +174,25 @@ end
 if numel(parameters.sweep)~=3
     error('parameters.sweep array should have three elements.');
 end
+if ~isfield(parameters,'npoints')
+    error('point counts should be specified in parameters.npoints variable.');
+end
+if (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+   (numel(parameters.npoints)~=3)||any(~isfinite(parameters.npoints))||...
+   any(mod(parameters.npoints,1)~=0)||any(parameters.npoints<1)
+    error('parameters.npoints must be a three-element vector of positive integers.');
+end
+if ~isfield(parameters,'zerofill')
+    error('zero filling should be specified in parameters.zerofill variable.');
+end
+if (~isnumeric(parameters.zerofill))||(~isreal(parameters.zerofill))||...
+   (numel(parameters.zerofill)~=3)||any(~isfinite(parameters.zerofill))||...
+   any(mod(parameters.zerofill,1)~=0)||any(parameters.zerofill<1)
+    error('parameters.zerofill must be a three-element vector of positive integers.');
+end
+if ~isequal(size(spectrum),parameters.zerofill)
+    error('spectrum dimensions must match parameters.zerofill.');
+end
 if ~isfield(parameters,'axis_units')
     error('axis units must be specified in parameters.axis_units variable.');
 end
@@ -216,4 +235,3 @@ end
 % that they are. That is both amusing and dangerous.
 %
 % Mickey Mouse
-

--- a/kernel/plotting/plot_uf.m
+++ b/kernel/plotting/plot_uf.m
@@ -140,17 +140,38 @@ end
 if (numel(parameters.offset)~=2)
     error('parameters.offset array should have two elements.');
 end
-if ~isfield(parameters,'deltat')  
-    error('the time step of the acquisition gradient should be specified in the parameters.deltat variable.');  
+if ~isfield(parameters,'deltat')
+    error('the time step of the acquisition gradient should be specified in the parameters.deltat variable.');
 end
-if ~isfield(parameters,'npoints')  
-    error('the number of points in the acquisition gradient should be specified in the parameters.npoints variable.');  
+if ~isfield(parameters,'npoints')
+    error('the number of points in the acquisition gradient should be specified in the parameters.npoints variable.');
 end
-if ~isfield(parameters,'Ga')  
-    error('the amplitude of the acquisition gradient should be specified in the parameters.Ga variable.');  
+if ~isfield(parameters,'nloops')
+    error('the number of acquisition loops should be specified in the parameters.nloops variable.');
+end
+if ~isfield(parameters,'Te')
+    error('the echo time should be specified in the parameters.Te variable.');
+end
+if ~isfield(parameters,'axis_units')
+    error('axis units should be specified in the parameters.axis_units variable.');
+end
+if ~isfield(parameters,'Ga')
+    error('the amplitude of the acquisition gradient should be specified in the parameters.Ga variable.');
 end
 if ~isfield(parameters,'dims')  
     error('the sample dimension should be specified in the parameters.dims variable.');  
+end
+if (~isnumeric(parameters.nloops))||(~isreal(parameters.nloops))||...
+   (~isscalar(parameters.nloops))||(~isfinite(parameters.nloops))||...
+   (parameters.nloops<1)||(mod(parameters.nloops,1)~=0)
+    error('parameters.nloops must be a positive real integer.');
+end
+if (~isnumeric(parameters.Te))||(~isreal(parameters.Te))||...
+   (~isscalar(parameters.Te))||(~isfinite(parameters.Te))||(parameters.Te<=0)
+    error('parameters.Te must be a positive real scalar.');
+end
+if (~ischar(parameters.axis_units))||(~ismember(parameters.axis_units,{'ppm','Hz'}))
+    error('parameters.axis_units must be ''ppm'' or ''Hz''.');
 end
 end
 
@@ -160,4 +181,3 @@ end
 % Gill Reid (Head of Department), 
 % to IK when he asked for a sabba-
 % tical to write his book
-

--- a/kernel/plotting/slice_2d.m
+++ b/kernel/plotting/slice_2d.m
@@ -135,11 +135,7 @@ end
 function parameters=defaults(spin_system,parameters)
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'axis_units')
     report(spin_system,'parameters.axis_units field not set, assuming ppm.');
@@ -180,6 +176,8 @@ if ~ischar(parameters.axis_units)
 end
 if ~isfield(parameters,'spins')
     error('working spins should be specified in parameters.spins variable.');
+elseif isempty(parameters.spins)
+    error('parameters.spins variable cannot be empty.');
 end
 if ~iscell(parameters.spins)
     error('parameters.spins should be a cell array of character strings.');
@@ -219,3 +217,4 @@ end
 % to read a book and a tired man who wants a book to read.
 %
 % Gilbert K. Chesterton
+

--- a/kernel/plotting/slice_2d.m
+++ b/kernel/plotting/slice_2d.m
@@ -135,7 +135,11 @@ end
 function parameters=defaults(spin_system,parameters)
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'axis_units')
     report(spin_system,'parameters.axis_units field not set, assuming ppm.');
@@ -215,4 +219,3 @@ end
 % to read a book and a tired man who wants a book to read.
 %
 % Gilbert K. Chesterton
-

--- a/kernel/plotting/slice_2d.m
+++ b/kernel/plotting/slice_2d.m
@@ -58,6 +58,9 @@
 
 function slice_2d(spin_system,spectrum,parameters,ncont,delta,k,ncol,m,signs)
 
+% Check spin specification
+grumble(spin_system,spectrum,parameters,ncont,delta,k,ncol,m,signs,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -144,7 +147,17 @@ end
 end
 
 % Consistency enforcement
-function grumble(spin_system,spectrum,parameters,ncont,delta,k,ncol,m,signs)
+function grumble(spin_system,spectrum,parameters,ncont,delta,k,ncol,m,signs,spins_only)
+
+if (nargin==10)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins should be specified in parameters.spins variable.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
+
 if (~isnumeric(spectrum))||(~ismatrix(spectrum))
     error('spectrum must be a matrix.');
 end

--- a/kernel/plotting/stack_2d.m
+++ b/kernel/plotting/stack_2d.m
@@ -166,11 +166,7 @@ end
 function parameters=defaults(spin_system,parameters)
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    if isfield(parameters,'spins')
-        parameters.offset=zeros(size(parameters.spins));
-    else
-        parameters.offset=[];
-    end
+    parameters.offset=zeros(size(parameters.spins));
 end
 if ~isfield(parameters,'axis_units')
     report(spin_system,'parameters.axis_units field not set, assuming ppm.');
@@ -203,6 +199,8 @@ if ~ischar(parameters.axis_units)
 end
 if ~isfield(parameters,'spins')
     error('working spins should be specified in parameters.spins variable.');
+elseif isempty(parameters.spins)
+    error('parameters.spins variable cannot be empty.');
 end
 if ~iscell(parameters.spins)
     error('parameters.spins should be a cell array of character strings.');
@@ -224,3 +222,4 @@ end
 % insist on being equal.
 %
 % Friedrich Nietzsche
+

--- a/kernel/plotting/stack_2d.m
+++ b/kernel/plotting/stack_2d.m
@@ -166,7 +166,11 @@ end
 function parameters=defaults(spin_system,parameters)
 if ~isfield(parameters,'offset')
     report(spin_system,'parameters.offset field not set, assuming zero offsets.');
-    parameters.offset=zeros(size(parameters.spins));
+    if isfield(parameters,'spins')
+        parameters.offset=zeros(size(parameters.spins));
+    else
+        parameters.offset=[];
+    end
 end
 if ~isfield(parameters,'axis_units')
     report(spin_system,'parameters.axis_units field not set, assuming ppm.');
@@ -220,4 +224,3 @@ end
 % insist on being equal.
 %
 % Friedrich Nietzsche
-

--- a/kernel/plotting/stack_2d.m
+++ b/kernel/plotting/stack_2d.m
@@ -32,6 +32,9 @@
 
 function stack_2d(spin_system,spectrum,parameters,stack_dim,alpha_fun)
 
+% Check spin specification
+grumble(spectrum,parameters,stack_dim,true);
+
 % Set common defaults
 parameters=defaults(spin_system,parameters);
 
@@ -175,7 +178,17 @@ end
 end
 
 % Consistency enforcement
-function grumble(spectrum,parameters,stack_dim)
+function grumble(spectrum,parameters,stack_dim,spins_only)
+
+if (nargin==4)&&spins_only
+    if ~isfield(parameters,'spins')
+        error('working spins should be specified in parameters.spins variable.');
+    elseif isempty(parameters.spins)
+        error('parameters.spins variable cannot be empty.');
+    end
+    return
+end
+
 if (~isnumeric(spectrum))||(~ismatrix(spectrum))
     error('spectrum must be a matrix.');
 end

--- a/kernel/pulses/cartesian2polar.m
+++ b/kernel/pulses/cartesian2polar.m
@@ -171,8 +171,9 @@ elseif nargin==8
         error('all input vectors must have the same dimension.');
     end
     if (size(Dxx,2)~=length(Dx))||(size(Dxx,1)~=size(Dxx,2))||...
-        all(size(Dxx)~=size(Dyy))||all(size(Dyy)~=size(Dxy))||...
-        all(size(Dxy)~=size(Dyx))
+        (~isequal(size(Dxx),size(Dyy)))||...
+        (~isequal(size(Dyy),size(Dxy)))||...
+        (~isequal(size(Dxy),size(Dyx)))
         error('all input matrices must have the same, square dimensions.');
     end
 end
@@ -181,4 +182,3 @@ end
 % Beware of geeks bearing formulas.
 %
 % Warren Buffett
-

--- a/kernel/pulses/chirp_pulse.m
+++ b/kernel/pulses/chirp_pulse.m
@@ -166,16 +166,24 @@ end
 % Consistency enforcement
 function grumble(npts,dur,bwidth,smp,type)
 if (~isnumeric(dur))||(~isreal(dur))||...
-   (~isfinite(dur))||(numel(dur)~=1)||(dur<=0)
+   (numel(dur)~=1)||(~isfinite(dur))||(dur<=0)
     error('dur must be a positive real number.');
 end
 if (~isnumeric(bwidth))||(~isreal(bwidth))||...
-   (~isfinite(bwidth))||(numel(bwidth)~=1)||(bwidth<=0)
+   (numel(bwidth)~=1)||(~isfinite(bwidth))||(bwidth<=0)
     error('bwidth must be a positive real number.');
 end
-if (~isnumeric(npts))||(~isreal(npts))||(~isfinite(npts))||...
-   (numel(npts)~=1)||(npts<1)||(mod(npts,1)~=0)
+if (~isnumeric(npts))||(~isreal(npts))||(numel(npts)~=1)||...
+   (~isfinite(npts))||(npts<1)||(mod(npts,1)~=0)
     error('npts must be a positive real integer.');
+end
+if (~ischar(type))||(~ismember(type,{'wurst','wurst-adaptive',...
+                                    'smoothed','smoothed-adaptive',...
+                                    'saltire','saltire-adaptive'}))
+    error('type must be a supported chirp pulse type.');
+end
+if (~isnumeric(smp))||(~isreal(smp))||(numel(smp)~=1)||(~isfinite(smp))
+    error('smp must be a finite real scalar.');
 end
 if contains(type,'wurst')&&(smp<1)
     error('smp for ''wurst'' pulse must be greater than 1.');
@@ -192,4 +200,3 @@ end
 %
 % Unofficial motto of Southampton
 % Chemistry Department
-

--- a/kernel/pulses/heterodyne.m
+++ b/kernel/pulses/heterodyne.m
@@ -72,16 +72,17 @@ end
 
 % Consistency enforcement
 function grumble(dt,signal,freq)
-if (~isnumeric(dt))||(~isreal(dt))||(~isscalar(dt))||(dt<=0)
+if (~isnumeric(dt))||(~isreal(dt))||(~isscalar(dt))||...
+   (~isfinite(dt))||(dt<=0)
     error('dt must be a positive real number.');
 end
 if (~isnumeric(signal))||(~isreal(signal))||(~iscolumn(signal))
     error('signal must be a real column vector.');
 end
-if (~isnumeric(freq))||(~isreal(freq))||(~isscalar(freq))
+if (~isnumeric(freq))||(~isreal(freq))||(~isscalar(freq))||(~isfinite(freq))
     error('freq must be a real number.');
 end
-if (2*dt)>(1/freq)
+if (freq~=0)&&((4*dt)>(1/abs(freq)))
     error('the specified frequency is not sampled well enough.');
 end
 end
@@ -97,4 +98,3 @@ end
 %
 % Malcolm Levitt's email to 
 % his group, July 2023.
-

--- a/kernel/pulses/iserstep.m
+++ b/kernel/pulses/iserstep.m
@@ -485,6 +485,9 @@ function grumble(LTM,rho_a,dt)
 if ~iscell(LTM)
     error('second input must be a cell array.');
 end
+if numel(LTM)~=3
+    error('second input must contain a generator, a time, and a method.');
+end
 if ~isa(LTM{1},'function_handle')
     error('evolution generator must be a function handle.');
 end
@@ -493,6 +496,10 @@ if (~isnumeric(LTM{2}))||(~isscalar(LTM{2}))
 end
 if ~ischar(LTM{3})
     error('method must be a character string.')
+end
+if ~ismember(LTM{3},{'PWCL','LG2','LG4','LG4A','RKMK4','RKMK-DP5',...
+                    'RKMK-DP8','RKMK-RKF45'})
+    error('method is not supported.')
 end
 if (~isnumeric(dt))||(~isnumeric(rho_a))
     error('rho_a and dt must be numeric.');
@@ -507,4 +514,3 @@ end
 % they didn't look capable of doing either.
 %
 % Ronald Reagan
-

--- a/kernel/pulses/polar2cartesian.m
+++ b/kernel/pulses/polar2cartesian.m
@@ -60,9 +60,6 @@
 
 function [x,y,Dx,Dy,Dxx,Dxy,Dyx,Dyy]=polar2cartesian(r,p,Dr,Dp,Drr,Drp,Dpr,Dpp)
 
-% Wrap phase
-p=wrapToPi(p);
-
 % Check consistency
 if nargin==2
     grumble(r,p);
@@ -73,6 +70,9 @@ elseif nargin==8
 else
     error('incorrect number of arguments.');
 end
+
+% Wrap phase
+p=wrapToPi(p);
 
 % Transform coordinates
 x=r.*cos(p); y=r.*sin(p);
@@ -137,7 +137,7 @@ elseif nargin==4
        (~all(size(df_dr)==size(df_dp)))
         error('all input vectors must have the same dimension.');
     end
-elseif nargin==7
+elseif nargin==8
     if (~isnumeric(r))||(~isreal(r))||(~all(r>=0))
         error('amplitude parameter must be a vector of non-negative real numbers.');
     end
@@ -167,8 +167,9 @@ elseif nargin==7
         error('ddf_dAdphi parameter must be a matrix of real numbers.');
     end
     if (size(d2f_dr2,2)~=length(df_dr))||(size(d2f_dr2,1)~=size(d2f_dr2,2))||...
-        all(size(d2f_dr2)~=size(d2f_dp2))||all(size(d2f_dp2)~=size(d2f_drdp))||...
-        all(size(d2f_drdp)~=size(d2f_dpdr))
+        (~isequal(size(d2f_dr2),size(d2f_dp2)))||...
+        (~isequal(size(d2f_dp2),size(d2f_drdp)))||...
+        (~isequal(size(d2f_drdp),size(d2f_dpdr)))
         error('all input matrices must have the same, square dimensions.');
     end
 end
@@ -177,4 +178,3 @@ end
 % A public opinion poll is no substitute for thought.
 %
 % Warren Buffett
-

--- a/kernel/pulses/restrans.m
+++ b/kernel/pulses/restrans.m
@@ -57,7 +57,7 @@
 function [X,Y,dt]=restrans(X_user,Y_user,dt_user,omega,Q,model,up_factor)
 
 % Check consistency
-grumble(X_user,Y_user,dt_user,omega,Q)
+grumble(X_user,Y_user,dt_user,omega,Q,model,up_factor)
 
 % 16 x Nyquist oversampling
 dt=pi/(16*omega);
@@ -156,20 +156,31 @@ end
 end
 
 % Consistency enforcement
-function grumble(X_user,Y_user,dt_user,omega,Q)
+function grumble(X_user,Y_user,dt_user,omega,Q,model,up_factor)
 if (~isnumeric(dt_user))||(~isreal(dt_user))||...
-   (~isscalar(dt_user))||(dt_user<=0)
+   (~isscalar(dt_user))||(~isfinite(dt_user))||(dt_user<=0)
     error('dt_user must be a real positive scalar.');
 end
 if (~isnumeric(X_user))||(~isreal(X_user))||(~iscolumn(X_user))||...
    (~isnumeric(Y_user))||(~isreal(Y_user))||(~iscolumn(Y_user))
     error('X_user and Y_user must be real column vectors.');
 end
-if (~isnumeric(omega))||(~isreal(omega))||(~isscalar(omega))
-    error('omega must be a real scalar.');
+if numel(X_user)~=numel(Y_user)
+    error('X_user and Y_user must have the same number of elements.');
 end
-if (~isnumeric(Q))||(~isreal(Q))||(~isscalar(Q))||(Q<=0)
+if (~isnumeric(omega))||(~isreal(omega))||(~isscalar(omega))||...
+   (~isfinite(omega))||(omega<=0)
+    error('omega must be a positive real scalar.');
+end
+if (~isnumeric(Q))||(~isreal(Q))||(~isscalar(Q))||(~isfinite(Q))||(Q<=0)
     error('Q must be a positive real scalar.');
+end
+if (~ischar(model))||(~ismember(model,{'pwc','pwl','pwl_tsc'}))
+    error('model must be ''pwc'', ''pwl'', or ''pwl_tsc''.');
+end
+if (~isnumeric(up_factor))||(~isreal(up_factor))||(~isscalar(up_factor))||...
+   (~isfinite(up_factor))||(up_factor<1)||(mod(up_factor,1)~=0)
+    error('up_factor must be a positive real integer.');
 end
 if dt_user<(pi/omega)
     error('dt_user breaks rotating frame approximation.');
@@ -182,4 +193,3 @@ end
 % famines, the enslavements - perpetrated by mankind's governments.
 %
 % Ayn Rand
-

--- a/kernel/pulses/rseq_compiler.m
+++ b/kernel/pulses/rseq_compiler.m
@@ -104,12 +104,25 @@ end
 if (~isnumeric(pulse_phi))||(~isreal(pulse_phi))
     error('pulse_phi must be a real numeric array.');
 end
-if (~isnumeric(pulse_dur))||(~isreal(pulse_dur))
-    error('pulse_dur must be a real numeric array.');
+if (~isnumeric(pulse_dur))||(~isreal(pulse_dur))||...
+   any(~isfinite(pulse_dur(:)))||any(pulse_dur(:)<=0)
+    error('pulse_dur must be a positive real numeric array.');
+end
+if ~ismember(element_type,{'180_pulse','90270_pulse'})
+    error('element_type is not supported.');
+end
+switch element_type
+    case '180_pulse'
+        if numel(pulse_dur)~=1
+            error('pulse_dur must be scalar for 180_pulse elements.');
+        end
+    case '90270_pulse'
+        if (numel(pulse_dur)~=2)||(mod(numel(pulse_phi),2)~=0)
+            error('90270_pulse elements require two durations and an even number of phases.');
+        end
 end
 end
 
 % The more I learn about people, the more I like my dog.
 %
 % Mark Twain
-

--- a/kernel/pulses/rsequence.m
+++ b/kernel/pulses/rsequence.m
@@ -175,8 +175,9 @@ if (~isnumeric(n_cycle_repeats))||(~isreal(n_cycle_repeats))||...
    (n_cycle_repeats<1)
     error('n_cycle_repeats must be a positive real scalar.');
 end
-if (~isnumeric(mas_rate))||(~isreal(mas_rate))||(~isscalar(mas_rate))
-    error('mas_rate must be a real scalar.');
+if (~isnumeric(mas_rate))||(~isreal(mas_rate))||(~isscalar(mas_rate))||...
+   (~isfinite(mas_rate))||(mas_rate<=0)
+    error('mas_rate must be a positive real scalar.');
 end
 if (~isnumeric(phase_factor))||(~isreal(phase_factor))||...
    (~isscalar(phase_factor))
@@ -193,4 +194,3 @@ end
 % Effortlessness is hard.
 %
 % Sarah Sands
-

--- a/kernel/pulses/shaped_pulse_af.m
+++ b/kernel/pulses/shaped_pulse_af.m
@@ -268,8 +268,9 @@ end
 if (~isnumeric(rf_amp_list))||(~isreal(rf_amp_list))||any(~isfinite(rf_amp_list))
     error('rf_amp_list must be a vector of real numbers.');
 end
-if (~isnumeric(rf_dur_list))||(~isreal(rf_dur_list))||any(~isfinite(rf_dur_list))
-    error('rf_amp_list must be a vector of real numbers.');
+if (~isnumeric(rf_dur_list))||(~isreal(rf_dur_list))||...
+   any(~isfinite(rf_dur_list))||any(rf_dur_list<=0)
+    error('rf_dur_list must be a vector of positive real numbers.');
 end
 if (numel(rf_frq_list)~=numel(rf_amp_list))||...
    (numel(rf_amp_list)~=numel(rf_dur_list))
@@ -291,4 +292,3 @@ end
 % of the puddles in the road.
 %
 % Alexander Smith
-

--- a/kernel/pulses/shaped_pulse_xy.m
+++ b/kernel/pulses/shaped_pulse_xy.m
@@ -366,8 +366,16 @@ if (~isnumeric(slice_durs))||(~isreal(slice_durs))||...
      any(~isfinite(slice_durs),'all')||any(slice_durs<0,'all')
     error('slice_durs must be a vector of non-negative real numbers.');
 end
+if (~ischar(method))||(~ismember(method,{'expv-pwc','expv-pwl',...
+                                         'expm-pwc','expm-pwl',...
+                                         'evol-pwc','evol-pwl'}))
+    error('method must be a supported propagation method string.');
+end
 if (~iscell(amplitudes))||isempty(amplitudes)
     error('amplitudes must be a cell array of vectors.');
+end
+if numel(amplitudes)~=numel(controls)
+    error('amplitudes must have one element per control operator.');
 end
 for n=1:numel(amplitudes)
     if ~isnumeric(amplitudes{n})
@@ -398,4 +406,3 @@ end
 % PTCL Teaching Lab, but the photographs of the resulting fibre tip
 % were left on Peter's table on Monday. The paper was accepted by 
 % JMR without revisions.
-

--- a/kernel/pulses/uhrig_times.m
+++ b/kernel/pulses/uhrig_times.m
@@ -39,10 +39,11 @@ end
 
 % Consistency enforcement
 function grumble(T,N)
-if (~isreal(T))||(~isscalar(T))||(T<=0)
+if (~isnumeric(T))||(~isreal(T))||(~isscalar(T))||(~isfinite(T))||(T<=0)
     error('T must be a positive real scalar.');
 end
-if (~isreal(N))||(~isscalar(N))||(N<1)||(mod(N,1)~=0)
+if (~isnumeric(N))||(~isreal(N))||(~isscalar(N))||(~isfinite(N))||...
+   (N<1)||(mod(N,1)~=0)
     error('N must be a positve real integer.');
 end
 end
@@ -57,4 +58,3 @@ end
 % is the law of Australia'. Finally, some progress in the war on math!"
 %
 % Laudation for Malcolm Turnbull's Pwnie Award nomination
-

--- a/kernel/pulses/vg_pulse.m
+++ b/kernel/pulses/vg_pulse.m
@@ -116,11 +116,11 @@ if ~ischar(pulse_name)
     error('pulse_name must be a character string.');
 end
 if (numel(npoints)~=1)||(~isnumeric(npoints))||(~isreal(npoints))||...
-   (npoints<1)||(mod(npoints,1)~=0)
+   (~isfinite(npoints))||(npoints<1)||(mod(npoints,1)~=0)
     error('npoints must be a positive real integer greater than 1.');
 end
 if (numel(duration)~=1)||(~isnumeric(duration))||...
-   (~isreal(duration))||(duration<0)
+   (~isreal(duration))||(~isfinite(duration))||(duration<=0)
     error('duration must be a positive real number.');
 end
 end
@@ -133,4 +133,3 @@ end
 % noble soul has reverence for itself.
 %
 % Friedrich Nietzsche, in "Beyond Good and Evil"
-

--- a/kernel/states/zftrip.m
+++ b/kernel/states/zftrip.m
@@ -96,8 +96,10 @@ if (~isnumeric(Z))||(~isreal(Z))||(size(Z,1)~=3)||...
    (size(Z,2)~=3)||(norm(Z-Z','fro')>1e-6*norm(Z,'fro'))
     error('Z must be a real symmetric 3x3 matrx.');
 end
-if (~isnumeric(pops))||(~isreal(pops))||(numel(pops)~=3)||(sum(pops)~=1)
-    error('pops must be a real three-element vector with a unit sum.');
+if (~isnumeric(pops))||(~isreal(pops))||(numel(pops)~=3)||...
+   any(~isfinite(pops(:)))||any(pops(:)<0)||...
+   (abs(sum(pops)-1)>1e-10)
+    error('pops must be a finite non-negative real three-element vector with a unit sum.');
 end
 if (~isnumeric(B))||(~isreal(B))||(~isscalar(B))
     error('B must be a real scalar.');
@@ -117,4 +119,3 @@ end
 % Lupus dentis, taurus cornis.
 %
 % A Latin proverb
-

--- a/kernel/utilities/apodisation.m
+++ b/kernel/utilities/apodisation.m
@@ -74,11 +74,11 @@
 
 function fid=apodisation(spin_system,fid,winfuns,fp_half)
 
-% Check consistency
-grumble(fid,winfuns);
-
 % Default is to halve first points
 if ~exist('fp_half','var'), fp_half=true(); end
+
+% Check consistency
+grumble(fid,winfuns,fp_half);
 
 % Find non-singleton dimensions
 rel_dims=true(1,ndims(fid));
@@ -206,17 +206,46 @@ end
 end
 
 % Consistency enforcement
-function grumble(fid,winfuns)
+function grumble(fid,winfuns,fp_half)
 if ~isnumeric(fid)
     error('fid must be a numeric array.');
 end
 if ~iscell(winfuns)
     error('winfuns must be a cell array.');
 end
+rel_dims=true(1,ndims(fid));
+rel_dims(size(fid)<2)=false();
+rel_dims=find(rel_dims);
+if (~isempty(rel_dims))&&(numel(winfuns)<max(rel_dims))
+    error('winfuns must cover all non-singleton dimensions of fid.');
+end
+if numel(winfuns)>ndims(fid)
+    error('winfuns must not have more elements than fid has dimensions.');
+end
 for n=1:numel(winfuns)
     if ~iscell(winfuns{n})
         error('elements of winfuns must be cell arrays.');
     end
+    if isempty(winfuns{n})
+        continue;
+    end
+    if (~ischar(winfuns{n}{1}))||...
+       (~ismember(winfuns{n}{1},{'none','crisp','exp','gauss','cos','sin',...
+                                  'sqcos','sqsin','kaiser','bad-z1','bad-z2'}))
+        error('window function type is not supported.');
+    end
+    if ismember(winfuns{n}{1},{'exp','gauss','kaiser','bad-z1','bad-z2'})
+        if (numel(winfuns{n})~=2)||(~isnumeric(winfuns{n}{2}))||...
+           (~isreal(winfuns{n}{2}))||(~isscalar(winfuns{n}{2}))||...
+           (~isfinite(winfuns{n}{2}))
+            error('window function parameter must be a finite real scalar.');
+        end
+    elseif numel(winfuns{n})~=1
+        error('this window function does not take parameters.');
+    end
+end
+if (~islogical(fp_half))||(~isscalar(fp_half))
+    error('fp_half must be a logical scalar.');
 end
 end
 
@@ -224,4 +253,3 @@ end
 % know how I am to arrive at them.
 % 
 % Carl Friedrich Gauss
-

--- a/kernel/utilities/apodisation.m
+++ b/kernel/utilities/apodisation.m
@@ -74,11 +74,11 @@
 
 function fid=apodisation(spin_system,fid,winfuns,fp_half)
 
+% Check consistency
+grumble(fid,winfuns);
+
 % Default is to halve first points
 if ~exist('fp_half','var'), fp_half=true(); end
-
-% Check consistency
-grumble(fid,winfuns,fp_half);
 
 % Find non-singleton dimensions
 rel_dims=true(1,ndims(fid));
@@ -206,7 +206,7 @@ end
 end
 
 % Consistency enforcement
-function grumble(fid,winfuns,fp_half)
+function grumble(fid,winfuns)
 if ~isnumeric(fid)
     error('fid must be a numeric array.');
 end
@@ -243,9 +243,6 @@ for n=1:numel(winfuns)
     elseif numel(winfuns{n})~=1
         error('this window function does not take parameters.');
     end
-end
-if (~islogical(fp_half))||(~isscalar(fp_half))
-    error('fp_half must be a logical scalar.');
 end
 end
 

--- a/kernel/utilities/hydrodynamics.m
+++ b/kernel/utilities/hydrodynamics.m
@@ -136,8 +136,12 @@ if (~ischar(parameters.deriv{1}))||(~ismember(parameters.deriv{1},{'period','fou
     error('the first element of parameters.deriv must be ''period'' or ''fourier''.');
 end
 if strcmp(parameters.deriv{1},'period')
+    if numel(parameters.deriv)~=2
+        error('periodic differentiation requires a stencil size in the second element of parameters.deriv.');
+    end
     if (~isnumeric(parameters.deriv{2}))||(~isreal(parameters.deriv{2}))||...
-       (numel(parameters.deriv{2})~=1)||mod(parameters.deriv{2},1)
+       (numel(parameters.deriv{2})~=1)||mod(parameters.deriv{2},1)||...
+       (parameters.deriv{2}<1)
         error('stencil size in the second element of parameters.deriv must be a positive integer.');
     end
     if parameters.deriv{2}>7
@@ -158,4 +162,3 @@ end
 % blowing forlornly in the direction indicated.
 %
 % Viktor Shenderovich
-

--- a/kernel/utilities/lorentzcon.m
+++ b/kernel/utilities/lorentzcon.m
@@ -27,7 +27,7 @@
 function y=lorentzcon(offs,ampl,fwhm,x)
 
 % Check consistency
-grumble(x,fwhm);
+grumble(offs,ampl,fwhm,x);
 
 % Width parameter
 gam=fwhm/2;
@@ -80,12 +80,20 @@ end
 end
 
 % Consistency enforcement
-function grumble(x,fwhm)
-if (~isnumeric(x))||(~isreal(x))
-    error('x must be an array of real numbers.');
+function grumble(offs,ampl,fwhm,x)
+if (~isnumeric(offs))||(~isreal(offs))||...
+   (~ismember(numel(offs),[1 3]))||any(~isfinite(offs(:)))
+    error('offs must be a finite real scalar or a three-element vector.');
+end
+if (~isnumeric(ampl))||(~isreal(ampl))||...
+   (numel(ampl)~=1)||(~isfinite(ampl))
+    error('ampl must be a finite real scalar.');
+end
+if (~isnumeric(x))||(~isreal(x))||any(~isfinite(x(:)))
+    error('x must be an array of finite real numbers.');
 end
 if (~isnumeric(fwhm))||(~isreal(fwhm))||...
-   (numel(fwhm)~=1)||(fwhm<=0)
+   (numel(fwhm)~=1)||(~isfinite(fwhm))||(fwhm<=0)
     error('fwhm must be a positive real number.');
 end
 end
@@ -95,4 +103,3 @@ end
 % to have to marry us for.
 %
 % A feminist web site
-

--- a/kernel/utilities/magpump.m
+++ b/kernel/utilities/magpump.m
@@ -45,7 +45,7 @@ end
 if (~isnumeric(rho))||(~iscolumn(rho))
     error('rho must be a column vector.');
 end
-if (~isnumeric(rate))||(~real(rate))||(~isscalar(rate))
+if (~isnumeric(rate))||(~isreal(rate))||(~isscalar(rate))||(~isfinite(rate))
     error('rate must be a real scalar.');
 end
 if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
@@ -65,4 +65,3 @@ end
 % beautiful form of regularity proves to have been latent all along.
 % 
 % Sir Francis Galton
-

--- a/kernel/utilities/svd_shrink.m
+++ b/kernel/utilities/svd_shrink.m
@@ -24,7 +24,7 @@
 function [vec,cov]=svd_shrink(spin_system,rho,tol)
 
 % Check consistency
-grumble(rho);
+grumble(rho,tol);
 
 % Run the singular value decomposition
 [vec,S,cov]=svd(full(rho)); S=diag(S);
@@ -46,9 +46,13 @@ cov=cov*diag(sqrt(S));
 end
 
 % Consistency enforcement
-function grumble(rho)
+function grumble(rho,tol)
 if (~isnumeric(rho))||(size(rho,1)~=size(rho,2))
     error('rho must be a square matrix.');
+end
+if (~isnumeric(tol))||(~isreal(tol))||(~isscalar(tol))||...
+   (~isfinite(tol))||(tol<0)
+    error('tol must be a finite non-negative real scalar.');
 end
 end
 
@@ -57,4 +61,3 @@ end
 % thing to grasp. Conflict goes with the territory.
 %
 % Andrew Oswald
-

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -330,8 +330,24 @@ if (numel(parameters.npts)==3)
     end
 end
 if isfield(parameters,'diff')
-    if (~isnumeric(parameters.diff))||(~isreal(parameters.diff))
-        error('parameters.diff must a real scalar or matrix.');
+    if (~isnumeric(parameters.diff))||(~isreal(parameters.diff))||...
+       any(~isfinite(parameters.diff(:)))
+        error('parameters.diff must be a finite real scalar or matrix.');
+    end
+    if isscalar(parameters.diff)
+        if parameters.diff<0
+            error('parameters.diff must be non-negative.');
+        end
+    else
+        if ~isequal(size(parameters.diff),numel(parameters.npts)*[1 1])
+            error('parameters.diff matrix dimensions must match the sample dimensionality.');
+        end
+        if norm(parameters.diff-parameters.diff','fro')>1e-10*norm(parameters.diff,'fro')
+            error('parameters.diff matrix must be symmetric.');
+        end
+        if any(eig(parameters.diff,'vector')<0)
+            error('parameters.diff matrix must have non-negative eigenvalues.');
+        end
     end
 end
 if ~isfield(parameters,'dims')
@@ -354,8 +370,12 @@ if (~ischar(parameters.deriv{1}))||(~ismember(parameters.deriv{1},{'period','fou
     error('the first element of parameters.deriv must be ''period'' or ''fourier''.');
 end
 if strcmp(parameters.deriv{1},'period')
+    if numel(parameters.deriv)~=2
+        error('periodic differentiation requires a stencil size in the second element of parameters.deriv.');
+    end
     if (~isnumeric(parameters.deriv{2}))||(~isreal(parameters.deriv{2}))||...
-       (numel(parameters.deriv{2})~=1)||mod(parameters.deriv{2},1)
+       (numel(parameters.deriv{2})~=1)||mod(parameters.deriv{2},1)||...
+       (parameters.deriv{2}<1)
         error('stencil size in the second element of parameters.deriv must be a positive integer.');
     end
     if parameters.deriv{2}>7
@@ -375,4 +395,3 @@ end
 % "He's spending a year dead for tax reasons."
 %
 % Douglas Adams, The Hitchhiker's Guide to the Galaxy
-


### PR DESCRIPTION
## Summary

- Fixes all issues listed in `Spinach_grumbler_audit_report.md` across kernel, contexts, utilities, pulses, plotting/cache/overloads, experiments, interfaces, and etc.
- Adds missing validation for optional/defaulted fields, filename/script inputs, grumbler typos, scalar-logical hazards, cell topology, pulse/Hessian dimensions, imaging/SPEN fields, and weak or empty grumblers.
- Keeps changes scoped to validation and the small runtime typo fixes identified by the audit.

## Validation

- `git diff --check`
- `matlab -nojvm -batch "run('/home/kuprov/.openclaw/workspace/tmp/slack_tasks/c0b00hlq2ce/1779367298-745639-spinach-grumbler-fix/validate_mtree.m')"` -> `MATLAB_MTREE_OK`
- `matlab -nojvm -batch "run('/home/kuprov/.openclaw/workspace/tmp/slack_tasks/c0b00hlq2ce/1779367298-745639-spinach-grumbler-fix/validate_probes.m')"` -> `MATLAB_PROBES_OK`

