### PR TITLE
docs: complete ttclass function headers

### DIFF
--- a/kernel/overloads/@ttclass/clearcoeff.m
+++ b/kernel/overloads/@ttclass/clearcoeff.m
@@ -1,9 +1,16 @@
-% Absorbs the physical coefficient of the tensor train into
-% its cores. Syntax: 
+% Absorbs physical coefficients into tensor train cores without
+% changing the value represented by the tensor train. Syntax:
 % 
 %                     tt=clearcoeff(tt)
 %
-% The value of the tensor train remains the same.
+% Parameters:
+%
+%    tt - tensor train object
+%
+% Outputs:
+%
+%    tt - tensor train object with each coefficient distributed
+%         into its cores and the coefficient array set to one
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
@@ -37,5 +44,5 @@ end
 %
 % Anonymous philosophy professor
 
-% #NGRUM #NHEAD
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/conj.m
+++ b/kernel/overloads/@ttclass/conj.m
@@ -1,6 +1,16 @@
-% Conjugate the elements of the tensor train matrix. Syntax:
+% Conjugates all core elements and coefficients of a tensor
+% train object. Syntax:
 %
 %                         tt=conj(tt)
+%
+% Parameters:
+%
+%    tt - tensor train object
+%
+% Outputs:
+%
+%    tt - tensor train object with complex-conjugated cores
+%         and coefficients
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
@@ -30,5 +40,5 @@ end
 %
 % Al Pacino
 
-% #NGRUM #NHEAD
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/ctranspose.m
+++ b/kernel/overloads/@ttclass/ctranspose.m
@@ -3,6 +3,14 @@
 %
 %                   ttrain=ctranspose(ttrain)
 %
+% Parameters:
+%
+%    ttrain - tensor train representation of a matrix
+%
+% Outputs:
+%
+%    ttrain - Hermitian conjugate of the input tensor train
+%
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
 %
@@ -29,5 +37,5 @@ end
 %
 % Igor Stravinsky
 
-% #NGRUM #NHEAD
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/diag.m
+++ b/kernel/overloads/@ttclass/diag.m
@@ -1,4 +1,4 @@
-% Mimics the diag behavior for tensor train matrix. Syntax:
+% Mimics the diag behaviour for tensor train matrix. Syntax:
 %
 %                         tt=diag(tt)
 %

--- a/kernel/overloads/@ttclass/hdot.m
+++ b/kernel/overloads/@ttclass/hdot.m
@@ -1,4 +1,4 @@
-% Haramard dot product between two tensor train matrices. Syntax:
+% Hadamard dot product between two tensor train matrices. Syntax:
 %
 %                         c=hdot(a,b)
 %

--- a/kernel/overloads/@ttclass/ismatrix.m
+++ b/kernel/overloads/@ttclass/ismatrix.m
@@ -1,6 +1,14 @@
-% Returns TRUE for the tensor train class. Syntax:
+% Returns TRUE for non-empty tensor train objects. Syntax:
 %
 %                answer=ismatrix(tt)
+%
+% Parameters:
+%
+%    tt - tensor train object
+%
+% Outputs:
+%
+%    answer - logical true for non-empty tensor train objects
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
@@ -22,5 +30,5 @@ end
 %
 % The Law of Three Little Pigs
 
-% #NHEAD #NGRUM
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/isnumeric.m
+++ b/kernel/overloads/@ttclass/isnumeric.m
@@ -1,6 +1,14 @@
-% Returns TRUE for the tensor train class. Syntax: 
+% Returns TRUE for non-empty tensor train objects. Syntax:
 %
 %                answer=isnumeric(tt)
+%
+% Parameters:
+%
+%    tt - tensor train object
+%
+% Outputs:
+%
+%    answer - logical true for non-empty tensor train objects
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
@@ -22,6 +30,4 @@ end
 % attitude towards the public.
 %
 % Johann Wolfgang von Goethe
-
-% #NHEAD
 

--- a/kernel/overloads/@ttclass/isreal.m
+++ b/kernel/overloads/@ttclass/isreal.m
@@ -1,6 +1,15 @@
-% Returns TRUE for the real-valued ttclass. Syntax: 
+% Returns TRUE for real-valued tensor train objects. Syntax:
 %
 %                answer=isreal(tt)
+%
+% Parameters:
+%
+%    tt - tensor train object
+%
+% Outputs:
+%
+%    answer - logical true when all coefficients and core
+%             elements of the tensor train are real
 %
 % d.savostyanov@soton.ac.uk
 %
@@ -38,5 +47,5 @@ end
 %
 % H.L. Mencken
 
-% #NHEAD #NGRUM
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/mldivide.m
+++ b/kernel/overloads/@ttclass/mldivide.m
@@ -6,7 +6,7 @@
 %
 %    A - ttclass matrix 
 %
-%    x - ttclass vector
+%    y - ttclass vector
 %
 % Outputs:
 %

--- a/kernel/overloads/@ttclass/nnz.m
+++ b/kernel/overloads/@ttclass/nnz.m
@@ -1,6 +1,14 @@
-% Number of nonzeros in all cores of a tensor train. Syntax: 
+% Counts non-zero elements in all cores of a tensor train. Syntax:
 %
 %                     answer=nnz(ttrain)
+%
+% Parameters:
+%
+%    ttrain - tensor train object
+%
+% Outputs:
+%
+%    answer - number of non-zero elements in all tensor train cores
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
@@ -21,5 +29,5 @@ end
 %
 % Vladimir Lenin
 
-% #NHEAD #NGRUM
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/norm.m
+++ b/kernel/overloads/@ttclass/norm.m
@@ -1,6 +1,6 @@
 % Computes the norm of the matrix represented by a tensor train. Syntax:
 %
-% #NORMOK               ttnorm=norm(ttrain,norm_type)
+%                    ttnorm=norm(ttrain,norm_type)
 %
 % Parameters:
 %
@@ -8,16 +8,17 @@
 %
 %    norm_type:
 %
-%       norm_type=1         returns the 1-norm
-%       norm_type=inf       returns the inf-norm
-%       norm_type=2         returns the 2-norm
+%       norm_type=1         not available for ttclass
+%       norm_type=inf       not available for ttclass
+%       norm_type=2         not available for ttclass
 %       norm_type='fro'     returns the Frobenius norm
 %
 % Outputs:
 %
 %    ttnorm - a positive real number
 %
-% Note: norms other than Frobenius norm are expensive for tensor trains.
+% Note: only Frobenius norm is currently available for tensor trains;
+%       other norm types raise errors.
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il

--- a/kernel/overloads/@ttclass/rand.m
+++ b/kernel/overloads/@ttclass/rand.m
@@ -1,5 +1,5 @@
 % Generates a tensor train representation of a matrix with random
-% tensor train cores, same physical index topology at the tensor
+% tensor train cores, same physical index topology as the tensor
 % train supplied, and user-specified bond ranks. Syntax:
 %
 %                        tt=rand(tt,ttrank)

--- a/kernel/overloads/@ttclass/revert.m
+++ b/kernel/overloads/@ttclass/revert.m
@@ -1,7 +1,16 @@
-% Bit-revert permutation for the tensor train operator. Syntax:
+% Applies a bit-revert permutation to a tensor train operator by
+% reversing the core order and swapping bond indices. Syntax:
 %
 %                       tt=revert(tt)
 % 
+% Parameters:
+%
+%    tt - tensor train operator
+%
+% Outputs:
+%
+%    tt - tensor train operator with reversed core order
+%
 % d.savostyanov@soton.ac.uk
 %
 % <https://spindynamics.org/wiki/index.php?title=ttclass/revert.m>
@@ -29,5 +38,5 @@ end
 %
 % Gerald M. Weinberg, "The psychology of computer programming"
 
-% #NHEAD #NGRUM
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/size.m
+++ b/kernel/overloads/@ttclass/size.m
@@ -11,9 +11,9 @@
 %
 % Outputs:
 %
-%    m,n - integers sepcifying the dimensions
+%    m,n - integers specifying the dimensions
 %
-% Note: for large tt matrices, n and n may be too large to fit
+% Note: for large tt matrices, m and n may be too large to fit
 %       into the maximum integer permitted by Matlab.
 %
 % d.savostyanov@soton.ac.uk

--- a/kernel/overloads/@ttclass/sizes.m
+++ b/kernel/overloads/@ttclass/sizes.m
@@ -1,9 +1,16 @@
 % Returns mode sizes (physical dimensions of each core) of
-% a tensor train. Syntax: 
+% a tensor train. Syntax:
 %
 %                   modesizes=sizes(tt)
 %
-% The output is an array with ncores rows and two columns.
+% Parameters:
+%
+%    tt - tensor train object
+%
+% Outputs:
+%
+%    modesizes - ncores by 2 array of physical dimensions
+%                of tensor train cores
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
@@ -32,5 +39,5 @@ end
 % 
 % Jim Hacker, in "Yes, Prime Minister" (a BBC documentary)
 
-% #NGRUM #NHEAD
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/subsref.m
+++ b/kernel/overloads/@ttclass/subsref.m
@@ -1,4 +1,18 @@
 % Dot and bracket property specifications for the tensor train class.
+% Syntax:
+%
+%                answer=subsref(ttrain,reference)
+%
+% Parameters:
+%
+%    ttrain    - tensor train object
+%
+%    reference - Matlab subscript reference structure
+%
+% Outputs:
+%
+%    answer    - requested tensor train property, scalar
+%                matrix element, or nested subscript result
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
@@ -79,5 +93,5 @@ end
 %
 % A Russian saying
 
-% #NGRUM #NHEAD
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/trace.m
+++ b/kernel/overloads/@ttclass/trace.m
@@ -2,6 +2,14 @@
 %
 %                     tttrace=trace(tt)
 %
+% Parameters:
+%
+%    tt - tensor train operator
+%
+% Outputs:
+%
+%    tttrace - trace of the tensor train operator
+%
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
 %
@@ -48,5 +56,5 @@ end
 %
 % Leo Szilard
 
-% #NHEAD #NGRUM
+% #NGRUM
 

--- a/kernel/overloads/@ttclass/transpose.m
+++ b/kernel/overloads/@ttclass/transpose.m
@@ -2,6 +2,14 @@
 %
 %                  ttrain=transpose(ttrain)
 %
+% Parameters:
+%
+%    ttrain - tensor train representation of a matrix
+%
+% Outputs:
+%
+%    ttrain - transpose of the input tensor train
+%
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
 %
@@ -26,5 +34,5 @@ end
 %
 % Ayn Rand, "Atlas Shrugged"
 
-% #NHEAD #NGRUM
+% #NGRUM
 


### PR DESCRIPTION
## Summary

- complete missing or defective documentation headers for `@ttclass` overloads
- correct several `@ttclass` header inaccuracies found during the Wiki repair audit
- keep changes limited to documentation comments; function bodies are unchanged

## Validation

- `git diff --cached --check`
- independent live Spin Dynamics Wiki audit: 39 `ttclass` pages checked, 0 template failures
- `python3 tools/run_matlab_batch_probe.py --script tmp/ttclass_wiki_repair_20260605/validate_ttclass_headers.m --log tmp/ttclass_wiki_repair_20260605/reports/matlab_ttclass_validation.log --success-marker TTCLASS_HEADER_VALIDATION_OK`
