### PR TITLE
Add Bloch sphere movie output

### DIFF
--- a/kernel/plotting/bloch_sph_plot.m
+++ b/kernel/plotting/bloch_sph_plot.m
@@ -86,8 +86,19 @@ axis_z(~good_axis)=NaN;
 
 % Static trajectory and instantaneous axis-tip curve
 if isempty(file_name)
-    plot3(x,y,z,varargin{:});
-    plot3(axis_x,axis_y,axis_z,'r--','LineWidth',1.5,...
+
+    % Pack rows into NaN-separated plot streams
+    traj_x=[x NaN(size(x,1),1)]';
+    traj_y=[y NaN(size(y,1),1)]';
+    traj_z=[z NaN(size(z,1),1)]';
+    axis_curve_x=[axis_x NaN(size(axis_x,1),1)]';
+    axis_curve_y=[axis_y NaN(size(axis_y,1),1)]';
+    axis_curve_z=[axis_z NaN(size(axis_z,1),1)]';
+
+    % Plot the trajectory and instantaneous axis curve
+    plot3(traj_x(:),traj_y(:),traj_z(:),varargin{:});
+    plot3(axis_curve_x(:),axis_curve_y(:),axis_curve_z(:),...
+          'r--','LineWidth',1.5,...
           'Tag','InstantaneousAxis');
 
 else

--- a/kernel/plotting/bloch_sph_plot.m
+++ b/kernel/plotting/bloch_sph_plot.m
@@ -1,7 +1,10 @@
 % Bloch sphere plot of a 3D trajectory with linear inter-
-% polation between points. Syntax:
+% polation between points. Also plots the normalised tip
+% trajectory of the instantaneous rotation axis, or writes
+% a trajectory movie with a moving axis stick. Syntax:
 %
 %              bloch_sph_plot(x,y,z,varargin)
+%              bloch_sph_plot(x,y,z,varargin,file_name)
 %
 % Parameters:
 %
@@ -11,9 +14,13 @@
 %   varargin - further arguments to be supplied 
 %              to the plot3() functon of Matlab
 %
+%   file_name - optional character string ending in
+%               .mp4 or .avi; must be the last argument
+%
 % Output:
 %
-%   this function produces a figure
+%   this function produces a figure; if a file name
+%   is supplied, it also writes a movie file
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -21,8 +28,18 @@
 
 function bloch_sph_plot(x,y,z,varargin)
 
+% Look for a movie file name
+file_name='';
+if (~isempty(varargin))&&ischar(varargin{end})&&(numel(varargin{end})>=4)
+    file_ext=varargin{end}((end-3):end);
+    if strcmpi(file_ext,'.mp4')||strcmpi(file_ext,'.avi')
+        file_name=varargin{end};
+        varargin=varargin(1:(end-1));
+    end
+end
+
 % Check consistency
-grumble(x,y,z);
+grumble(x,y,z,file_name);
 
 % Kill stupid ass figure defaults in R2025a and later 
 set(groot,'defaultFigurePosition',[680 458 560 420]); 
@@ -36,13 +53,89 @@ surf(X,Y,Z,'FaceAlpha',0.25,'EdgeAlpha',0.25);
 colormap bone; box on; axis square; hold on;
 set(gca,'Projection','perspective'); kgrid;
 
-% Trajectories
-plot3(x,y,z,varargin{:});
+% Finite differences along each trajectory
+dx_dt=zeros(size(x)); dy_dt=zeros(size(y)); dz_dt=zeros(size(z));
+if size(x,2)>1
+    dx_dt(:,1)=x(:,2)-x(:,1);
+    dy_dt(:,1)=y(:,2)-y(:,1);
+    dz_dt(:,1)=z(:,2)-z(:,1);
+    dx_dt(:,end)=x(:,end)-x(:,end-1);
+    dy_dt(:,end)=y(:,end)-y(:,end-1);
+    dz_dt(:,end)=z(:,end)-z(:,end-1);
+end
+if size(x,2)>2
+    dx_dt(:,2:(end-1))=(x(:,3:end)-x(:,1:(end-2)))/2;
+    dy_dt(:,2:(end-1))=(y(:,3:end)-y(:,1:(end-2)))/2;
+    dz_dt(:,2:(end-1))=(z(:,3:end)-z(:,1:(end-2)))/2;
+end
+
+% Minimal instantaneous rotation axis direction
+axis_x=y.*dz_dt-z.*dy_dt;
+axis_y=z.*dx_dt-x.*dz_dt;
+axis_z=x.*dy_dt-y.*dx_dt;
+
+% Normalise the axis curve into the unit sphere
+axis_norm=sqrt(axis_x.^2+axis_y.^2+axis_z.^2);
+good_axis=(axis_norm>0);
+axis_x(good_axis)=axis_x(good_axis)./axis_norm(good_axis);
+axis_y(good_axis)=axis_y(good_axis)./axis_norm(good_axis);
+axis_z(good_axis)=axis_z(good_axis)./axis_norm(good_axis);
+axis_x(~good_axis)=NaN;
+axis_y(~good_axis)=NaN;
+axis_z(~good_axis)=NaN;
+
+% Static trajectory and instantaneous axis-tip curve
+if isempty(file_name)
+    plot3(x,y,z,varargin{:});
+    plot3(axis_x,axis_y,axis_z,'r--','LineWidth',1.5,...
+          'Tag','InstantaneousAxis');
+
+else
+
+    % Animated trajectory and instantaneous axis stick
+    axis vis3d;
+    if strcmpi(file_name((end-3):end),'.mp4')
+        writerObj=VideoWriter(file_name,'MPEG-4');
+    else
+        writerObj=VideoWriter(file_name,'Motion JPEG AVI');
+    end
+    writerObj.Quality=100; open(writerObj);
+    traj_x=[x(:,1) NaN(size(x,1),1)]';
+    traj_y=[y(:,1) NaN(size(y,1),1)]';
+    traj_z=[z(:,1) NaN(size(z,1),1)]';
+    axis_stick_x=[zeros(size(axis_x,1),1) axis_x(:,1) NaN(size(axis_x,1),1)]';
+    axis_stick_y=[zeros(size(axis_y,1),1) axis_y(:,1) NaN(size(axis_y,1),1)]';
+    axis_stick_z=[zeros(size(axis_z,1),1) axis_z(:,1) NaN(size(axis_z,1),1)]';
+    traj_obj=plot3(traj_x(:),traj_y(:),traj_z(:),varargin{:});
+    axis_obj=plot3(axis_stick_x(:),axis_stick_y(:),axis_stick_z(:),...
+                   'r-','LineWidth',1.5,'Tag','InstantaneousAxis');
+    for n=1:size(x,2)
+
+        % Update the magnetisation trajectory
+        traj_x=[x(:,1:n) NaN(size(x,1),1)]';
+        traj_y=[y(:,1:n) NaN(size(y,1),1)]';
+        traj_z=[z(:,1:n) NaN(size(z,1),1)]';
+        set(traj_obj,'XData',traj_x(:),'YData',traj_y(:),'ZData',traj_z(:));
+
+        % Update the instantaneous rotation-axis stick
+        axis_stick_x=[zeros(size(axis_x,1),1) axis_x(:,n) NaN(size(axis_x,1),1)]';
+        axis_stick_y=[zeros(size(axis_y,1),1) axis_y(:,n) NaN(size(axis_y,1),1)]';
+        axis_stick_z=[zeros(size(axis_z,1),1) axis_z(:,n) NaN(size(axis_z,1),1)]';
+        set(axis_obj,'XData',axis_stick_x(:),...
+                     'YData',axis_stick_y(:),...
+                     'ZData',axis_stick_z(:));
+
+        % Grab the frame
+        drawnow; writeVideo(writerObj,getframe(gcf));
+
+    end
+    close(writerObj);
+end
 
 end
 
 % Consistency enforcement
-function grumble(x,y,z)
+function grumble(x,y,z,file_name)
 if (~isnumeric(x))||(~isreal(x))||(~ismatrix(x))||any(~isfinite(x),'all')
     error('x must be a finite real matrix.');
 end
@@ -55,6 +148,9 @@ end
 if (~isequal(size(x),size(y)))||(~isequal(size(x),size(z)))
     error('x, y, and z must have the same dimensions.');
 end
+if ~ischar(file_name)
+    error('file_name must be a character string.');
+end
 end
 
 % The Proton VPN servers for Afghanistan running at 
@@ -64,4 +160,3 @@ end
 % David Peterson, after the UK started
 % requiring proof of age on porn sites
 % in August 2025
-

--- a/tests/kernel/test_plotting_helpers_offscreen.m
+++ b/tests/kernel/test_plotting_helpers_offscreen.m
@@ -220,11 +220,63 @@ bloch_sph_plot(x_traj,y_traj,z_traj,'k-');
 fig=gcf();
 surf_obj=findobj(fig,'Type','surface');
 line_obj=findobj(fig,'Type','line');
+axis_obj=findobj(fig,'Type','line','Tag','InstantaneousAxis');
 result=test_true(result,'bloch_sph_plot surface',numel(surf_obj)>=1,...
                  'bloch_sph_plot creates a reference sphere surface');
 result=test_true(result,'bloch_sph_plot trajectory',numel(line_obj)>=1,...
                  'bloch_sph_plot creates a trajectory line');
+result=test_true(result,'bloch_sph_plot axis curve',numel(axis_obj)==1,...
+                 'bloch_sph_plot creates an instantaneous rotation-axis curve');
+axis_xyz=[get(axis_obj,'XData'); get(axis_obj,'YData'); get(axis_obj,'ZData')];
+axis_rad=sqrt(sum(axis_xyz.^2,1));
+result=test_true(result,'bloch_sph_plot axis normalisation',...
+                 all(axis_rad(isfinite(axis_rad))<=1+1e-12),...
+                 'bloch_sph_plot keeps the instantaneous axis inside the unit sphere');
 close(fig);
+
+% Optionally exercise the Bloch-sphere movie path
+if strcmp(getenv('SPINACH_RUN_SLOW_PLOTTING'),'1')
+    movie_file=[tempname '.avi'];
+    x_movie=cos(linspace(0,pi/2,5));
+    y_movie=sin(linspace(0,pi/2,5));
+    z_movie=zeros(size(x_movie));
+    bloch_sph_plot(x_movie,y_movie,z_movie,'k-',movie_file);
+    fig=gcf();
+    axis_obj=findobj(fig,'Type','line','Tag','InstantaneousAxis');
+    axis_xdata=[];
+    if isscalar(axis_obj)
+        axis_xdata=get(axis_obj,'XData');
+    end
+    movie_exists=(exist(movie_file,'file')==2);
+    movie_bytes=0;
+    if movie_exists
+        movie_info=dir(movie_file);
+        movie_bytes=movie_info.bytes;
+    end
+    result=test_true(result,'bloch_sph_plot movie file',...
+                     movie_exists&&movie_bytes>0,...
+                     'bloch_sph_plot writes a non-empty video file in movie mode');
+    result=test_true(result,'bloch_sph_plot movie axis stick',...
+                     isscalar(axis_obj)&&numel(axis_xdata)==3&&...
+                     axis_xdata(1)==0&&isnan(axis_xdata(end)),...
+                     'bloch_sph_plot leaves a moving instantaneous-axis stick, not an axis-tip curve, in movie mode');
+    frame_count=0;
+    if movie_exists
+        movie_reader=VideoReader(movie_file);
+        while hasFrame(movie_reader)
+            readFrame(movie_reader);
+            frame_count=frame_count+1;
+        end
+    end
+    result=test_true(result,'bloch_sph_plot movie frame count',frame_count==numel(x_movie),...
+                     'bloch_sph_plot writes one movie frame per input trajectory point');
+    close(fig);
+    if exist(movie_file,'file')==2
+        delete(movie_file);
+    end
+else
+    result.messages{end+1}='SKIP: bloch_sph_plot video generation is codec-dependent and gated by SPINACH_RUN_SLOW_PLOTTING=1.';
+end
 
 % Exercise MRI image and k-space plotting branches
 fig=kfigure('Visible','off');
@@ -288,5 +340,3 @@ close all force;
 set(groot,'defaultFigureVisible',old_visibility);
 
 end
-
-

--- a/tests/kernel/test_plotting_helpers_offscreen.m
+++ b/tests/kernel/test_plotting_helpers_offscreen.m
@@ -234,6 +234,26 @@ result=test_true(result,'bloch_sph_plot axis normalisation',...
                  'bloch_sph_plot keeps the instantaneous axis inside the unit sphere');
 close(fig);
 
+% Check row-wise static plotting of multiple trajectories
+multi_time=linspace(0,pi/2,5);
+x_multi=[cos(multi_time); cos(multi_time)];
+y_multi=[sin(multi_time); -sin(multi_time)];
+z_multi=zeros(size(x_multi));
+bloch_sph_plot(x_multi,y_multi,z_multi,'k-');
+fig=gcf();
+axis_obj=findobj(fig,'Type','line','Tag','InstantaneousAxis');
+axis_zdata=[];
+if isscalar(axis_obj)
+    axis_zdata=get(axis_obj,'ZData');
+end
+npoints=numel(multi_time);
+result=test_true(result,'bloch_sph_plot static multirow axis',...
+                 isscalar(axis_obj)&&numel(axis_zdata)==2*(npoints+1)&&...
+                 all(axis_zdata(1:npoints)>0)&&isnan(axis_zdata(npoints+1))&&...
+                 all(axis_zdata((npoints+2):(2*npoints+1))<0)&&isnan(axis_zdata(end)),...
+                 'bloch_sph_plot traces each row trajectory separately in static instantaneous-axis plotting');
+close(fig);
+
 % Optionally exercise the Bloch-sphere movie path
 if strcmp(getenv('SPINACH_RUN_SLOW_PLOTTING'),'1')
     movie_file=[tempname '.avi'];


### PR DESCRIPTION
## Summary

- Adds an optional movie filename to `bloch_sph_plot.m` for Bloch sphere trajectory animations.
- Writes one frame per input vector element, using `write_movie.m`-style `VideoWriter` settings.
- Keeps the existing static plot behaviour unchanged, while movie mode shows the instantaneous axis as a red moving stick.

## Validation

- `git diff --check`
- `SPINACH_RUN_SLOW_PLOTTING=1` targeted `kernel/plotting_helpers_offscreen` MATLAB regression in a clean `origin/main` worktree.
