### PR TITLE
Fix HCCH-TOCSY carbon mixing phase handling

### DIFF
--- a/examples/nmr_proteins/hcch_tocsy_simple.m
+++ b/examples/nmr_proteins/hcch_tocsy_simple.m
@@ -63,14 +63,14 @@ f3_neg_neg=fftshift(fft(fid.neg_neg,parameters.zerofill(3),3),3);
 
 % Absorption part of F3 signal
 f3_pos=f3_pos_pos+conj(f3_neg_neg);
-f3_neg=f3_neg_pos-1i*conj(f3_pos_neg);
+f3_neg=f3_neg_pos+conj(f3_pos_neg);
 
 % F2 Fourier transform
 f3f2_pos=fftshift(fft(f3_pos,parameters.zerofill(2),2),2);
 f3f2_neg=fftshift(fft(f3_neg,parameters.zerofill(2),2),2);
 
 % Absorption part of F2 signal
-f3f2=f3f2_pos+1i*conj(f3f2_neg);
+f3f2=f3f2_pos+conj(f3f2_neg);
 
 % F1 Fourier transform
 spectrum=fftshift(fft(f3f2,parameters.zerofill(1),1),1);

--- a/experiments/nmr_protein/hcch_tocsy.m
+++ b/experiments/nmr_protein/hcch_tocsy.m
@@ -166,8 +166,10 @@ coil_stack=evolution(spin_system,L',[],coil_stack,-parameters.delta,1,'final');
 % Effective carbon isotropic mixing Liouvillian
 isomix_system=spin_system;
 isomix_system=dictum(isomix_system,{'13C'},'ignore');
+isomix_system=dictum(isomix_system,{'1H'},'ignore');
 isomix_system=dictum(isomix_system,{'13C','13C'},'strong');
 isomix_system=dictum(isomix_system,{'1H','13C'},'ignore');
+isomix_system=dictum(isomix_system,{'13C','1H'},'ignore');
 isomix_system=dictum(isomix_system,{'1H','1H'},'ignore');
 L_isomix=hamiltonian(isomix_system)+1i*R+1i*K;
 


### PR DESCRIPTION
## Summary

- restrict HCCH-TOCSY isotropic mixing to the carbon network by suppressing proton terms and both `1H-13C`/`13C-1H` coupling orderings in the mixing Hamiltonian
- restore HCCH-COSY-style States recombination in `hcch_tocsy_simple.m` by adding conjugate phase partners without empirical `+/-i` factors

## Literature basis

- Bax, Clore, and Gronenborn, JMR 88, 425-431 (1990): HCCH-TOCSY is HCCH-COSY-like, with the `13C` COSY transfer pulse replaced by DIPSI isotropic mixing of `13C` magnetization.
- Kay, Ikura, and Bax, JACS 112, 888-889 (1990): HCCH-COSY uses the `1H -> 13C -> 13C -> 1H` route and TPPI-States quadrature in both indirect dimensions.
- The validation target is absorptive/even line shape, not all-positive peak amplitude; the simulated cube has positive and negative absorptive components.

## Validation

- `git diff --check -- experiments/nmr_protein/hcch_tocsy.m examples/nmr_proteins/hcch_tocsy_simple.m`
- `HCCH_TOCSY_FINAL_VALIDATE_OK`
  - standard `(+,+,+)` States recombination, real spectrum
  - full-cube even-dominant checks: `51/54`
  - projections: `F1/F3 22/24`, `F1/F2 23/24`, `F2/F3 22/24`
  - diagonal and off-diagonal peaks are both present, with both positive and negative absorptive components
- `HCCH_TOCSY_SIMPLE_EXAMPLE_OK`
