### PR TITLE
Add pseudomodulation kernel function

### DIFF
--- a/kernel/derivatives/pseudomodulation.m
+++ b/kernel/derivatives/pseudomodulation.m
@@ -1,0 +1,115 @@
+% Pseudomodulation of uniformly sampled spectra using the Hyde
+% et al. Fourier-domain algorithm. Syntax:
+%
+%       output=pseudomodulation(field,spectrum,mod_amp,mod_order)
+%
+% Parameters:
+%
+%       field     - N-by-1 real, ordered, uniformly spaced field
+%                   axis
+%
+%       spectrum  - N-by-M spectrum matrix; rows are field samples,
+%                   and columns are independent spectra
+%
+%       mod_amp   - non-negative modulation amplitude in field units
+%
+%       mod_order - modulation harmonic order: 0, 1, or 2
+%
+% Outputs:
+%
+%       output    - N-by-M pseudomodulated spectrum matrix
+%
+% The implementation follows Eqs. 5-7 of Hyde et al., J. Magn.
+% Reson. 96, 1-13 (1992). After phase-sensitive detection, the
+% time-dependent prefactors are set to unity, leaving amplitude
+% factors 2i for the first harmonic, and 2 for the second harmonic.
+%
+% alexey.bogdanov@weizmann.ac.il
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=pseudomodulation.m>
+
+function output=pseudomodulation(field,spectrum,mod_amp,mod_order)
+
+% Check consistency
+grumble(field,spectrum,mod_amp,mod_order);
+
+% Get field grid parameters
+npts=numel(field);
+field_step=field(2)-field(1);
+
+% Build the angular frequency axis in Matlab FFT ordering
+ang_freq=sign(field_step)*real(fftdiff(1,npts,abs(field_step))/1i);
+ang_freq=ang_freq(:);
+
+% Convert the modulation amplitude into Bessel arguments
+bessel_arg=mod_amp*ang_freq/2;
+
+% Fourier transform along the field axis
+spec_ft=fft(spectrum,npts,1);
+
+% Apply the requested pseudomodulation harmonic
+switch mod_order
+
+    case 0
+
+        % Zeroth harmonic
+        output=ifft(spec_ft.*besselj(0,bessel_arg),npts,1);
+
+    case 1
+
+        % First harmonic
+        output=2i*ifft(spec_ft.*besselj(1,bessel_arg),npts,1);
+
+    case 2
+
+        % Second harmonic
+        output=2*ifft(spec_ft.*besselj(2,bessel_arg),npts,1);
+
+end
+
+% Remove round-off imaginary parts from real input spectra
+if isreal(spectrum)
+    output=real(output);
+end
+
+end
+
+% Consistency enforcement
+function grumble(field,spectrum,mod_amp,mod_order)
+if (~isfloat(field))||isempty(field)||issparse(field)||(~iscolumn(field))
+    error('field must be a non-empty dense floating-point column vector.');
+end
+if (~isreal(field))||any(~isfinite(field(:)))
+    error('field must contain finite real numbers.');
+end
+npts=numel(field);
+if npts<3
+    error('field must contain at least three points.');
+end
+field_ref=linspace(field(1),field(end),npts).';
+grid_tol=npts*eps(max([1; abs(field)]));
+if any(abs(field-field_ref)>grid_tol)
+    error('field must be ordered and uniformly spaced.');
+end
+if field(1)==field(end)
+    error('field must have a non-zero sweep width.');
+end
+if (~isfloat(spectrum))||isempty(spectrum)||issparse(spectrum)||(~ismatrix(spectrum))
+    error('spectrum must be a non-empty dense floating-point matrix.');
+end
+if any(~isfinite(spectrum(:)))
+    error('spectrum must not contain NaN or Inf values.');
+end
+if size(spectrum,1)~=npts
+    error('spectrum must have the same number of rows as field has points.');
+end
+if (~isnumeric(mod_amp))||(~isreal(mod_amp))||(numel(mod_amp)~=1)||...
+   (~isfinite(mod_amp))||(mod_amp<0)
+    error('mod_amp must be a non-negative finite real scalar.');
+end
+if (~isnumeric(mod_order))||(~isreal(mod_order))||(numel(mod_order)~=1)||...
+   (~ismember(mod_order,[0 1 2]))
+    error('mod_order must be 0, 1, or 2.');
+end
+end

--- a/tests/kernel/test_finite_difference_suite.m
+++ b/tests/kernel/test_finite_difference_suite.m
@@ -7,8 +7,9 @@
 %     result  - regression test result with explanatory messages
 %
 % The test checks finite-difference weights, finite-difference matrices,
-% Fourier differentiation, Laplacians, FFT differentiation kernels, and
-% matrix-exponential directional derivatives against exact simple cases.
+% Fourier differentiation, Laplacians, FFT differentiation kernels,
+% pseudomodulation, and matrix-exponential directional derivatives
+% against exact simple cases.
 %
 % ilya.kuprov@weizmann.ac.il
 
@@ -20,7 +21,7 @@ fprintf('TESTING: Finite-difference and spectral differentiation functions\n');
 % State the differentiation target of the test
 result=new_test_result('kernel/finite_difference_suite',...
                        'Finite-difference and spectral differentiation functions',...
-                       'differentiation helpers must reproduce exact low-order polynomial and Fourier derivatives.');
+                       'differentiation and pseudomodulation helpers must reproduce exact limiting cases.');
 
 % Three-point centred finite-difference weights at zero are exact and familiar
 w=fdweights(0,[-1 0 1],2);
@@ -110,6 +111,46 @@ result=test_close(result,'fourlap sine eigenfunction',Lf*s,-s,1e-12,1e-12,...
 kern=fftdiff(1,N,2*pi/N); kern=kern(:);
 result=test_close(result,'fftdiff sine derivative',real(ifft(fft(s).*kern)),cos(grid),1e-12,1e-12,...
                   'fftdiff kernel differentiates periodic signals through Fourier multipliers');
+
+% Pseudomodulation zeroth harmonic with zero amplitude is the input spectrum
+pm_field=(0:31)'*(2*pi/32);
+pm_spec=[sin(2*pm_field) cos(3*pm_field)];
+pm_zero=pseudomodulation(pm_field,pm_spec,0,0);
+result=test_close(result,'pseudomodulation zero amplitude',pm_zero,pm_spec,1e-14,1e-14,...
+                  'zero-amplitude zeroth harmonic must return the input spectrum');
+
+% Pseudomodulation first harmonic tends to half the modulation amplitude times the derivative
+pm_amp=1e-4;
+pm_first=pseudomodulation(pm_field,sin(2*pm_field),pm_amp,1);
+pm_first_ref=pm_amp*cos(2*pm_field);
+result=test_close(result,'pseudomodulation first derivative limit',pm_first,pm_first_ref,1e-9,1e-12,...
+                  'small-amplitude first harmonic must match the Hyde derivative limit');
+
+% Pseudomodulation second harmonic tends to minus one sixteenth of amplitude squared times the second derivative
+pm_second=pseudomodulation(pm_field,sin(2*pm_field),pm_amp,2);
+pm_second_ref=(pm_amp^2/4)*sin(2*pm_field);
+result=test_close(result,'pseudomodulation second derivative limit',pm_second,pm_second_ref,1e-13,1e-14,...
+                  'small-amplitude second harmonic must match the Hyde derivative limit');
+
+% Pseudomodulation requires spectra down the rows
+try
+    pseudomodulation(pm_field,pm_spec.',pm_amp,1);
+    error('FAILED: pseudomodulation() accepted spectra across columns.');
+catch err
+    result=test_true(result,'pseudomodulation row convention',...
+                     contains(err.message,'same number of rows'),...
+                     'pseudomodulation() must follow the sgolaydiff() row convention');
+end
+
+% Pseudomodulation requires a column field axis
+try
+    pseudomodulation(pm_field.',pm_spec,pm_amp,1);
+    error('FAILED: pseudomodulation() accepted a row-vector field axis.');
+catch err
+    result=test_true(result,'pseudomodulation field convention',...
+                     contains(err.message,'column vector'),...
+                     'pseudomodulation() must require a column field axis');
+end
 
 % Directional derivative of a commuting matrix exponential has a closed form
 spin_system.sys.output='hush';


### PR DESCRIPTION
Summary:
- adds `kernel/derivatives/pseudomodulation.m`
- records Alexey Bogdanov and Ilya Kuprov in the function author list
- extends the finite-difference regression suite with pseudomodulation limiting-case checks

Validation:
- `matlab -nojvm -batch "cd('/home/kuprov/.openclaw/workspace/Spinach'); fix_path('reset'); addpath('tests'); result=run_test('finite_difference'); assert(strcmp(result.status,'PASS')); disp('PSEUDOMODULATION_KERNEL_VALIDATION_OK');"`
- `git diff --cached --check`
