### PR TITLE
Fix kgrid minor grid overlays

### DIFF
--- a/kernel/plotting/kgrid.m
+++ b/kernel/plotting/kgrid.m
@@ -1,6 +1,12 @@
-% A replacement for the 'grid' command in Matlab that
-% produces grey (rather than black-and-transparent) grid
-% lines that are suitable for publishing.
+% A replacement for the 'grid' command in MATLAB that produces
+% grey, rather than black-and-transparent, grid lines suitable
+% for publishing. Syntax:
+%
+%                          kgrid()
+%
+% Outputs:
+%
+%    creates or updates a custom grid overlay in the current axes
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -8,17 +14,213 @@
 
 function kgrid()
 
-% Publisher-friendly grid settings
-box on; grid on; grid minor;
-set(gca,'MinorGridAlpha',1,...
-        'MinorGridColor',[0.95 0.95 0.95],...
-        'MinorGridLineStyle','-')
-set(gca,'GridAlpha',1,...
-        'GridColor',[0.85 0.85 0.85],...
-        'GridLineStyle','-');
-set(gca,'Layer','bottom');
+% Get the current axis object
+ax=gca();
+
+% Remove any previous Spinach grid overlay
+if isappdata(ax,'SpinachKGrid')
+    local_clear(ax,getappdata(ax,'SpinachKGrid'));
+end
+
+% Set native grid styling before replacing it
+if ~isappdata(ax,'SpinachKBox'), box(ax,'on'); end
+grid(ax,'on'); grid(ax,'minor');
+set(ax,'MinorGridAlpha',1,'MinorGridColor',[0.95 0.95 0.95],...
+       'MinorGridLineStyle','-','GridAlpha',1,...
+       'GridColor',[0.85 0.85 0.85],'GridLineStyle','-',...
+       'Layer','top','XGrid','off','YGrid','off','ZGrid','off',...
+       'XMinorGrid','off','YMinorGrid','off','ZMinorGrid','off');
+
+% Preserve the caller's colour order
+colour_idx=get(ax,'ColorOrderIndex');
+
+% Create two grid line strips in the plot axes
+state.minor_line=line(ax,nan,nan,'Color',get(ax,'MinorGridColor'),...
+                      'HandleVisibility','off',...
+                      'HitTest','off','PickableParts','none',...
+                      'Tag','SpinachKGridMinor');
+state.major_line=line(ax,nan,nan,'Color',get(ax,'GridColor'),...
+                      'HandleVisibility','off',...
+                      'HitTest','off','PickableParts','none',...
+                      'Tag','SpinachKGridMajor');
+set(ax,'ColorOrderIndex',colour_idx);
+
+% Exclude custom grid lines from automatic legends
+set(get(get(state.minor_line,'Annotation'),'LegendInformation'),...
+    'IconDisplayStyle','off');
+set(get(get(state.major_line,'Annotation'),'LegendInformation'),...
+    'IconDisplayStyle','off');
+
+% Exclude custom grid lines from autoscaling
+lim_props={'XLimInclude','YLimInclude','ZLimInclude'};
+for n=1:numel(lim_props)
+    if isprop(state.minor_line,lim_props{n})
+        set([state.minor_line state.major_line],lim_props{n},'off');
+    end
+end
+
+% Update only on data-space changes, not on camera motion
+props={'XLim','YLim','ZLim','XTick','YTick','ZTick',...
+       'XMinorTick','YMinorTick','ZMinorTick','GridColor',...
+       'MinorGridColor','GridLineStyle','MinorGridLineStyle','LineWidth',...
+       'Children'};
+state.listeners={};
+for n=1:numel(props)
+    prop=findprop(ax,props{n});
+    if ~isempty(prop)&&prop.SetObservable
+        state.listeners{end+1}=addlistener(ax,props{n},'PostSet',...
+                                          @(~,~)local_update(ax));
+    end
+end
+state.busy=false;
+state.had_data=false;
+
+% Clean or refresh the overlay after axes child events
+state.listeners{end+1}=addlistener(ax,'Cla',@(~,~)local_cla(ax));
+state.listeners{end+1}=addlistener(ax,'ChildRemoved',@(~,~)local_update(ax));
+setappdata(ax,'SpinachKGrid',state);
+
+% Draw the custom grid immediately
+local_update(ax);
 
 end
+
+
+function local_update(ax)
+
+% Ignore inactive or recursive updates
+if ~ishandle(ax)||~isappdata(ax,'SpinachKGrid'), return, end
+state=getappdata(ax,'SpinachKGrid');
+if state.busy, return, end
+state.busy=true; setappdata(ax,'SpinachKGrid',state);
+
+% Remove overlay after ordinary axes clears
+kids=allchild(ax);
+grid_kids=(kids==state.minor_line)|(kids==state.major_line);
+data_kids=kids(~grid_kids);
+if isempty(data_kids)&&isfield(state,'had_data')&&state.had_data
+    local_clear(ax,state); return
+end
+
+% Collect axes geometry
+xl=get(ax,'XLim'); yl=get(ax,'YLim'); zl=get(ax,'ZLim');
+signature={numel(kids),xl,yl,zl,get(ax,'XTick'),get(ax,'YTick'),...
+           get(ax,'ZTick'),get(ax,'XMinorTick'),get(ax,'YMinorTick'),...
+           get(ax,'ZMinorTick'),get(ax,'XMinorGrid'),...
+           get(ax,'YMinorGrid'),get(ax,'ZMinorGrid'),...
+           get(ax,'GridLineStyle'),get(ax,'MinorGridLineStyle'),...
+           get(ax,'LineWidth'),get(ax,'GridColor'),...
+           get(ax,'MinorGridColor')};
+if isfield(state,'signature')&&isequaln(signature,state.signature)
+    state.busy=false; setappdata(ax,'SpinachKGrid',state); return
+end
+state.signature=signature;
+is3d=(abs(get(ax,'View')*[0;1]-90)>sqrt(eps))||...
+     any(arrayfun(@(h)isprop(h,'ZData')&&~isempty(get(h,'ZData')),data_kids));
+
+% Draw minor and major strips
+for k=1:2
+    if k==1
+        ticks={local_ticks(ax,'x','minor'),local_ticks(ax,'y','minor'),local_ticks(ax,'z','minor')};
+        line_obj=state.minor_line; colour=get(ax,'MinorGridColor'); style=get(ax,'MinorGridLineStyle');
+    else
+        ticks={local_ticks(ax,'x','major'),local_ticks(ax,'y','major'),local_ticks(ax,'z','major')};
+        line_obj=state.major_line; colour=get(ax,'GridColor'); style=get(ax,'GridLineStyle');
+    end
+    x=[]; y=[]; z=[];
+    if is3d
+        for q=ticks{1}, [x,y,z]=local_seg(x,y,z,[q yl(1) zl(1)],[q yl(2) zl(1)]); end
+        for q=ticks{2}, [x,y,z]=local_seg(x,y,z,[xl(1) q zl(1)],[xl(2) q zl(1)]); end
+        for q=ticks{1}, [x,y,z]=local_seg(x,y,z,[q yl(1) zl(1)],[q yl(1) zl(2)]); end
+        for q=ticks{3}, [x,y,z]=local_seg(x,y,z,[xl(1) yl(1) q],[xl(2) yl(1) q]); end
+        for q=ticks{2}, [x,y,z]=local_seg(x,y,z,[xl(1) q zl(1)],[xl(1) q zl(2)]); end
+        for q=ticks{3}, [x,y,z]=local_seg(x,y,z,[xl(1) yl(1) q],[xl(1) yl(2) q]); end
+    else
+        for q=ticks{1}, x=[x q q nan]; y=[y yl nan]; end %#ok<AGROW>
+        for q=ticks{2}, x=[x xl nan]; y=[y q q nan]; end %#ok<AGROW>
+        z=[];
+    end
+    set(line_obj,'XData',x,'YData',y,'ZData',z,'Color',colour,...
+                 'LineStyle',style,'LineWidth',get(ax,'LineWidth'));
+end
+
+% Stack data above major grid, and major grid above minor grid
+kids=allchild(ax);
+grid_kids=(kids==state.minor_line)|(kids==state.major_line);
+set(ax,'Children',[kids(~grid_kids); state.major_line; state.minor_line]);
+state.had_data=~isempty(kids(~grid_kids));
+state.busy=false; setappdata(ax,'SpinachKGrid',state);
+
+end
+
+
+function local_cla(ax)
+
+% Remove overlay after ordinary axes clears
+if ishandle(ax)&&isappdata(ax,'SpinachKGrid')
+    local_clear(ax,getappdata(ax,'SpinachKGrid'));
+end
+
+end
+
+
+function local_clear(ax,state)
+
+% Remove callbacks owned by the overlay
+if isfield(state,'listeners')&&~isempty(state.listeners)
+    cellfun(@delete,state.listeners(cellfun(@isvalid,state.listeners)));
+end
+
+% Remove the minor grid strip
+if isfield(state,'minor_line')&&ishandle(state.minor_line)
+    delete(state.minor_line);
+end
+
+% Remove the major grid strip
+if isfield(state,'major_line')&&ishandle(state.major_line)
+    delete(state.major_line);
+end
+
+% Remove stored overlay state
+if ishandle(ax)&&isappdata(ax,'SpinachKGrid')
+    rmappdata(ax,'SpinachKGrid');
+end
+
+end
+
+
+function ticks=local_ticks(ax,dim,kind)
+
+% Read major or ruler-computed minor tick locations
+lim=get(ax,[upper(dim) 'Lim']);
+major=get(ax,[upper(dim) 'Tick']);
+if strcmp(kind,'major')
+    ticks=major;
+else
+    ruler=get(ax,[upper(dim) 'Axis']);
+    ticks=get(ruler,'MinorTickValues');
+    for n=1:numel(major)
+        ticks=ticks(abs(ticks-major(n))>1024*eps(max([1 abs(lim) abs(major)])));
+    end
+end
+
+% Keep only finite interior ticks
+tol=1024*eps(max([1 abs(lim)]));
+ticks=double(ticks(:)).';
+ticks=ticks(isfinite(ticks)&(ticks>min(lim)+tol)&(ticks<max(lim)-tol));
+
+end
+
+
+function [x,y,z]=local_seg(x,y,z,a,b)
+
+% Add one NaN-separated segment
+x=[x a(1) b(1) nan];
+y=[y a(2) b(2) nan];
+z=[z a(3) b(3) nan];
+
+end
+
 
 % Frigid gentlewomen of the jury! I had thought that 
 % months, perhaps years, would elapse before I dared
@@ -29,5 +231,4 @@ end
 %
 % Vladimir Nabokov, "Lolita"
 
-% #NGRUM #NHEAD
-
+% #NGRUM

--- a/kernel/plotting/kgrid.m
+++ b/kernel/plotting/kgrid.m
@@ -59,11 +59,12 @@ for n=1:numel(lim_props)
     end
 end
 
-% Update only on data-space changes, not on camera motion
+% Update on data-space and camera changes
 props={'XLim','YLim','ZLim','XTick','YTick','ZTick',...
        'XMinorTick','YMinorTick','ZMinorTick','GridColor',...
-       'MinorGridColor','GridLineStyle','MinorGridLineStyle','LineWidth',...
-       'Children'};
+       'MinorGridColor','GridLineStyle','MinorGridLineStyle',...
+       'LineWidth','XDir','YDir','ZDir','View','CameraPosition',...
+       'CameraTarget','CameraUpVector','CameraViewAngle','Children'};
 state.listeners={};
 for n=1:numel(props)
     prop=findprop(ax,props{n});
@@ -104,19 +105,30 @@ end
 
 % Collect axes geometry
 xl=get(ax,'XLim'); yl=get(ax,'YLim'); zl=get(ax,'ZLim');
+is3d=(abs(get(ax,'View')*[0;1]-90)>sqrt(eps))||...
+     any(arrayfun(@(h)isprop(h,'ZData')&&~isempty(get(h,'ZData')),data_kids));
+
+% Select the plotting-box faces opposite to the camera
+face_pos=[];
+if is3d
+    cam_pos=get(ax,'CameraPosition');
+    box_ctr=[sum(xl)/2 sum(yl)/2 sum(zl)/2];
+    face_pos=[xl(1) yl(1) zl(1)];
+    if cam_pos(1)<box_ctr(1), face_pos(1)=xl(2); end
+    if cam_pos(2)<box_ctr(2), face_pos(2)=yl(2); end
+    if cam_pos(3)<box_ctr(3), face_pos(3)=zl(2); end
+end
 signature={numel(kids),xl,yl,zl,get(ax,'XTick'),get(ax,'YTick'),...
            get(ax,'ZTick'),get(ax,'XMinorTick'),get(ax,'YMinorTick'),...
            get(ax,'ZMinorTick'),get(ax,'XMinorGrid'),...
            get(ax,'YMinorGrid'),get(ax,'ZMinorGrid'),...
            get(ax,'GridLineStyle'),get(ax,'MinorGridLineStyle'),...
            get(ax,'LineWidth'),get(ax,'GridColor'),...
-           get(ax,'MinorGridColor')};
+           get(ax,'MinorGridColor'),get(ax,'View'),face_pos};
 if isfield(state,'signature')&&isequaln(signature,state.signature)
     state.busy=false; setappdata(ax,'SpinachKGrid',state); return
 end
 state.signature=signature;
-is3d=(abs(get(ax,'View')*[0;1]-90)>sqrt(eps))||...
-     any(arrayfun(@(h)isprop(h,'ZData')&&~isempty(get(h,'ZData')),data_kids));
 
 % Draw minor and major strips
 for k=1:2
@@ -129,12 +141,12 @@ for k=1:2
     end
     x=[]; y=[]; z=[];
     if is3d
-        for q=ticks{1}, [x,y,z]=local_seg(x,y,z,[q yl(1) zl(1)],[q yl(2) zl(1)]); end
-        for q=ticks{2}, [x,y,z]=local_seg(x,y,z,[xl(1) q zl(1)],[xl(2) q zl(1)]); end
-        for q=ticks{1}, [x,y,z]=local_seg(x,y,z,[q yl(1) zl(1)],[q yl(1) zl(2)]); end
-        for q=ticks{3}, [x,y,z]=local_seg(x,y,z,[xl(1) yl(1) q],[xl(2) yl(1) q]); end
-        for q=ticks{2}, [x,y,z]=local_seg(x,y,z,[xl(1) q zl(1)],[xl(1) q zl(2)]); end
-        for q=ticks{3}, [x,y,z]=local_seg(x,y,z,[xl(1) yl(1) q],[xl(1) yl(2) q]); end
+        for q=ticks{1}, [x,y,z]=local_seg(x,y,z,[q yl(1) face_pos(3)],[q yl(2) face_pos(3)]); end
+        for q=ticks{2}, [x,y,z]=local_seg(x,y,z,[xl(1) q face_pos(3)],[xl(2) q face_pos(3)]); end
+        for q=ticks{1}, [x,y,z]=local_seg(x,y,z,[q face_pos(2) zl(1)],[q face_pos(2) zl(2)]); end
+        for q=ticks{3}, [x,y,z]=local_seg(x,y,z,[xl(1) face_pos(2) q],[xl(2) face_pos(2) q]); end
+        for q=ticks{2}, [x,y,z]=local_seg(x,y,z,[face_pos(1) q zl(1)],[face_pos(1) q zl(2)]); end
+        for q=ticks{3}, [x,y,z]=local_seg(x,y,z,[face_pos(1) yl(1) q],[face_pos(1) yl(2) q]); end
     else
         for q=ticks{1}, x=[x q q nan]; y=[y yl nan]; end %#ok<AGROW>
         for q=ticks{2}, x=[x xl nan]; y=[y q q nan]; end %#ok<AGROW>

--- a/tests/kernel/test_plotting_helpers_offscreen.m
+++ b/tests/kernel/test_plotting_helpers_offscreen.m
@@ -88,6 +88,69 @@ result=test_true(result,'kcolourbar object',isscalar(colour_obj),...
                  'kcolourbar creates one colour-bar object');
 close(fig);
 
+% Exercise kgrid before a three-dimensional caller adds data
+fig=kfigure('Visible','off');
+hold('on'); kgrid();
+plot3([0 1],[0 1],[0 1],'k-');
+drawnow();
+ax=gca();
+grid_state=getappdata(ax,'SpinachKGrid');
+listener_events=cellfun(@(listener)listener.EventName,grid_state.listeners,...
+                        'UniformOutput',false);
+minor_data=get(grid_state.minor_line,'XData');
+major_data=get(grid_state.major_line,'XData');
+cam_before=get(ax,'CameraPosition');
+for n=1:12
+    camorbit(ax,5,3,'camera');
+    drawnow();
+end
+cam_after=get(ax,'CameraPosition');
+result=test_true(result,'kgrid pre-plot minor strip',nnz(isfinite(minor_data))>0,...
+                 'kgrid creates a minor grid strip when plot3 data arrives after kgrid');
+result=test_true(result,'kgrid pre-plot major strip',nnz(isfinite(major_data))>0,...
+                 'kgrid creates a major grid strip when plot3 data arrives after kgrid');
+result=test_true(result,'kgrid no redraw listener',~any(strcmp(listener_events,'MarkedClean')),...
+                 'kgrid does not listen to redraw events during camera motion');
+result=test_true(result,'kgrid camera motion',norm(cam_after-cam_before)>0,...
+                 'caller-created kgrid axes remain responsive to camera motion');
+close(fig);
+
+% Check that kgrid does not consume caller plot colours
+fig=kfigure('Visible','off');
+ax=axes('Parent',fig); hold(ax,'on');
+colour_order=get(ax,'ColorOrder');
+colour_idx=get(ax,'ColorOrderIndex');
+expected_colour=colour_order(1+mod(colour_idx-1,size(colour_order,1)),:);
+kgrid();
+data_line=plot(ax,[0 1],[0 1]);
+result=test_close(result,'kgrid colour order',get(data_line,'Color'),expected_colour,1e-12,1e-12,...
+                  'kgrid helper lines do not advance the caller colour order');
+close(fig);
+
+% Check that listened grid style changes refresh cached overlay data
+fig=kfigure('Visible','off');
+plot(0:10,0:10,'k-');
+kgrid(); ax=gca();
+set(ax,'MinorGridLineStyle',':','GridLineStyle','--');
+drawnow();
+grid_state=getappdata(ax,'SpinachKGrid');
+result=test_true(result,'kgrid cached minor style',strcmp(get(grid_state.minor_line,'LineStyle'),':'),...
+                 'kgrid refreshes minor line style after axes style changes');
+result=test_true(result,'kgrid cached major style',strcmp(get(grid_state.major_line,'LineStyle'),'--'),...
+                 'kgrid refreshes major line style after axes style changes');
+close(fig);
+
+% Check that ordinary axes clears remove the overlay
+fig=kfigure('Visible','off');
+plot(0:10,0:10,'k-');
+kgrid(); ax=gca();
+cla(ax); drawnow();
+result=test_true(result,'kgrid cla cleanup',~isappdata(ax,'SpinachKGrid')&&...
+                 isempty(findall(ax,'Tag','SpinachKGridMinor'))&&...
+                 isempty(findall(ax,'Tag','SpinachKGridMajor')),...
+                 'ordinary axes clearing removes kgrid overlay state and line strips');
+close(fig);
+
 end
 
 

--- a/tests/kernel/test_plotting_helpers_offscreen.m
+++ b/tests/kernel/test_plotting_helpers_offscreen.m
@@ -90,27 +90,34 @@ close(fig);
 
 % Exercise kgrid before a three-dimensional caller adds data
 fig=kfigure('Visible','off');
-hold('on'); kgrid();
-plot3([0 1],[0 1],[0 1],'k-');
-drawnow();
 ax=gca();
+hold(ax,'on'); kgrid();
+plot3(ax,[0 1],[0 1],[0 1],'k-');
+axis(ax,[0 1 0 1 0 1]);
+view(ax,[-35 25]);
+drawnow();
 grid_state=getappdata(ax,'SpinachKGrid');
-listener_events=cellfun(@(listener)listener.EventName,grid_state.listeners,...
-                        'UniformOutput',false);
 minor_data=get(grid_state.minor_line,'XData');
 major_data=get(grid_state.major_line,'XData');
+face_before=local_grid_faces(ax,grid_state.major_line);
+expected_before=local_expected_faces(ax);
 cam_before=get(ax,'CameraPosition');
-for n=1:12
-    camorbit(ax,5,3,'camera');
-    drawnow();
-end
+camorbit(ax,180,0,'camera');
+drawnow();
+grid_state=getappdata(ax,'SpinachKGrid');
+face_after=local_grid_faces(ax,grid_state.major_line);
+expected_after=local_expected_faces(ax);
 cam_after=get(ax,'CameraPosition');
 result=test_true(result,'kgrid pre-plot minor strip',nnz(isfinite(minor_data))>0,...
                  'kgrid creates a minor grid strip when plot3 data arrives after kgrid');
 result=test_true(result,'kgrid pre-plot major strip',nnz(isfinite(major_data))>0,...
                  'kgrid creates a major grid strip when plot3 data arrives after kgrid');
-result=test_true(result,'kgrid no redraw listener',~any(strcmp(listener_events,'MarkedClean')),...
-                 'kgrid does not listen to redraw events during camera motion');
+result=test_close(result,'kgrid initial 3D faces',face_before,expected_before,1e-12,1e-12,...
+                  'kgrid starts on the MATLAB back faces for the initial camera view');
+result=test_close(result,'kgrid rotated 3D faces',face_after,expected_after,1e-12,1e-12,...
+                  'kgrid follows MATLAB back-face switching during camera rotation');
+result=test_true(result,'kgrid face switch',~isequaln(face_before,face_after),...
+                 'camera rotation moves the kgrid overlay between plotting-box faces');
 result=test_true(result,'kgrid camera motion',norm(cam_after-cam_before)>0,...
                  'caller-created kgrid axes remain responsive to camera motion');
 close(fig);
@@ -344,6 +351,57 @@ spectrum=pos_peak-neg_peak;
 end
 
 
+function faces=local_grid_faces(ax,line_obj)
+
+% Read axis limits and grid line-strip data
+x_lim=get(ax,'XLim'); y_lim=get(ax,'YLim'); z_lim=get(ax,'ZLim');
+x_data=get(line_obj,'XData'); y_data=get(line_obj,'YData');
+z_data=get(line_obj,'ZData');
+
+% Count interior major ticks in each direction
+x_ticks=local_interior_ticks(get(ax,'XTick'),x_lim);
+y_ticks=local_interior_ticks(get(ax,'YTick'),y_lim);
+z_ticks=local_interior_ticks(get(ax,'ZTick'),z_lim);
+
+% Locate the first segment on each plotting-box face
+segments=reshape(1:numel(x_data),3,[]).';
+x_face=numel(x_ticks)+numel(y_ticks)+numel(x_ticks)+numel(z_ticks)+1;
+y_face=numel(x_ticks)+numel(y_ticks)+1;
+z_face=1;
+faces=[x_data(segments(x_face,1)) ...
+       y_data(segments(y_face,1)) ...
+       z_data(segments(z_face,1))];
+
+end
+
+
+function ticks=local_interior_ticks(ticks,axis_lim)
+
+% Keep finite tick locations away from the plotting-box boundary
+axis_tol=1024*eps(max([1 abs(axis_lim)]));
+ticks=double(ticks(:)).';
+ticks=ticks(isfinite(ticks)&(ticks>min(axis_lim)+axis_tol)&...
+            (ticks<max(axis_lim)-axis_tol));
+
+end
+
+
+function faces=local_expected_faces(ax)
+
+% Read the current plotting box and camera position
+x_lim=get(ax,'XLim'); y_lim=get(ax,'YLim'); z_lim=get(ax,'ZLim');
+cam_pos=get(ax,'CameraPosition');
+box_ctr=[sum(x_lim)/2 sum(y_lim)/2 sum(z_lim)/2];
+
+% Select the back face in each Cartesian direction
+faces=[x_lim(1) y_lim(1) z_lim(1)];
+if cam_pos(1)<box_ctr(1), faces(1)=x_lim(2); end
+if cam_pos(2)<box_ctr(2), faces(2)=y_lim(2); end
+if cam_pos(3)<box_ctr(3), faces(3)=z_lim(2); end
+
+end
+
+
 function local_cleanup(old_visibility)
 
 % Restore figure state after success or failure
@@ -351,5 +409,3 @@ close all force;
 set(groot,'defaultFigureVisible',old_visibility);
 
 end
-
-


### PR DESCRIPTION
## Summary

- Replace the native MATLAB grid depth workaround in `kgrid.m` with explicit major and minor line-strip objects.
- Keep major grid lines above minor grid lines, and keep plotted data above both.
- Remove the redraw listener that could interfere with camera interaction.
- Add a focused plotting-helper regression for `kgrid` before plotting and after camera motion.

## Validation

- Caller-level and GUI validation will be re-run from this fresh PR branch before merge readiness is reported.
