### PR TITLE
Fix protein States phase recombination

### DIFF
--- a/examples/nmr_proteins/hcch_tocsy_simple.m
+++ b/examples/nmr_proteins/hcch_tocsy_simple.m
@@ -63,14 +63,14 @@ f3_neg_neg=fftshift(fft(fid.neg_neg,parameters.zerofill(3),3),3);
 
 % Absorption part of F3 signal
 f3_pos=f3_pos_pos+conj(f3_neg_neg);
-f3_neg=f3_neg_pos+conj(f3_pos_neg);
+f3_neg=f3_neg_pos-1i*conj(f3_pos_neg);
 
 % F2 Fourier transform
 f3f2_pos=fftshift(fft(f3_pos,parameters.zerofill(2),2),2);
 f3f2_neg=fftshift(fft(f3_neg,parameters.zerofill(2),2),2);
 
 % Absorption part of F2 signal
-f3f2=f3f2_pos+conj(f3f2_neg);
+f3f2=f3f2_pos+1i*conj(f3f2_neg);
 
 % F1 Fourier transform
 spectrum=fftshift(fft(f3f2,parameters.zerofill(1),1),1);

--- a/examples/nmr_proteins/hncaco_simple.m
+++ b/examples/nmr_proteins/hncaco_simple.m
@@ -59,15 +59,15 @@ f3_neg_pos=fftshift(fft(fid.neg_pos,parameters.zerofill(3),3),3);
 f3_neg_neg=fftshift(fft(fid.neg_neg,parameters.zerofill(3),3),3);
 
 % Absorption part of F3 signal
-f3_pos=f3_pos_pos+conj(f3_neg_neg);
-f3_neg=f3_neg_pos+conj(f3_pos_neg);
+f3_pos=f3_pos_pos+1i*conj(f3_neg_neg);
+f3_neg=f3_neg_pos-conj(f3_pos_neg);
 
 % F2 Fourier transform
 f3f2_pos=fftshift(fft(f3_pos,parameters.zerofill(2),2),2);
 f3f2_neg=fftshift(fft(f3_neg,parameters.zerofill(2),2),2);
 
 % Absorption part of F2 signal
-f3f2=f3f2_pos+conj(f3f2_neg);
+f3f2=f3f2_pos+1i*conj(f3f2_neg);
 
 % F1 Fourier transform
 spectrum=fftshift(fft(f3f2,parameters.zerofill(1),1),1);


### PR DESCRIPTION
## Summary

- fixes remaining anti-phase line shapes in the quick HCCH-TOCSY and HNCACO protein examples
- changes only the States/hypercomplex recombination factors in the processing stage
- leaves the pulse sequence implementations unchanged

## Phase Recombination

The previous examples used real `+conj(...)` recombination at all three conjugate-combination points. A `{+1,-1,+i,-i}` scan of the three phase factors selected:

- `hcch_tocsy_simple.m`: `+1`, `-i`, `+i`
- `hncaco_simple.m`: `+i`, `-1`, `+i`

The selected rows gave same-sign absorption windows in all three spectral dimensions in the numerical line-shape scan.

## Validation

- `git diff --check -- examples/nmr_proteins/hcch_tocsy_simple.m examples/nmr_proteins/hncaco_simple.m`
- direct run of both modified examples with `QT_QPA_PLATFORM=offscreen`, hidden figures, and `examples/nmr_proteins` added to the MATLAB path
- success marker: `MODIFIED_EXAMPLES_DONE`

