### PR TITLE
Regularise instantaneous frequency control plots

### DIFF
--- a/kernel/optimcon/ctrl_trajan.m
+++ b/kernel/optimcon/ctrl_trajan.m
@@ -489,11 +489,8 @@ if ismember('frq_controls',spin_system.control.plotting)
         cplx_ch_wf=    waveform(2*n-1,1:last_slice_to_plot)...
                    -1i*waveform(2*n  ,1:last_slice_to_plot);
 
-        % Compute the unwrapped phase
-        phase_profile=unwrap(angle(cplx_ch_wf(:)));
-
-        % Differentiate the phase using local least-squares fits
-        frq_profile(n,:)=sgolaydiff(phase_profile,1,npoints,poly_order)'/(2*pi*dt);
+        % Compute the instantaneous frequency profile
+        frq_profile(n,:)=inst_freq(cplx_ch_wf,dt,npoints,poly_order);
 
     end
 

--- a/kernel/optimcon/ctrl_trajan.m
+++ b/kernel/optimcon/ctrl_trajan.m
@@ -469,6 +469,16 @@ if ismember('frq_controls',spin_system.control.plotting)
     % Get the time grid stepping
     dt=spin_system.control.pulse_dt(1);
 
+    % Set half-window to the geometric mean of one slice and pulse duration
+    win_half=ceil(sqrt(last_slice_to_plot));
+
+    % Count the local least-squares averaging window
+    npoints=min(last_slice_to_plot,2*win_half+1);
+    if mod(npoints,2)==0, npoints=npoints-1; end
+
+    % Set the local polynomial order
+    poly_order=min(3,npoints-2);
+
     % Preallocate the instantaneous frequency array
     frq_profile=zeros(size(waveform,1)/2,last_slice_to_plot);
 
@@ -479,14 +489,13 @@ if ismember('frq_controls',spin_system.control.plotting)
         cplx_ch_wf=    waveform(2*n-1,1:last_slice_to_plot)...
                    -1i*waveform(2*n  ,1:last_slice_to_plot);
 
-        % Compute instantaneous frequencies
-        frq_profile(n,:)=inst_freq(cplx_ch_wf,dt);
+        % Compute the unwrapped phase
+        phase_profile=unwrap(angle(cplx_ch_wf(:)));
+
+        % Differentiate the phase using local least-squares fits
+        frq_profile(n,:)=sgolaydiff(phase_profile,1,npoints,poly_order)'/(2*pi*dt);
 
     end
-
-    % Apply the frequency stability filter
-    filter_order=2*ceil(sqrt(size(frq_profile,2)))+1;
-    frq_profile=medfilt1(frq_profile,filter_order,[],2);
 
     % Plot with predictable colours
     p=plot(t_axis(1:last_slice_to_plot)',frq_profile');
@@ -762,11 +771,14 @@ if ismember('spectrogram',spin_system.control.plotting)
         error('spectrograms require an even number of control channels.');
     end
 end
+if ismember('frq_controls',spin_system.control.plotting)
+    if ~(mod(size(waveform,1),2)==0)
+        error('instantaneous frequency plots require an even number of control channels.');
+    end
+end
 end
 
 % If you can't explain it simply, you don't
 % understand it well enough.
 %
 % Albert Einstein
-
-

--- a/kernel/optimcon/inst_freq.m
+++ b/kernel/optimcon/inst_freq.m
@@ -1,7 +1,7 @@
-% Instantaneous frequency trajectory from a complex time-domain 
-% signal. Uses product-phase finite differences. Syntax:
+% Instantaneous frequency trajectory from a complex time-domain
+% signal by regularised phase differentiation. Syntax:
 %
-%                   freq=inst_freq(signal,dt)
+%          freq=inst_freq(signal,dt,npoints,poly_order)
 %
 % Parameters:
 %
@@ -11,47 +11,40 @@
 %    dt     - time step duration between 
 %             signal points (seconds)
 %
+%    npoints    - odd number of signal points in the
+%                 local least-squares window
+%
+%    poly_order - local polynomial order used for
+%                 phase differentiation
+%
 % Outputs:
 %
 %    freq   - instantaneous frequency trajec-
 %             tory (Hz), same size as signal
 %             and on the same time grid
 %
-% Note: central second-order phase-difference approximation is 
-%       used in the interior, second-order one-sided approxi-
-%       mations are used at the boundaries; all formulas use
-%       one-step phase differences.
+% Note: signal phase is unwrapped first and then differentiated
+%       by Savitzky-Golay local least-squares polynomial fits.
+%       This regularises numerical phase noise before the deri-
+%       vative is taken.
 %
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=inst_freq.m>
 
-function freq=inst_freq(signal,dt)
+function freq=inst_freq(signal,dt,npoints,poly_order)
 
 % Check consistency
-grumble(signal,dt);
+grumble(signal,dt,npoints,poly_order);
 
 % Input into column
 signal_col=signal(:);
 
-% Preallocate output array
-freq=zeros(size(signal_col));
+% Unwrap the phase trajectory
+phase_col=unwrap(angle(signal_col));
 
-% Compute interior points using central second-order 
-% formula from one-step phase differences
-phase_fwd=angle(signal_col(3:end).*conj(signal_col(2:(end-1))));
-phase_bwd=angle(signal_col(2:(end-1)).*conj(signal_col(1:(end-2))));
-freq(2:(end-1))=(phase_fwd+phase_bwd)/(4*pi*dt);
-
-% Compute first point using forward second-order formula
-phase_01=angle(signal_col(2)*conj(signal_col(1)));
-phase_12=angle(signal_col(3)*conj(signal_col(2)));
-freq(1)=(3*phase_01-phase_12)/(4*pi*dt);
-
-% Compute last point using backward second-order formula
-phase_n1=angle(signal_col(end)*conj(signal_col(end-1)));
-phase_n2=angle(signal_col(end-1)*conj(signal_col(end-2)));
-freq(end)=(3*phase_n1-phase_n2)/(4*pi*dt);
+% Differentiate the phase using local least-squares fits
+freq=sgolaydiff(phase_col,1,npoints,poly_order)/(2*pi*dt);
 
 % Shape back to input shape
 freq=reshape(freq,size(signal));
@@ -59,7 +52,7 @@ freq=reshape(freq,size(signal));
 end
 
 % Consistency enforcement
-function grumble(signal,dt)
+function grumble(signal,dt,npoints,poly_order)
 if (~isnumeric(signal))||(~isvector(signal))||isempty(signal)||isreal(signal)
     error('signal must be a non-empty complex numeric vector.');
 end
@@ -71,6 +64,23 @@ if any(~isfinite(signal))
 end
 if (~isnumeric(dt))||(~isreal(dt))||(~isscalar(dt))||(~isfinite(dt))||(dt<=0)
     error('dt must be a positive real scalar.');
+end
+if (~isnumeric(npoints))||(~isreal(npoints))||(numel(npoints)~=1)||...
+   (npoints<3)||(mod(npoints,1)~=0)
+    error('npoints must be a positive odd integer greater than two.');
+end
+if mod(npoints,2)~=1
+    error('npoints must be an odd integer.');
+end
+if npoints>numel(signal)
+    error('npoints must not exceed the number of signal points.');
+end
+if (~isnumeric(poly_order))||(~isreal(poly_order))||(numel(poly_order)~=1)||...
+   (poly_order<1)||(mod(poly_order,1)~=0)
+    error('poly_order must be a positive real integer.');
+end
+if poly_order>=npoints
+    error('poly_order must be smaller than npoints.');
 end
 end
 

--- a/tests/kernel/test_dynamic_optimcon_remaining.m
+++ b/tests/kernel/test_dynamic_optimcon_remaining.m
@@ -279,6 +279,22 @@ plot_wave=[1 2 3; -1 0 1];
 ctrl_trajan(plot_system,plot_wave,{struct()},0.5);
 result.messages{end+1}='PASS: ctrl_trajan xy_controls -- plotting smoke path completed offscreen';
 
+% Check instantaneous frequency plotting on a linear phase track
+time_step=1e-4;
+npoints=65;
+freq_ref=123.4;
+time_axis=(0:(npoints-1))*time_step;
+signal=exp(2i*pi*freq_ref*time_axis);
+plot_system.control.plotting={'frq_controls'};
+plot_system.control.pulse_dt=time_step*ones(1,npoints);
+plot_wave=[real(signal); -imag(signal)];
+ctrl_trajan(plot_system,plot_wave,{struct()},0.5);
+line_obj=findobj(gca,'Type','line');
+freq_plot=get(line_obj(1),'YData');
+result=test_close(result,'ctrl_trajan frq_controls',freq_plot,freq_ref*ones(size(freq_plot)),...
+                  1e-10,1e-10,...
+                  'ctrl_trajan must recover the instantaneous frequency of a linear phase');
+
 end
 
 

--- a/tests/kernel/test_dynamic_optimcon_remaining.m
+++ b/tests/kernel/test_dynamic_optimcon_remaining.m
@@ -218,7 +218,7 @@ base_freq=3;
 chirp_rate=4;
 signal=exp(1i*2*pi*(base_freq*time_axis+0.5*chirp_rate*time_axis.^2));
 freq_ref=base_freq+chirp_rate*time_axis;
-freq=inst_freq(signal,sample_dt);
+freq=inst_freq(signal,sample_dt,5,2);
 result=test_close(result,'inst_freq chirp',freq,freq_ref,1e-10,1e-10,...
                   'inst_freq must recover the exact frequency of a quadratic phase');
 


### PR DESCRIPTION
Summary:
- update `inst_freq.m` to compute instantaneous frequency by unwrapping complex-signal phase and differentiating it with `sgolaydiff()` local least-squares polynomial fits
- add required `npoints` and `poly_order` inputs to `inst_freq.m` so the smoothing scale and differentiating polynomial are explicit rather than hidden defaults
- keep `ctrl_trajan.m` responsible for choosing a plotting window from the geometric mean of one control slice and the plotted uniform pulse duration, then delegate frequency estimation to `inst_freq()`
- add `frq_controls` pair-count validation and focused regression coverage for both `inst_freq()` and the plotting path

Validation:
- `git diff --check -- kernel/optimcon/inst_freq.m kernel/optimcon/ctrl_trajan.m tests/kernel/test_dynamic_optimcon_remaining.m`
- direct headless MATLAB probe: row and column `inst_freq()` chirp recovery plus `ctrl_trajan(...,'frq_controls')`, marker `TALOS_INST_FREQ_DIRECT_OK`
- focused headless MATLAB regression: `run_test('kernel/dynamic_optimcon_remaining')`, marker `TALOS_DYNAMIC_OPTIMCON_REMAINING_OK`