### PR TITLE
Update derivative and optimcon regression tests

### DIFF
--- a/examples/fundamentals/derivative_tests/dirdiff_1.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_1.m
@@ -1,56 +1,58 @@
-% Test of matrix exponential differentiation routines. The first pair of
-% matrices must be equal; the second pair of matrices must be equal.
+% Test of matrix exponential differentiation routines. Analytical
+% derivatives are compared to central finite differences.
 %
 % ilya.kuprov@weizmann.ac.il
 
 function dirdiff_1()
 
-% Isotopes
-sys.isotopes={'1H','1H'};
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Magnetic induction
-sys.magnet=5.9;
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Chemical shifts
-inter.zeeman.scalar={1.0 1.5};
+    % Get the Spinach object
+    spin_system=dirdiff_test_system(formalisms{n});
 
-% Scalar couplings
-inter.coupling.scalar=cell(2,2);
-inter.coupling.scalar{1,2}=7.0; 
+    % Random Hamiltonian
+    H=randn(5)+1i*randn(5); H=(H+H')/2;
 
-% Basis set
-bas.formalism='sphten-liouv';
-bas.approximation='none';
+    % Random direction operators
+    A=randn(5)+1i*randn(5); A=(A+A')/20;
+    B=randn(5)+1i*randn(5); B=(B+B')/20;
 
-% Spinach housekeeping
-spin_system=create(sys,inter);
-spin_system=basis(spin_system,bas);
+    % First derivative, numerical
+    D_num=(propagator(spin_system,H+1e-3*A,1)-...
+           propagator(spin_system,H-1e-3*A,1))/2e-3;
 
-% Random Hamiltonian
-H=randn(5)+1i*randn(5); H=(H+H')/2;
+    % First derivative, analytical
+    D_anl=dirdiff(spin_system,H,A,1,2);
 
-% Random direction operators
-A=randn(5)+1i*randn(5); A=(A+A')/20;
-B=randn(5)+1i*randn(5); B=(B+B')/20;
+    % Test the first derivative
+    if norm(D_num-D_anl{2},2)/norm(D_num,2)>1e-5
+        error([formalisms{n} ' first derivative test failed']);
+    else
+        disp([formalisms{n} ' first derivative test passed']);
+    end
 
-% First derivative, numerical
-D=(propagator(spin_system,H+1e-3*A,1)-propagator(spin_system,H-1e-3*A,1))/2e-3; 
-disp('First derivative, numerical:'); disp(D); disp(' ');
+    % Second derivative, numerical
+    D_num=(propagator(spin_system,H+1e-3*A+1e-3*B,1)-...
+           propagator(spin_system,H+1e-3*A-1e-3*B,1)-...
+           propagator(spin_system,H-1e-3*A+1e-3*B,1)+...
+           propagator(spin_system,H-1e-3*A-1e-3*B,1))/4e-6;
 
-% First derivative, analytical
-D=dirdiff(spin_system,H,A,1,2);
-disp('First derivative, analytical:'); disp(D{2}); disp(' ');
+    % Second derivative, analytical
+    P=dirdiff(spin_system,H,{A,B},1,3);
+    Q=dirdiff(spin_system,H,{B,A},1,3);
+    D_anl=(P{3}+Q{3})/2;
 
-% Second derivative, numerical
-D=(propagator(spin_system,H+1e-3*A+1e-3*B,1)-propagator(spin_system,H+1e-3*A-1e-3*B,1)-...
-   propagator(spin_system,H-1e-3*A+1e-3*B,1)+propagator(spin_system,H-1e-3*A-1e-3*B,1))/4e-6;
-disp('Second derivative, numerical:'); disp(D); disp(' ');
-
-% Second derivative, analytical
-P=dirdiff(spin_system,H,{A,B},1,3);
-Q=dirdiff(spin_system,H,{B,A},1,3);
-disp('Second derivative, analytical:');
-disp((P{3}+Q{3})/2);
+    % Test the second derivative
+    if norm(D_num-D_anl,2)/norm(D_num,2)>1e-3
+        error([formalisms{n} ' second derivative test failed']);
+    else
+        disp([formalisms{n} ' second derivative test passed']);
+    end
 
 end
 
+end

--- a/examples/fundamentals/derivative_tests/dirdiff_2.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_2.m
@@ -8,42 +8,49 @@
 
 function dirdiff_2()
 
-% Bootstrap Spinach
-spin_system=bootstrap();
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Left and right drift generators, dissipative
-Hd={randn(50)+1i*randn(50), randn(50)+1i*randn(50)};
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Control operator
-Hc=randn(50)+1i*randn(50);
+    % Get the Spinach object
+    spin_system=dirdiff_test_system(formalisms{n});
 
-% A reasonable time step estimate
-dt=mean([1/norm(Hd{1},2), 1/norm(Hd{2},2)]);
+    % Left and right drift generators, dissipative
+    Hd={randn(50)+1i*randn(50), randn(50)+1i*randn(50)};
 
-% Reasonable controls
-cL=0.1*randn()*norm(Hd{1},2);
-cR=0.1*randn()*norm(Hd{2},2);
+    % Control operator
+    Hc=randn(50)+1i*randn(50);
 
-% Get analytical derivatives
-[DL_anl,DR_anl]=trapdiff(spin_system,Hd,Hc,dt,cL,cR);
+    % A reasonable time step estimate
+    dt=mean([1/norm(Hd{1},2), 1/norm(Hd{2},2)]);
 
-% Get numerical derivatives
-dc=sqrt(eps('double'));
-H_dir_L=(1/2)*Hc+1i*dt*(sqrt(3)/12)*(Hc*Hd{2}-Hd{2}*Hc);
-H_dir_R=(1/2)*Hc+1i*dt*(sqrt(3)/12)*(Hd{1}*Hc-Hc*Hd{1});
-H=(Hd{1}+Hd{2})/2+cL*H_dir_L+cR*H_dir_R;
-DL_num=(expm(-1i*dt*(H+dc*H_dir_L))-...
-        expm(-1i*dt*(H-dc*H_dir_L)))/(2*dc);
-DR_num=(expm(-1i*dt*(H+dc*H_dir_R))-...
-        expm(-1i*dt*(H-dc*H_dir_R)))/(2*dc);
+    % Reasonable controls
+    cL=0.1*randn()*norm(Hd{1},2);
+    cR=0.1*randn()*norm(Hd{2},2);
 
-% Test analytical against finite difference
-if (norm(DL_anl-DL_num,2)<10*sqrt(eps('double')))&&...
-   (norm(DR_anl-DR_num,2)<10*sqrt(eps('double')))
-   disp('test passed');
-else
-   error('test failed');
+    % Get analytical derivatives
+    [DL_anl,DR_anl]=trapdiff(spin_system,Hd,Hc,dt,cL,cR);
+
+    % Get numerical derivatives
+    dc=sqrt(eps('double'));
+    H_dir_L=(1/2)*Hc+1i*dt*(sqrt(3)/12)*(Hc*Hd{2}-Hd{2}*Hc);
+    H_dir_R=(1/2)*Hc+1i*dt*(sqrt(3)/12)*(Hd{1}*Hc-Hc*Hd{1});
+    H=(Hd{1}+Hd{2})/2+cL*H_dir_L+cR*H_dir_R;
+    DL_num=(expm(-1i*dt*(H+dc*H_dir_L))-...
+            expm(-1i*dt*(H-dc*H_dir_L)))/(2*dc);
+    DR_num=(expm(-1i*dt*(H+dc*H_dir_R))-...
+            expm(-1i*dt*(H-dc*H_dir_R)))/(2*dc);
+
+    % Test analytical against finite difference
+    if (norm(DL_anl-DL_num,2)<10*sqrt(eps('double')))&&...
+       (norm(DR_anl-DR_num,2)<10*sqrt(eps('double')))
+        disp([formalisms{n} ' test passed']);
+    else
+        error([formalisms{n} ' test failed']);
+    end
+
 end
 
 end
-

--- a/examples/fundamentals/derivative_tests/dirdiff_3_rect.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_3_rect.m
@@ -6,99 +6,75 @@
 
 function dirdiff_3_rect()
 
-% Set the magnetic field
-sys.magnet=28.18;
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Put 100 non-interacting spins at equal intervals 
-% within the [-100,+100] ppm chemical shift range 
-n_spins=100; sys.isotopes=cell(n_spins,1);
-for n=1:n_spins
-    sys.isotopes{n}='13C';
-end
-inter.zeeman.scalar=num2cell(linspace(-100,100,n_spins));
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Select a basis set - IK-2 keeps complete basis on each 
-% spin in this case, but ignores multi-spin orders
-bas.formalism='sphten-liouv';
-bas.approximation='IK-2';
-bas.space_level=1;
-bas.connectivity='scalar_couplings';
+    % Build the derivative-test system
+    [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalisms{n});
 
-% Run Spinach housekeeping
-spin_system=create(sys,inter);
-spin_system=basis(spin_system,bas);
+    % Define control parameters
+    control.drifts={{H}};                           % Drift
+    control.operators={Lx Ly};                      % Controls
+    control.rho_init={ Sx Sy Sz};                   % Starting states
+    control.rho_targ={-Sz Sy Sx};                   % Target states
+    control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
+    control.method='lbfgs';                         % Optimisation method
+    control.max_iter=1000;                          % Termination condition
+    control.plotting={};                            % Plotting options
+    control.integrator='rectangle';                 % Integrator
 
-% Set up spin states
-Sx=state(spin_system,'Lx','13C'); Sx=Sx/norm(full(Sx),2);
-Sy=state(spin_system,'Ly','13C'); Sy=Sy/norm(full(Sy),2);
-Sz=state(spin_system,'Lz','13C'); Sz=Sz/norm(full(Sz),2);
+    % Set the interval grid
+    control.pulse_dt=12.8e-6*ones(1,5);
 
-% Get control operators
-Lx=operator(spin_system,'Lx','13C');
-Ly=operator(spin_system,'Ly','13C');
+    % Spinach housekeeping
+    spin_system=optimcon(spin_system,control);
 
-% Get the drift Hamiltonian
-H=hamiltonian(assume(spin_system,'nmr'));
+    % Random guess and finite diff increment
+    guess=randn(2,5)/3; h=sqrt(eps('double'));
 
-% Define control parameters
-control.drifts={{H}};                           % Drift
-control.operators={Lx Ly};                      % Controls
-control.rho_init={ Sx Sy Sz};                   % Starting states
-control.rho_targ={-Sz Sy Sx};                   % Target states
-control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
-control.method='lbfgs';                         % Optimisation method
-control.max_iter=1000;                          % Termination condition
-control.plotting={};                            % Plotting options
-control.integrator='rectangle';                 % Integrator
+    % Call GRAPE and request analytical gradient
+    [~,~,grad_anl]=grape_xy(guess,spin_system);
+    grad_anl=squeeze(grad_anl(:,:,1));
 
-% Set the interval grid
-control.pulse_dt=12.8e-6*ones(1,5);
+    % Left waveform edge
+    wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
+    wave_back=guess; wave_back(1)=wave_back(1)-h;
+    [~,fid_forw]=grape_xy(wave_forw,spin_system);
+    [~,fid_back]=grape_xy(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' left edge test passed']);
+    else
+        error([formalisms{n} ' left edge test failed']);
+    end
 
-% Spinach housekeeping
-spin_system=optimcon(spin_system,control);
+    % Right waveform edge
+    wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
+    wave_back=guess; wave_back(end)=wave_back(end)-h;
+    [~,fid_forw]=grape_xy(wave_forw,spin_system);
+    [~,fid_back]=grape_xy(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' right edge test passed']);
+    else
+        error([formalisms{n} ' right edge test failed']);
+    end
 
-% Random guess and finite diff increment
-guess=randn(2,5)/3; h=sqrt(eps('double'));
-
-% Call GRAPE and request analytical gradient
-[~,~,grad_anl]=grape_xy(guess,spin_system);
-grad_anl=squeeze(grad_anl(:,:,1));
-
-% Left waveform edge
-wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
-wave_back=guess; wave_back(1)=wave_back(1)-h;
-[~,fid_forw]=grape_xy(wave_forw,spin_system);
-[~,fid_back]=grape_xy(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
-    disp('left edge test passed');
-else
-    error('left edge test failed');
-end
-
-% Right waveform edge
-wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
-wave_back=guess; wave_back(end)=wave_back(end)-h;
-[~,fid_forw]=grape_xy(wave_forw,spin_system);
-[~,fid_back]=grape_xy(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
-    disp('right edge test passed');
-else
-    error('right edge test failed');
-end
-
-% Waveform midpoint
-wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
-wave_back=guess; wave_back(3)=wave_back(3)-h;
-[~,fid_forw]=grape_xy(wave_forw,spin_system);
-[~,fid_back]=grape_xy(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
-    disp('midpoint test passed');
-else
-    error('midpoint test failed');
-end
+    % Waveform midpoint
+    wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
+    wave_back=guess; wave_back(3)=wave_back(3)-h;
+    [~,fid_forw]=grape_xy(wave_forw,spin_system);
+    [~,fid_back]=grape_xy(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' midpoint test passed']);
+    else
+        error([formalisms{n} ' midpoint test failed']);
+    end
 
 end
 
+end

--- a/examples/fundamentals/derivative_tests/dirdiff_3_trap.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_3_trap.m
@@ -6,99 +6,75 @@
 
 function dirdiff_3_trap()
 
-% Set the magnetic field
-sys.magnet=28.18;
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Put 100 non-interacting spins at equal intervals 
-% within the [-100,+100] ppm chemical shift range 
-n_spins=100; sys.isotopes=cell(n_spins,1);
-for n=1:n_spins
-    sys.isotopes{n}='13C';
-end
-inter.zeeman.scalar=num2cell(linspace(-100,100,n_spins));
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Select a basis set - IK-2 keeps complete basis on each 
-% spin in this case, but ignores multi-spin orders
-bas.formalism='sphten-liouv';
-bas.approximation='IK-2';
-bas.space_level=1;
-bas.connectivity='scalar_couplings';
+    % Build the derivative-test system
+    [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalisms{n});
 
-% Run Spinach housekeeping
-spin_system=create(sys,inter);
-spin_system=basis(spin_system,bas);
+    % Define control parameters
+    control.drifts={{H}};                           % Drift
+    control.operators={Lx Ly};                      % Controls
+    control.rho_init={ Sx Sy Sz};                   % Starting states
+    control.rho_targ={-Sz Sy Sx};                   % Target states
+    control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
+    control.method='lbfgs';                         % Optimisation method
+    control.max_iter=1000;                          % Termination condition
+    control.plotting={};                            % Plotting options
+    control.integrator='trapezium';                 % Integrator
 
-% Set up spin states
-Sx=state(spin_system,'Lx','13C'); Sx=Sx/norm(full(Sx),2);
-Sy=state(spin_system,'Ly','13C'); Sy=Sy/norm(full(Sy),2);
-Sz=state(spin_system,'Lz','13C'); Sz=Sz/norm(full(Sz),2);
+    % Set the interval grid
+    control.pulse_dt=12.8e-6*ones(1,4);
 
-% Get control operators
-Lx=operator(spin_system,'Lx','13C');
-Ly=operator(spin_system,'Ly','13C');
+    % Spinach housekeeping
+    spin_system=optimcon(spin_system,control);
 
-% Get the drift Hamiltonian
-H=hamiltonian(assume(spin_system,'nmr'));
+    % Random guess and finite diff increment
+    guess=randn(2,5)/3; h=sqrt(eps('double'));
 
-% Define control parameters
-control.drifts={{H}};                           % Drift
-control.operators={Lx Ly};                      % Controls
-control.rho_init={ Sx Sy Sz};                   % Starting states
-control.rho_targ={-Sz Sy Sx};                   % Target states
-control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
-control.method='lbfgs';                         % Optimisation method
-control.max_iter=1000;                          % Termination condition
-control.plotting={};                            % Plotting options
-control.integrator='trapezium';                 % Integrator
+    % Call GRAPE and request analytical gradient
+    [~,~,grad_anl]=grape_xy(guess,spin_system);
+    grad_anl=squeeze(grad_anl(:,:,1));
 
-% Set the interval grid
-control.pulse_dt=12.8e-6*ones(1,4);
+    % Left waveform edge
+    wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
+    wave_back=guess; wave_back(1)=wave_back(1)-h;
+    [~,fid_forw]=grape_xy(wave_forw,spin_system);
+    [~,fid_back]=grape_xy(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' left edge test passed']);
+    else
+        error([formalisms{n} ' left edge test failed']);
+    end
 
-% Spinach housekeeping
-spin_system=optimcon(spin_system,control);
+    % Right waveform edge
+    wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
+    wave_back=guess; wave_back(end)=wave_back(end)-h;
+    [~,fid_forw]=grape_xy(wave_forw,spin_system);
+    [~,fid_back]=grape_xy(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' right edge test passed']);
+    else
+        error([formalisms{n} ' right edge test failed']);
+    end
 
-% Random guess and finite diff increment
-guess=randn(2,5)/3; h=sqrt(eps('double'));
-
-% Call GRAPE and request analytical gradient
-[~,~,grad_anl]=grape_xy(guess,spin_system);
-grad_anl=squeeze(grad_anl(:,:,1));
-
-% Left waveform edge
-wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
-wave_back=guess; wave_back(1)=wave_back(1)-h;
-[~,fid_forw]=grape_xy(wave_forw,spin_system);
-[~,fid_back]=grape_xy(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
-    disp('left edge test passed');
-else
-    error('left edge test failed');
-end
-
-% Right waveform edge
-wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
-wave_back=guess; wave_back(end)=wave_back(end)-h;
-[~,fid_forw]=grape_xy(wave_forw,spin_system);
-[~,fid_back]=grape_xy(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
-    disp('right edge test passed');
-else
-    error('right edge test failed');
-end
-
-% Waveform midpoint
-wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
-wave_back=guess; wave_back(3)=wave_back(3)-h;
-[~,fid_forw]=grape_xy(wave_forw,spin_system);
-[~,fid_back]=grape_xy(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
-    disp('midpoint test passed');
-else
-    error('midpoint test failed');
-end
+    % Waveform midpoint
+    wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
+    wave_back=guess; wave_back(3)=wave_back(3)-h;
+    [~,fid_forw]=grape_xy(wave_forw,spin_system);
+    [~,fid_back]=grape_xy(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' midpoint test passed']);
+    else
+        error([formalisms{n} ' midpoint test failed']);
+    end
 
 end
 
+end

--- a/examples/fundamentals/derivative_tests/dirdiff_4_rect.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_4_rect.m
@@ -6,100 +6,76 @@
 
 function dirdiff_4_rect()
 
-% Set the magnetic field
-sys.magnet=28.18;
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Put 100 non-interacting spins at equal intervals 
-% within the [-100,+100] ppm chemical shift range 
-n_spins=100; sys.isotopes=cell(n_spins,1);
-for n=1:n_spins
-    sys.isotopes{n}='13C';
-end
-inter.zeeman.scalar=num2cell(linspace(-100,100,n_spins));
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Select a basis set - IK-2 keeps complete basis on each 
-% spin in this case, but ignores multi-spin orders
-bas.formalism='sphten-liouv';
-bas.approximation='IK-2';
-bas.space_level=1;
-bas.connectivity='scalar_couplings';
+    % Build the derivative-test system
+    [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalisms{n});
 
-% Run Spinach housekeeping
-spin_system=create(sys,inter);
-spin_system=basis(spin_system,bas);
+    % Define control parameters
+    control.drifts={{H}};                           % Drift
+    control.operators={Lx,Ly};                      % Controls
+    control.rho_init={ Sx Sy Sz};                   % Starting states
+    control.rho_targ={-Sz Sy Sx};                   % Target states
+    control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
+    control.method='lbfgs';                         % Optimisation method
+    control.max_iter=1000;                          % Termination condition
+    control.plotting={};                            % Plotting options
+    control.integrator='rectangle';                 % Integrator
 
-% Set up spin states
-Sx=state(spin_system,'Lx','13C'); Sx=Sx/norm(full(Sx),2);
-Sy=state(spin_system,'Ly','13C'); Sy=Sy/norm(full(Sy),2);
-Sz=state(spin_system,'Lz','13C'); Sz=Sz/norm(full(Sz),2);
+    % Set the interval grid
+    control.pulse_dt=12.8e-6*ones(1,5);
+    control.amplitudes=ones(1,5);
 
-% Get control operators
-Lx=operator(spin_system,'Lx','13C');
-Ly=operator(spin_system,'Ly','13C');
+    % Spinach housekeeping
+    spin_system=optimcon(spin_system,control);
 
-% Get the drift Hamiltonian
-H=hamiltonian(assume(spin_system,'nmr'));
+    % Random phases and finite diff increment
+    guess=randn(1,5)/3; h=sqrt(eps('double'));
 
-% Define control parameters
-control.drifts={{H}};                           % Drift
-control.operators={Lx,Ly};                      % Controls
-control.rho_init={ Sx Sy Sz};                   % Starting states
-control.rho_targ={-Sz Sy Sx};                   % Target states
-control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
-control.method='lbfgs';                         % Optimisation method
-control.max_iter=1000;                          % Termination condition
-control.plotting={};                            % Plotting options
-control.integrator='rectangle';                 % Integrator
+    % Call GRAPE and request analytical gradient
+    [~,~,grad_anl]=grape_phase(guess,spin_system);
+    grad_anl=squeeze(grad_anl(:,:,1));
 
-% Set the interval grid
-control.pulse_dt=12.8e-6*ones(1,5);
-control.amplitudes=ones(1,5); 
+    % Left waveform edge
+    wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
+    wave_back=guess; wave_back(1)=wave_back(1)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' left edge test passed']);
+    else
+        error([formalisms{n} ' left edge test failed']);
+    end
 
-% Spinach housekeeping
-spin_system=optimcon(spin_system,control);
+    % Right waveform edge
+    wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
+    wave_back=guess; wave_back(end)=wave_back(end)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' right edge test passed']);
+    else
+        error([formalisms{n} ' right edge test failed']);
+    end
 
-% Random phases and finite diff increment
-guess=randn(1,5)/3; h=sqrt(eps('double'));
-
-% Call GRAPE and request analytical gradient
-[~,~,grad_anl]=grape_phase(guess,spin_system);
-grad_anl=squeeze(grad_anl(:,:,1));
-
-% Left waveform edge
-wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
-wave_back=guess; wave_back(1)=wave_back(1)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
-    disp('left edge test passed');
-else
-    error('left edge test failed');
-end
-
-% Right waveform edge
-wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
-wave_back=guess; wave_back(end)=wave_back(end)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
-    disp('right edge test passed');
-else
-    error('right edge test failed');
-end
-
-% Waveform midpoint
-wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
-wave_back=guess; wave_back(3)=wave_back(3)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
-    disp('midpoint test passed');
-else
-    error('midpoint test failed');
-end
+    % Waveform midpoint
+    wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
+    wave_back=guess; wave_back(3)=wave_back(3)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' midpoint test passed']);
+    else
+        error([formalisms{n} ' midpoint test failed']);
+    end
 
 end
 
+end

--- a/examples/fundamentals/derivative_tests/dirdiff_4_trap.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_4_trap.m
@@ -6,100 +6,76 @@
 
 function dirdiff_4_trap()
 
-% Set the magnetic field
-sys.magnet=28.18;
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Put 100 non-interacting spins at equal intervals 
-% within the [-100,+100] ppm chemical shift range 
-n_spins=100; sys.isotopes=cell(n_spins,1);
-for n=1:n_spins
-    sys.isotopes{n}='13C';
-end
-inter.zeeman.scalar=num2cell(linspace(-100,100,n_spins));
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Select a basis set - IK-2 keeps complete basis on each 
-% spin in this case, but ignores multi-spin orders
-bas.formalism='sphten-liouv';
-bas.approximation='IK-2';
-bas.space_level=1;
-bas.connectivity='scalar_couplings';
+    % Build the derivative-test system
+    [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalisms{n});
 
-% Run Spinach housekeeping
-spin_system=create(sys,inter);
-spin_system=basis(spin_system,bas);
+    % Define control parameters
+    control.drifts={{H}};                           % Drift
+    control.operators={Lx,Ly};                      % Controls
+    control.rho_init={ Sx Sy Sz};                   % Starting states
+    control.rho_targ={-Sz Sy Sx};                   % Target states
+    control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
+    control.method='lbfgs';                         % Optimisation method
+    control.max_iter=1000;                          % Termination condition
+    control.plotting={};                            % Plotting options
+    control.integrator='trapezium';                 % Integrator
 
-% Set up spin states
-Sx=state(spin_system,'Lx','13C'); Sx=Sx/norm(full(Sx),2);
-Sy=state(spin_system,'Ly','13C'); Sy=Sy/norm(full(Sy),2);
-Sz=state(spin_system,'Lz','13C'); Sz=Sz/norm(full(Sz),2);
+    % Set the interval grid
+    control.pulse_dt=12.8e-6*ones(1,4);
+    control.amplitudes=ones(1,5);
 
-% Get control operators
-Lx=operator(spin_system,'Lx','13C');
-Ly=operator(spin_system,'Ly','13C');
+    % Spinach housekeeping
+    spin_system=optimcon(spin_system,control);
 
-% Get the drift Hamiltonian
-H=hamiltonian(assume(spin_system,'nmr'));
+    % Random phases and finite diff increment
+    guess=randn(1,5)/3; h=sqrt(eps('double'));
 
-% Define control parameters
-control.drifts={{H}};                           % Drift
-control.operators={Lx,Ly};                      % Controls
-control.rho_init={ Sx Sy Sz};                   % Starting states
-control.rho_targ={-Sz Sy Sx};                   % Target states
-control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
-control.method='lbfgs';                         % Optimisation method
-control.max_iter=1000;                          % Termination condition
-control.plotting={};                            % Plotting options
-control.integrator='trapezium';                 % Integrator
+    % Call GRAPE and request analytical gradient
+    [~,~,grad_anl]=grape_phase(guess,spin_system);
+    grad_anl=squeeze(grad_anl(:,:,1));
 
-% Set the interval grid
-control.pulse_dt=12.8e-6*ones(1,4);
-control.amplitudes=ones(1,5); 
+    % Left waveform edge
+    wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
+    wave_back=guess; wave_back(1)=wave_back(1)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' left edge test passed']);
+    else
+        error([formalisms{n} ' left edge test failed']);
+    end
 
-% Spinach housekeeping
-spin_system=optimcon(spin_system,control);
+    % Right waveform edge
+    wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
+    wave_back=guess; wave_back(end)=wave_back(end)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' right edge test passed']);
+    else
+        error([formalisms{n} ' right edge test failed']);
+    end
 
-% Random phases and finite diff increment
-guess=randn(1,5)/3; h=sqrt(eps('double'));
-
-% Call GRAPE and request analytical gradient
-[~,~,grad_anl]=grape_phase(guess,spin_system);
-grad_anl=squeeze(grad_anl(:,:,1));
-
-% Left waveform edge
-wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
-wave_back=guess; wave_back(1)=wave_back(1)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
-    disp('left edge test passed');
-else
-    error('left edge test failed');
-end
-
-% Right waveform edge
-wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
-wave_back=guess; wave_back(end)=wave_back(end)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
-    disp('right edge test passed');
-else
-    error('right edge test failed');
-end
-
-% Waveform midpoint
-wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
-wave_back=guess; wave_back(3)=wave_back(3)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
-    disp('midpoint test passed');
-else
-    error('midpoint test failed');
-end
+    % Waveform midpoint
+    wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
+    wave_back=guess; wave_back(3)=wave_back(3)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' midpoint test passed']);
+    else
+        error([formalisms{n} ' midpoint test failed']);
+    end
 
 end
 
+end

--- a/examples/fundamentals/derivative_tests/dirdiff_5_rect.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_5_rect.m
@@ -6,88 +6,64 @@
 
 function dirdiff_5_rect()
 
-% Set the magnetic field
-sys.magnet=28.18;
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Put 100 non-interacting spins at equal intervals 
-% within the [-100,+100] ppm chemical shift range 
-n_spins=100; sys.isotopes=cell(n_spins,1);
-for n=1:n_spins
-    sys.isotopes{n}='13C';
-end
-inter.zeeman.scalar=num2cell(linspace(-100,100,n_spins));
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Select a basis set - IK-2 keeps complete basis on each 
-% spin in this case, but ignores multi-spin orders
-bas.formalism='sphten-liouv';
-bas.approximation='IK-2';
-bas.space_level=1;
-bas.connectivity='scalar_couplings';
+    % Build the derivative-test system
+    [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalisms{n});
 
-% Run Spinach housekeeping
-spin_system=create(sys,inter);
-spin_system=basis(spin_system,bas);
+    % Define control parameters
+    control.drifts={{H}};                           % Drift
+    control.operators={Lx,Ly};                      % Controls
+    control.rho_init={ Sx Sy Sz};                   % Starting states
+    control.rho_targ={-Sz Sy Sx};                   % Target states
+    control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
+    control.max_iter=1000;                          % Termination condition
+    control.plotting={};                            % Plotting options
+    control.integrator='rectangle';                 % Integrator
+    control.pulse_dt=12.8e-6*ones(1,5);             % Time interval grid
 
-% Set up spin states
-Sx=state(spin_system,'Lx','13C'); Sx=Sx/norm(full(Sx),2);
-Sy=state(spin_system,'Ly','13C'); Sy=Sy/norm(full(Sy),2);
-Sz=state(spin_system,'Lz','13C'); Sz=Sz/norm(full(Sz),2);
+    % Pick initial guess, phase-modulated GRAPE
+    control.amplitudes=ones(1,5); guess=randn(1,5)/3;
 
-% Get control operators
-Lx=operator(spin_system,'Lx','13C');
-Ly=operator(spin_system,'Ly','13C');
+    % Get Newton Hessian
+    control.method='newton';
+    spin_system=optimcon(spin_system,control);
+    [~,~,~,newton_hess_ph]=grape_phase(guess,spin_system);
 
-% Get the drift Hamiltonian
-H=hamiltonian(assume(spin_system,'nmr'));
+    % Get Goodwin Hessian
+    control.method='goodwin';
+    spin_system=optimcon(spin_system,control);
+    [~,~,~,goodwin_hess_ph]=grape_phase(guess,spin_system);
 
-% Define control parameters
-control.drifts={{H}};                           % Drift
-control.operators={Lx,Ly};                      % Controls
-control.rho_init={ Sx Sy Sz};                   % Starting states
-control.rho_targ={-Sz Sy Sx};                   % Target states
-control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
-control.max_iter=1000;                          % Termination condition
-control.plotting={};                            % Plotting options
-control.integrator='rectangle';                 % Integrator
-control.pulse_dt=12.8e-6*ones(1,5);             % Time interval grid
+    % Pick initial guess, XY-modulated GRAPE
+    guess=randn(2,5)/3;
 
-% Pick initial guess, phase-modulated GRAPE
-control.amplitudes=ones(1,5); guess=randn(1,5)/3;
+    % Get Newton Hessian
+    control.method='newton';
+    spin_system=optimcon(spin_system,control);
+    [~,~,~,newton_hess_xy]=grape_xy(guess,spin_system);
 
-% Get Newton Hessian
-control.method='newton';
-spin_system=optimcon(spin_system,control);
-[~,~,~,newton_hess_ph]=grape_phase(guess,spin_system);
+    % Get Goodwin Hessian
+    control.method='goodwin';
+    spin_system=optimcon(spin_system,control);
+    [~,~,~,goodwin_hess_xy]=grape_xy(guess,spin_system);
 
-% Get Goodwin Hessian
-control.method='goodwin';
-spin_system=optimcon(spin_system,control);
-[~,~,~,goodwin_hess_ph]=grape_phase(guess,spin_system);
-
-% Pick initial guess, XY-modulated GRAPE
-guess=randn(2,5)/3;
-
-% Get Newton Hessian
-control.method='newton';
-spin_system=optimcon(spin_system,control);
-[~,~,~,newton_hess_xy]=grape_xy(guess,spin_system);
-
-% Get Goodwin Hessian
-control.method='goodwin';
-spin_system=optimcon(spin_system,control);
-[~,~,~,goodwin_hess_xy]=grape_xy(guess,spin_system);
-
-% Run the comparisons
-if norm(newton_hess_ph(:)-goodwin_hess_ph(:),1)>1e-6*norm(newton_hess_ph(:),1)
-    error('Phase Hessian internal consistency test failed.');
-else
-    disp('Phase Hessian internal consistency test passed.');
-end
-if norm(newton_hess_xy(:)-goodwin_hess_xy(:),1)>1e-6*norm(newton_hess_xy(:),1)
-    error('Cartesian Hessian internal consistency test failed.');
-else
-    disp('Cartesian internal consistency test passed.');
-end
+    % Run the comparisons
+    if norm(newton_hess_ph(:)-goodwin_hess_ph(:),1)>1e-6*norm(newton_hess_ph(:),1)
+        error([formalisms{n} ' phase Hessian internal consistency test failed.']);
+    else
+        disp([formalisms{n} ' phase Hessian internal consistency test passed.']);
+    end
+    if norm(newton_hess_xy(:)-goodwin_hess_xy(:),1)>1e-6*norm(newton_hess_xy(:),1)
+        error([formalisms{n} ' Cartesian Hessian internal consistency test failed.']);
+    else
+        disp([formalisms{n} ' Cartesian internal consistency test passed.']);
+    end
 
 end
 
+end

--- a/examples/fundamentals/derivative_tests/dirdiff_6_rect.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_6_rect.m
@@ -5,103 +5,79 @@
 
 function dirdiff_6_rect()
 
-% Set the magnetic field
-sys.magnet=28.18;
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Put 100 non-interacting spins at equal intervals 
-% within the [-100,+100] ppm chemical shift range 
-n_spins=100; sys.isotopes=cell(n_spins,1);
-for n=1:n_spins
-    sys.isotopes{n}='13C';
-end
-inter.zeeman.scalar=num2cell(linspace(-100,100,n_spins));
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Select a basis set - IK-2 keeps complete basis on each 
-% spin in this case, but ignores multi-spin orders
-bas.formalism='sphten-liouv';
-bas.approximation='IK-2';
-bas.space_level=1;
-bas.connectivity='scalar_couplings';
+    % Build the derivative-test system
+    [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalisms{n});
 
-% Run Spinach housekeeping
-spin_system=create(sys,inter);
-spin_system=basis(spin_system,bas);
+    % Define control parameters
+    control.drifts={{H}};                           % Drift
+    control.operators={Lx,Ly};                      % Controls
+    control.rho_init={ Sx Sy Sz};                   % Starting states
+    control.rho_targ={-Sz Sy Sx};                   % Target states
+    control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
+    control.max_iter=1000;                          % Termination condition
+    control.plotting={};                            % Plotting options
+    control.integrator='rectangle';                 % Integrator
+    control.pulse_dt=12.8e-6*ones(1,5);             % Time interval grid
+    control.method='newton';                        % Optimisation method
 
-% Set up spin states
-Sx=state(spin_system,'Lx','13C'); Sx=Sx/norm(full(Sx),2);
-Sy=state(spin_system,'Ly','13C'); Sy=Sy/norm(full(Sy),2);
-Sz=state(spin_system,'Lz','13C'); Sz=Sz/norm(full(Sz),2);
+    % Spinach housekeeping
+    spin_system=optimcon(spin_system,control);
 
-% Get control operators
-Lx=operator(spin_system,'Lx','13C');
-Ly=operator(spin_system,'Ly','13C');
+    % Random guess and finite diff increment
+    guess=randn(2,5)/3; h=sqrt(eps('double'));
 
-% Get the drift Hamiltonian
-H=hamiltonian(assume(spin_system,'nmr'));
+    % Call GRAPE and request analytical Hessian
+    [~,~,~,hess_anl]=grape_xy(guess,spin_system);
+    hess_anl=squeeze(hess_anl(:,:,1));
 
-% Define control parameters
-control.drifts={{H}};                           % Drift
-control.operators={Lx,Ly};                      % Controls
-control.rho_init={ Sx Sy Sz};                   % Starting states
-control.rho_targ={-Sz Sy Sx};                   % Target states
-control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
-control.max_iter=1000;                          % Termination condition
-control.plotting={};                            % Plotting options
-control.integrator='rectangle';                 % Integrator
-control.pulse_dt=12.8e-6*ones(1,5);             % Time interval grid
-control.method='newton';                        % Optimisation method
+    % Leftmost Hessian column
+    wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
+    wave_back=guess; wave_back(1)=wave_back(1)-h;
+    [~,~,grad_forw]=grape_xy(wave_forw,spin_system);
+    [~,~,grad_back]=grape_xy(wave_back,spin_system);
+    grad_forw=squeeze(grad_forw(:,:,1)); grad_forw=grad_forw(:);
+    grad_back=squeeze(grad_back(:,:,1)); grad_back=grad_back(:);
+    hess_num=(grad_forw-grad_back)/(2*h);
+    if norm(hess_anl(:,1)-hess_num,1)<1e-6*norm(hess_num,1)
+        disp([formalisms{n} ' leftmost column test passed']);
+    else
+        error([formalisms{n} ' leftmost column test failed']);
+    end
 
-% Spinach housekeeping
-spin_system=optimcon(spin_system,control);
+    % Rightmost Hessian column
+    wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
+    wave_back=guess; wave_back(end)=wave_back(end)-h;
+    [~,~,grad_forw]=grape_xy(wave_forw,spin_system);
+    [~,~,grad_back]=grape_xy(wave_back,spin_system);
+    grad_forw=squeeze(grad_forw(:,:,1)); grad_forw=grad_forw(:);
+    grad_back=squeeze(grad_back(:,:,1)); grad_back=grad_back(:);
+    hess_num=(grad_forw-grad_back)/(2*h);
+    if norm(hess_anl(:,end)-hess_num,1)<1e-6*norm(hess_num,1)
+        disp([formalisms{n} ' rightmost column test passed']);
+    else
+        error([formalisms{n} ' rightmost column test failed']);
+    end
 
-% Random guess and finite diff increment
-guess=randn(2,5)/3; h=sqrt(eps('double'));
-
-% Call GRAPE and request analytical Hessian
-[~,~,~,hess_anl]=grape_xy(guess,spin_system);
-hess_anl=squeeze(hess_anl(:,:,1));
-
-% Leftmost Hessian column
-wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
-wave_back=guess; wave_back(1)=wave_back(1)-h;
-[~,~,grad_forw]=grape_xy(wave_forw,spin_system);
-[~,~,grad_back]=grape_xy(wave_back,spin_system);
-grad_forw=squeeze(grad_forw(:,:,1)); grad_forw=grad_forw(:);
-grad_back=squeeze(grad_back(:,:,1)); grad_back=grad_back(:);
-hess_num=(grad_forw-grad_back)/(2*h);
-if norm(hess_anl(:,1)-hess_num,1)<1e-6*norm(hess_num,1)
-    disp('leftmost column test passed');
-else
-    error('leftmost column test failed');
-end
-
-% Rightmost Hessian column
-wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
-wave_back=guess; wave_back(end)=wave_back(end)-h;
-[~,~,grad_forw]=grape_xy(wave_forw,spin_system);
-[~,~,grad_back]=grape_xy(wave_back,spin_system);
-grad_forw=squeeze(grad_forw(:,:,1)); grad_forw=grad_forw(:);
-grad_back=squeeze(grad_back(:,:,1)); grad_back=grad_back(:);
-hess_num=(grad_forw-grad_back)/(2*h);
-if norm(hess_anl(:,end)-hess_num,1)<1e-6*norm(hess_num,1)
-    disp('rightmost column test passed');
-else
-    error('rightmost column test failed');
-end
-
-% Middle Hessian column
-wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
-wave_back=guess; wave_back(3)=wave_back(3)-h;
-[~,~,grad_forw]=grape_xy(wave_forw,spin_system);
-[~,~,grad_back]=grape_xy(wave_back,spin_system);
-grad_forw=squeeze(grad_forw(:,:,1)); grad_forw=grad_forw(:);
-grad_back=squeeze(grad_back(:,:,1)); grad_back=grad_back(:);
-hess_num=(grad_forw-grad_back)/(2*h);
-if norm(hess_anl(:,3)-hess_num,1)<1e-6*norm(hess_num,1)
-    disp('middle column test passed');
-else
-    error('middle column test failed');
-end
+    % Middle Hessian column
+    wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
+    wave_back=guess; wave_back(3)=wave_back(3)-h;
+    [~,~,grad_forw]=grape_xy(wave_forw,spin_system);
+    [~,~,grad_back]=grape_xy(wave_back,spin_system);
+    grad_forw=squeeze(grad_forw(:,:,1)); grad_forw=grad_forw(:);
+    grad_back=squeeze(grad_back(:,:,1)); grad_back=grad_back(:);
+    hess_num=(grad_forw-grad_back)/(2*h);
+    if norm(hess_anl(:,3)-hess_num,1)<1e-6*norm(hess_num,1)
+        disp([formalisms{n} ' middle column test passed']);
+    else
+        error([formalisms{n} ' middle column test failed']);
+    end
 
 end
 
+end

--- a/examples/fundamentals/derivative_tests/dirdiff_7_rect.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_7_rect.m
@@ -7,104 +7,80 @@
 
 function dirdiff_7_rect()
 
-% Set the magnetic field
-sys.magnet=28.18;
+% Formalisms to test
+formalisms={'sphten-liouv','zeeman-liouv','zeeman-hilb'};
 
-% Put 100 non-interacting spins at equal intervals 
-% within the [-100,+100] ppm chemical shift range 
-n_spins=100; sys.isotopes=cell(n_spins,1);
-for n=1:n_spins
-    sys.isotopes{n}='13C';
-end
-inter.zeeman.scalar=num2cell(linspace(-100,100,n_spins));
+% Loop over formalisms
+for n=1:numel(formalisms)
 
-% Select a basis set - IK-2 keeps complete basis on each 
-% spin in this case, but ignores multi-spin orders
-bas.formalism='sphten-liouv';
-bas.approximation='IK-2';
-bas.space_level=1;
-bas.connectivity='scalar_couplings';
+    % Build the derivative-test system
+    [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalisms{n});
 
-% Run Spinach housekeeping
-spin_system=create(sys,inter);
-spin_system=basis(spin_system,bas);
+    % Define control parameters
+    control.drifts={{H}};                           % Drift
+    control.operators={Lx,Ly};                      % Controls
+    control.rho_init={ Sx Sy Sz};                   % Starting states
+    control.rho_targ={-Sz Sy Sx};                   % Target states
+    control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
+    control.method='lbfgs';                         % Optimisation method
+    control.max_iter=1000;                          % Termination condition
+    control.plotting={};                            % Plotting options
+    control.integrator='rectangle';                 % Integrator
 
-% Set up spin states
-Sx=state(spin_system,'Lx','13C'); Sx=Sx/norm(full(Sx),2);
-Sy=state(spin_system,'Ly','13C'); Sy=Sy/norm(full(Sy),2);
-Sz=state(spin_system,'Lz','13C'); Sz=Sz/norm(full(Sz),2);
+    % Define an ensemble of distortion chains
+    control.distortion={@(w)firf(w,[0.9 0.1i]), @(w)spf(w,0.2), @(w)szf(w,0.2), @(w)amp_root(w,2*pi*20e3,4);
+                        @(w)szf(w,0.2), @(w)spf(w,0.2), @(w)amp_root(w,2*pi*20e3,4), @(w)firf(w,[0.9 0.1i])};
 
-% Get control operators
-Lx=operator(spin_system,'Lx','13C');
-Ly=operator(spin_system,'Ly','13C');
+    % Set the interval grid
+    control.pulse_dt=12.8e-6*ones(1,5);
+    control.amplitudes=ones(1,5);
 
-% Get the drift Hamiltonian
-H=hamiltonian(assume(spin_system,'nmr'));
+    % Spinach housekeeping
+    spin_system=optimcon(spin_system,control);
 
-% Define control parameters
-control.drifts={{H}};                           % Drift
-control.operators={Lx,Ly};                      % Controls
-control.rho_init={ Sx Sy Sz};                   % Starting states
-control.rho_targ={-Sz Sy Sx};                   % Target states
-control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
-control.method='lbfgs';                         % Optimisation method
-control.max_iter=1000;                          % Termination condition
-control.plotting={};                            % Plotting options
-control.integrator='rectangle';                 % Integrator
+    % Random phases and finite diff increment
+    guess=randn(1,5)/3; h=sqrt(eps('double'));
 
-% Define an ensemble of distortion chains
-control.distortion={@(w)firf(w,[0.9 0.1i]), @(w)spf(w,0.2), @(w)szf(w,0.2), @(w)amp_root(w,2*pi*20e3,4);
-                    @(w)szf(w,0.2), @(w)spf(w,0.2), @(w)amp_root(w,2*pi*20e3,4), @(w)firf(w,[0.9 0.1i])};
+    % Call GRAPE and request analytical gradient
+    [~,~,grad_anl]=grape_phase(guess,spin_system);
+    grad_anl=squeeze(grad_anl(:,:,1));
 
-% Set the interval grid
-control.pulse_dt=12.8e-6*ones(1,5);
-control.amplitudes=ones(1,5); 
+    % Left waveform edge
+    wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
+    wave_back=guess; wave_back(1)=wave_back(1)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' left edge test passed']);
+    else
+        error([formalisms{n} ' left edge test failed']);
+    end
 
-% Spinach housekeeping
-spin_system=optimcon(spin_system,control);
+    % Right waveform edge
+    wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
+    wave_back=guess; wave_back(end)=wave_back(end)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' right edge test passed']);
+    else
+        error([formalisms{n} ' right edge test failed']);
+    end
 
-% Random phases and finite diff increment
-guess=randn(1,5)/3; h=sqrt(eps('double'));
-
-% Call GRAPE and request analytical gradient
-[~,~,grad_anl]=grape_phase(guess,spin_system);
-grad_anl=squeeze(grad_anl(:,:,1));
-
-% Left waveform edge
-wave_forw=guess; wave_forw(1)=wave_forw(1)+h;
-wave_back=guess; wave_back(1)=wave_back(1)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(1)-grad_num)/abs(grad_num)<1e-6
-    disp('left edge test passed');
-else
-    error('left edge test failed');
-end
-
-% Right waveform edge
-wave_forw=guess; wave_forw(end)=wave_forw(end)+h;
-wave_back=guess; wave_back(end)=wave_back(end)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(end)-grad_num)/abs(grad_num)<1e-6
-    disp('right edge test passed');
-else
-    error('right edge test failed');
-end
-
-% Waveform midpoint
-wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
-wave_back=guess; wave_back(3)=wave_back(3)-h;
-[~,fid_forw]=grape_phase(wave_forw,spin_system);
-[~,fid_back]=grape_phase(wave_back,spin_system);
-grad_num=(fid_forw(1)-fid_back(1))/(2*h);
-if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
-    disp('midpoint test passed');
-else
-    error('midpoint test failed');
-end
+    % Waveform midpoint
+    wave_forw=guess; wave_forw(3)=wave_forw(3)+h;
+    wave_back=guess; wave_back(3)=wave_back(3)-h;
+    [~,fid_forw]=grape_phase(wave_forw,spin_system);
+    [~,fid_back]=grape_phase(wave_back,spin_system);
+    grad_num=(fid_forw(1)-fid_back(1))/(2*h);
+    if abs(grad_anl(3)-grad_num)/abs(grad_num)<1e-6
+        disp([formalisms{n} ' midpoint test passed']);
+    else
+        error([formalisms{n} ' midpoint test failed']);
+    end
 
 end
 
+end

--- a/examples/fundamentals/derivative_tests/dirdiff_test_system.m
+++ b/examples/fundamentals/derivative_tests/dirdiff_test_system.m
@@ -1,0 +1,80 @@
+% Spin system generator for directional derivative tests. Syntax:
+%
+%    [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalism)
+%
+% ilya.kuprov@weizmann.ac.il
+
+function [spin_system,Sx,Sy,Sz,Lx,Ly,H]=dirdiff_test_system(formalism)
+
+% Check consistency
+grumble(formalism);
+
+% Select system size
+switch formalism
+
+    case 'sphten-liouv'
+
+        % Keep the original large Liouville-space test
+        n_spins=100;
+
+    case {'zeeman-liouv','zeeman-hilb'}
+
+        % Use a compact system for full Zeeman formalisms
+        n_spins=2;
+
+end
+
+% Set the magnetic field
+sys.magnet=28.18;
+sys.output='hush';
+
+% Put non-interacting spins at equal intervals
+% within the [-100,+100] ppm chemical shift range
+sys.isotopes=cell(n_spins,1);
+for n=1:n_spins
+    sys.isotopes{n}='13C';
+end
+inter.zeeman.scalar=num2cell(linspace(-100,100,n_spins));
+
+% Select the requested basis set
+bas.formalism=formalism;
+switch formalism
+
+    case 'sphten-liouv'
+
+        % Keep complete single-spin terms only
+        bas.approximation='IK-2';
+        bas.space_level=1;
+        bas.connectivity='scalar_couplings';
+
+    case {'zeeman-liouv','zeeman-hilb'}
+
+        % Keep the full Zeeman basis
+        bas.approximation='none';
+
+end
+
+% Run Spinach housekeeping
+spin_system=create(sys,inter);
+spin_system=basis(spin_system,bas);
+
+% Set up spin states
+Sx=state(spin_system,'Lx','13C'); Sx=Sx/norm(full(Sx),2);
+Sy=state(spin_system,'Ly','13C'); Sy=Sy/norm(full(Sy),2);
+Sz=state(spin_system,'Lz','13C'); Sz=Sz/norm(full(Sz),2);
+
+% Get control operators
+Lx=operator(spin_system,'Lx','13C');
+Ly=operator(spin_system,'Ly','13C');
+
+% Get the drift Hamiltonian
+H=hamiltonian(assume(spin_system,'nmr'));
+
+end
+
+% Consistency enforcement
+function grumble(formalism)
+if (~ischar(formalism))||(~ismember(formalism,{'sphten-liouv','zeeman-liouv','zeeman-hilb'}))
+    error('formalism must be ''sphten-liouv'', ''zeeman-liouv'', or ''zeeman-hilb''.');
+end
+end

--- a/tests/kernel/test_dynamic_optimcon_remaining.m
+++ b/tests/kernel/test_dynamic_optimcon_remaining.m
@@ -274,6 +274,7 @@ plot_system.control.pwr_levels=1;
 plot_system.control.integrator='rectangle';
 plot_system.control.l_bound=-10;
 plot_system.control.u_bound=10;
+plot_system.control.freeze=[];
 plot_wave=[1 2 3; -1 0 1];
 ctrl_trajan(plot_system,plot_wave,{struct()},0.5);
 result.messages{end+1}='PASS: ctrl_trajan xy_controls -- plotting smoke path completed offscreen';
@@ -589,6 +590,8 @@ spin_system.control.keyholes=cell(1,2);
 spin_system.control.method='newton';
 spin_system.control.plotting={};
 spin_system.control.parallel='time';
+spin_system.control.freeze=[];
+spin_system.control.steady=false();
 drift=[0.20 0.10; -0.05 -0.10];
 controls={[0 1; 1 0],[0 -1i; 1i 0]};
 rho_init=[1; 0.2];
@@ -731,5 +734,4 @@ function fidelity=local_tgrape_fid(spin_system,drift,controls,waveform,dt_grid,r
 fidelity=tgrape(spin_system,drift,controls,waveform,dt_grid,1,rho_init,rho_targ);
 
 end
-
 


### PR DESCRIPTION
## Summary
- Update `dirdiff_1.m` to report pass/fail checks instead of printing raw derivative matrices.
- Run the derivative examples in `examples/fundamentals/derivative_tests` across `sphten-liouv`, `zeeman-liouv`, and `zeeman-hilb` where the tests depend on Spinach formalism.
- Update optimal-control regression fixtures for current `control.freeze` / `control.steady` syntax requirements.

## Validation
- `matlab -nojvm -batch "cd('/home/kuprov/.openclaw/workspace/Spinach'); fix_path('add'); addpath(fullfile(pwd,'examples','fundamentals','derivative_tests')); tests={'auxmat_test','dirdiff_1','dirdiff_2','dirdiff_3_rect','dirdiff_3_trap','dirdiff_4_rect','dirdiff_4_trap','dirdiff_5_rect','dirdiff_6_rect','dirdiff_7_rect'}; for k=1:numel(tests), fprintf('RUN %s\\n',tests{k}); feval(tests{k}); end; fprintf('DERIVATIVE_EXAMPLES_OK\\n');"`
- `matlab -nojvm -batch "cd('/home/kuprov/.openclaw/workspace/Spinach'); fix_path('add'); addpath(fullfile(pwd,'tests')); addpath(fullfile(pwd,'tests','lib')); run_test('optimcon/grape_one_spin'); run_test('optimcon/support_paths'); run_test('kernel/dynamic_optimcon_remaining'); fprintf('OPTCON_REGRESSION_OK\\n');"`
- `git diff --cached --check` before commit