### PR TITLE
Fix portable paths in examples

### DIFF
--- a/examples/nmr_liquids/inad_sucrose.m
+++ b/examples/nmr_liquids/inad_sucrose.m
@@ -10,7 +10,7 @@ function inad_sucrose()
 
 % Spin system properties (vacuum DFT calculation)
 options.min_j=5.0; options.no_xyz=1;
-[sys,inter]=g2spinach(gparse('..\standard_systems\sucrose.log'),...
+[sys,inter]=g2spinach(gparse('../standard_systems/sucrose.log'),...
             {{'H','1H'},{'C','13C'}},[31.8 189.7],options);
 
 % Set the isotropic parts of shielding tensors to experimental values

--- a/examples/nmr_solids/cp_acquire_mas_gly.m
+++ b/examples/nmr_solids/cp_acquire_mas_gly.m
@@ -9,7 +9,7 @@
 function cp_acquire_mas_gly()
 
 % Spin system properties (PCM DFT calculation)
-[sys,inter]=g2spinach(gparse('..\..\examples\standard_systems\glycine.log'),...
+[sys,inter]=g2spinach(gparse('../../examples/standard_systems/glycine.log'),...
                       {{'H','1H'},{'C','13C'}},[31.8 182.1],[]);
 
 % 400 MHz spectrometer

--- a/examples/nmr_solids/fslghetcor_mas_gly.m
+++ b/examples/nmr_solids/fslghetcor_mas_gly.m
@@ -8,7 +8,7 @@
 function fslghetcor_mas_gly()
 
 % Spin system properties (PCM DFT calculation)
-[sys,inter]=g2spinach(gparse('..\..\examples\standard_systems\glycine.log'),...
+[sys,inter]=g2spinach(gparse('../../examples/standard_systems/glycine.log'),...
                       {{'H','1H'},{'C','13C'}},[31.8 182.1],[]);
 
 % 400 MHz spectrometer

--- a/examples/nmr_solids/wise_mas_gly.m
+++ b/examples/nmr_solids/wise_mas_gly.m
@@ -8,7 +8,7 @@
 function wise_mas_gly()
 
 % Spin system properties (PCM DFT calculation)
-[sys,inter]=g2spinach(gparse('..\..\examples\standard_systems\glycine.log'),...
+[sys,inter]=g2spinach(gparse('../../examples/standard_systems/glycine.log'),...
                       {{'H','1H'},{'C','13C'}},[31.8 182.1],[]);
 
 % 400 MHz spectrometer

--- a/examples/visualisation/cst_peptide_bond.m
+++ b/examples/visualisation/cst_peptide_bond.m
@@ -9,7 +9,7 @@
 function cst_peptide_bond()
     
 % Read the Gaussian log
-props=gparse('..\standard_systems\amino_acids\ala.log');
+props=gparse('../standard_systems/amino_acids/ala.log');
 
 % Do the visualisation
 kfigure(); scale_figure([2.0 1.0]);


### PR DESCRIPTION
Summary:
- Replace Windows-only backslash separators in five example `gparse()` calls with forward slashes.
- Keep the changes conservative: no path shortening, refactoring, or example logic changes.

Validation:
- `git diff --check`
- `rg -n "gparse\\('.*\\\\.*\\.log" examples` returned no remaining matching example log paths.
- MATLAB `exist()` check from the affected example directories printed `PATH_CHECK_PASS`.
- MATLAB `gparse()` check parsed the sucrose, glycine, and alanine Gaussian logs and printed `GPARSE_PATH_CHECK_PASS`; the known JVM-free MATLAB shutdown allocator crash occurred after the success marker.
