### PR TITLE
Add Euler rotation equivalence helper

### DIFF
--- a/kernel/conventions/transforms/euler_equiv.m
+++ b/kernel/conventions/transforms/euler_equiv.m
@@ -1,0 +1,75 @@
+% Checks whether two ZYZ active Euler angle sets specify the same
+% rotation. Syntax:
+%
+%              answer=euler_equiv(eulers_a,eulers_b,tol)
+%
+% Parameters:
+%
+%    eulers_a   - first Euler angle set [alpha beta gamma],
+%                 radians, ZYZ active convention
+%
+%    eulers_b   - second Euler angle set [alpha beta gamma],
+%                 radians, ZYZ active convention
+%
+%    tol        - non-negative angular tolerance, radians
+%
+% Outputs:
+%
+%    answer     - true if the relative rotation angle between
+%                 the two rotations is not greater than tol
+%
+% Note: Euler angles are not unique, and so this function compares
+%       the rotations produced by euler2dcm(), not the angles
+%       themselves.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=euler_equiv.m>
+
+function answer=euler_equiv(eulers_a,eulers_b,tol)
+
+% Check consistency
+grumble(eulers_a,eulers_b,tol);
+
+% Cast Euler angles to row vectors
+eulers_a=eulers_a(:)';
+eulers_b=eulers_b(:)';
+
+% Build direction cosine matrices
+dcm_a=euler2dcm(eulers_a);
+dcm_b=euler2dcm(eulers_b);
+
+% Compute the relative rotation
+dcm_rel=dcm_b*dcm_a';
+
+% Compute the sine and cosine of the relative rotation angle
+sin_ang=norm([dcm_rel(3,2)-dcm_rel(2,3);...
+              dcm_rel(1,3)-dcm_rel(3,1);...
+              dcm_rel(2,1)-dcm_rel(1,2)],2)/2;
+cos_ang=(trace(dcm_rel)-1)/2;
+
+% Clamp round-off in the cosine
+cos_ang=max(min(cos_ang,1),-1);
+
+% Compare the geodesic distance on SO(3)
+answer=(atan2(sin_ang,cos_ang)<=tol);
+
+end
+
+% Consistency enforcement
+function grumble(eulers_a,eulers_b,tol)
+if (~isnumeric(eulers_a))||(~isreal(eulers_a))||(~isvector(eulers_a))||...
+   (numel(eulers_a)~=3)||any(~isfinite(eulers_a(:)))
+    error('eulers_a must be a real finite vector with three elements.');
+end
+if (~isnumeric(eulers_b))||(~isreal(eulers_b))||(~isvector(eulers_b))||...
+   (numel(eulers_b)~=3)||any(~isfinite(eulers_b(:)))
+    error('eulers_b must be a real finite vector with three elements.');
+end
+if (~isnumeric(tol))||(~isreal(tol))||(numel(tol)~=1)||...
+   (~isfinite(tol))||(tol<0)
+    error('tol must be a non-negative real finite scalar.');
+end
+end
+
+

--- a/tests/kernel/test_transform_rotation_suite.m
+++ b/tests/kernel/test_transform_rotation_suite.m
@@ -30,6 +30,18 @@ result=test_close(result,'euler2dcm active Z rotation',R,R_ref,1e-15,1e-15,...
 result=test_close(result,'euler2dcm vector input',euler2dcm([pi/2 0 0]),R_ref,1e-15,1e-15,...
                   'the one-vector syntax must match the three-scalar syntax');
 
+% Compare equivalent rotations through their Euler angle degeneracy
+result=test_true(result,'euler_equiv zero-beta degeneracy',euler_equiv([0.3 0 0.4],[0.7 0 0],1e-14),...
+                 'for beta equal to zero, alpha and gamma only enter through their sum');
+
+% Check angular tolerance acceptance
+result=test_true(result,'euler_equiv tolerance pass',euler_equiv([0 0 0],[5e-7 0 0],1e-6),...
+                 'relative rotations inside the angular tolerance must pass');
+
+% Check angular tolerance rejection
+result=test_true(result,'euler_equiv tolerance fail',~euler_equiv([0 0 0],[2e-6 0 0],1e-6),...
+                 'relative rotations outside the angular tolerance must fail');
+
 % Recover a non-singular Euler rotation through its DCM
 angles=[0.37 0.91 -0.42];
 R=euler2dcm(angles);


### PR DESCRIPTION
Summary:
- added euler_equiv() for testing whether two ZYZ active Euler-angle triplets represent the same SO(3) rotation
- compare the angular distance of the relative rotation matrix, avoiding direct angle normalisation
- added regression coverage for zero-beta Euler degeneracy and tolerance pass/fail behaviour

Validation:
- matlab -nojvm -batch direct euler_equiv() assertions
- matlab -nojvm -batch run_test('kernel/transform_rotation_suite')
