### PR TITLE
Add engineering axis tick helpers

### DIFF
--- a/kernel/plotting/kxtickfix.m
+++ b/kernel/plotting/kxtickfix.m
@@ -1,5 +1,6 @@
 % Switches X axis tick labels to engineering notation by setting
-% the numeric-ruler exponent to a multiple of three. Syntax:
+% the numeric-ruler exponent to a multiple of three and installs
+% a pan/zoom auto-updater. Syntax:
 %
 %                         kxtickfix()
 %
@@ -9,7 +10,7 @@
 %
 % Outputs:
 %
-%    updates the current axis system
+%    updates the current axis system and installs an auto-updater
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -23,6 +24,59 @@ ruler=ax.XAxis;
 
 % Check consistency
 grumble(ruler);
+
+% Preserve any existing limit-change callback
+app_key='SpinachKXTickFix';
+if isappdata(ax,app_key)
+    state=getappdata(ax,app_key);
+    if isfield(state,'callback')&&isequal(ruler.LimitsChangedFcn,state.callback)
+        old_fcn=state.old_fcn;
+    else
+        old_fcn=ruler.LimitsChangedFcn;
+    end
+else
+    old_fcn=ruler.LimitsChangedFcn;
+end
+
+% Install the automatic exponent updater
+callback=@(source,event)local_callback(source,event,ax,app_key);
+state.callback=callback; state.old_fcn=old_fcn;
+setappdata(ax,app_key,state);
+ruler.LimitsChangedFcn=callback;
+
+% Set the current exponent
+local_update(ruler);
+
+end
+
+% Local update callback
+function local_callback(ruler,event,ax,app_key)
+
+% Ignore deleted graphics objects
+if ~ishandle(ruler)||~ishandle(ax)||~isappdata(ax,app_key), return, end
+
+% Update the engineering exponent
+local_update(ruler);
+
+% Run the pre-existing callback if there was one
+state=getappdata(ax,app_key);
+if ~isempty(state.old_fcn)
+    if isa(state.old_fcn,'function_handle')
+        state.old_fcn(ruler,event);
+    elseif iscell(state.old_fcn)
+        feval(state.old_fcn{1},ruler,event,state.old_fcn{2:end});
+    elseif ischar(state.old_fcn)||isstring(state.old_fcn)
+        evalin('base',char(state.old_fcn));
+    end
+end
+
+end
+
+% Local exponent updater
+function local_update(ruler)
+
+% Ignore non-linear axis state after installation
+if ~strcmp(ruler.Scale,'linear'), return, end
 
 % Extract finite non-zero tick values
 ticks=ruler.TickValues;

--- a/kernel/plotting/kxtickfix.m
+++ b/kernel/plotting/kxtickfix.m
@@ -1,0 +1,55 @@
+% Switches X axis tick labels to engineering notation by setting
+% the numeric-ruler exponent to a multiple of three. Syntax:
+%
+%                         kxtickfix()
+%
+% Parameters:
+%
+%    none
+%
+% Outputs:
+%
+%    updates the current axis system
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=kxtickfix.m>
+
+function kxtickfix()
+
+% Pull out the current X axis ruler
+ax=gca;
+ruler=ax.XAxis;
+
+% Check consistency
+grumble(ruler);
+
+% Extract finite non-zero tick values
+ticks=ruler.TickValues;
+ticks=ticks(isfinite(ticks)&(ticks~=0));
+
+% Use finite non-zero limits when tick values are unavailable
+if isempty(ticks)
+    ticks=ruler.Limits;
+    ticks=ticks(isfinite(ticks)&(ticks~=0));
+end
+
+% Use unscaled labels for zero axes
+if isempty(ticks)
+    ruler.Exponent=0;
+else
+    ruler.Exponent=3*floor(log10(max(abs(ticks)))/3);
+end
+
+end
+
+% Consistency enforcement
+function grumble(ruler)
+if ~isa(ruler,'matlab.graphics.axis.decorator.NumericRuler')
+    error('X axis must be numeric.');
+end
+if ~strcmp(ruler.Scale,'linear')
+    error('X axis scale must be linear.');
+end
+end
+

--- a/kernel/plotting/kytickfix.m
+++ b/kernel/plotting/kytickfix.m
@@ -1,0 +1,55 @@
+% Switches Y axis tick labels to engineering notation by setting
+% the numeric-ruler exponent to a multiple of three. Syntax:
+%
+%                         kytickfix()
+%
+% Parameters:
+%
+%    none
+%
+% Outputs:
+%
+%    updates the current axis system
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=kytickfix.m>
+
+function kytickfix()
+
+% Pull out the current Y axis ruler
+ax=gca;
+ruler=ax.YAxis;
+
+% Check consistency
+grumble(ruler);
+
+% Extract finite non-zero tick values
+ticks=ruler.TickValues;
+ticks=ticks(isfinite(ticks)&(ticks~=0));
+
+% Use finite non-zero limits when tick values are unavailable
+if isempty(ticks)
+    ticks=ruler.Limits;
+    ticks=ticks(isfinite(ticks)&(ticks~=0));
+end
+
+% Use unscaled labels for zero axes
+if isempty(ticks)
+    ruler.Exponent=0;
+else
+    ruler.Exponent=3*floor(log10(max(abs(ticks)))/3);
+end
+
+end
+
+% Consistency enforcement
+function grumble(ruler)
+if ~isa(ruler,'matlab.graphics.axis.decorator.NumericRuler')
+    error('Y axis must be numeric.');
+end
+if ~strcmp(ruler.Scale,'linear')
+    error('Y axis scale must be linear.');
+end
+end
+

--- a/kernel/plotting/kytickfix.m
+++ b/kernel/plotting/kytickfix.m
@@ -1,5 +1,6 @@
 % Switches Y axis tick labels to engineering notation by setting
-% the numeric-ruler exponent to a multiple of three. Syntax:
+% the numeric-ruler exponent to a multiple of three and installs
+% a pan/zoom auto-updater. Syntax:
 %
 %                         kytickfix()
 %
@@ -9,7 +10,7 @@
 %
 % Outputs:
 %
-%    updates the current axis system
+%    updates the current axis system and installs an auto-updater
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -23,6 +24,59 @@ ruler=ax.YAxis;
 
 % Check consistency
 grumble(ruler);
+
+% Preserve any existing limit-change callback
+app_key='SpinachKYTickFix';
+if isappdata(ax,app_key)
+    state=getappdata(ax,app_key);
+    if isfield(state,'callback')&&isequal(ruler.LimitsChangedFcn,state.callback)
+        old_fcn=state.old_fcn;
+    else
+        old_fcn=ruler.LimitsChangedFcn;
+    end
+else
+    old_fcn=ruler.LimitsChangedFcn;
+end
+
+% Install the automatic exponent updater
+callback=@(source,event)local_callback(source,event,ax,app_key);
+state.callback=callback; state.old_fcn=old_fcn;
+setappdata(ax,app_key,state);
+ruler.LimitsChangedFcn=callback;
+
+% Set the current exponent
+local_update(ruler);
+
+end
+
+% Local update callback
+function local_callback(ruler,event,ax,app_key)
+
+% Ignore deleted graphics objects
+if ~ishandle(ruler)||~ishandle(ax)||~isappdata(ax,app_key), return, end
+
+% Update the engineering exponent
+local_update(ruler);
+
+% Run the pre-existing callback if there was one
+state=getappdata(ax,app_key);
+if ~isempty(state.old_fcn)
+    if isa(state.old_fcn,'function_handle')
+        state.old_fcn(ruler,event);
+    elseif iscell(state.old_fcn)
+        feval(state.old_fcn{1},ruler,event,state.old_fcn{2:end});
+    elseif ischar(state.old_fcn)||isstring(state.old_fcn)
+        evalin('base',char(state.old_fcn));
+    end
+end
+
+end
+
+% Local exponent updater
+function local_update(ruler)
+
+% Ignore non-linear axis state after installation
+if ~strcmp(ruler.Scale,'linear'), return, end
 
 % Extract finite non-zero tick values
 ticks=ruler.TickValues;

--- a/kernel/plotting/kztickfix.m
+++ b/kernel/plotting/kztickfix.m
@@ -1,0 +1,55 @@
+% Switches Z axis tick labels to engineering notation by setting
+% the numeric-ruler exponent to a multiple of three. Syntax:
+%
+%                         kztickfix()
+%
+% Parameters:
+%
+%    none
+%
+% Outputs:
+%
+%    updates the current axis system
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=kztickfix.m>
+
+function kztickfix()
+
+% Pull out the current Z axis ruler
+ax=gca;
+ruler=ax.ZAxis;
+
+% Check consistency
+grumble(ruler);
+
+% Extract finite non-zero tick values
+ticks=ruler.TickValues;
+ticks=ticks(isfinite(ticks)&(ticks~=0));
+
+% Use finite non-zero limits when tick values are unavailable
+if isempty(ticks)
+    ticks=ruler.Limits;
+    ticks=ticks(isfinite(ticks)&(ticks~=0));
+end
+
+% Use unscaled labels for zero axes
+if isempty(ticks)
+    ruler.Exponent=0;
+else
+    ruler.Exponent=3*floor(log10(max(abs(ticks)))/3);
+end
+
+end
+
+% Consistency enforcement
+function grumble(ruler)
+if ~isa(ruler,'matlab.graphics.axis.decorator.NumericRuler')
+    error('Z axis must be numeric.');
+end
+if ~strcmp(ruler.Scale,'linear')
+    error('Z axis scale must be linear.');
+end
+end
+

--- a/kernel/plotting/kztickfix.m
+++ b/kernel/plotting/kztickfix.m
@@ -1,5 +1,6 @@
 % Switches Z axis tick labels to engineering notation by setting
-% the numeric-ruler exponent to a multiple of three. Syntax:
+% the numeric-ruler exponent to a multiple of three and installs
+% a pan/zoom auto-updater. Syntax:
 %
 %                         kztickfix()
 %
@@ -9,7 +10,7 @@
 %
 % Outputs:
 %
-%    updates the current axis system
+%    updates the current axis system and installs an auto-updater
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -23,6 +24,59 @@ ruler=ax.ZAxis;
 
 % Check consistency
 grumble(ruler);
+
+% Preserve any existing limit-change callback
+app_key='SpinachKZTickFix';
+if isappdata(ax,app_key)
+    state=getappdata(ax,app_key);
+    if isfield(state,'callback')&&isequal(ruler.LimitsChangedFcn,state.callback)
+        old_fcn=state.old_fcn;
+    else
+        old_fcn=ruler.LimitsChangedFcn;
+    end
+else
+    old_fcn=ruler.LimitsChangedFcn;
+end
+
+% Install the automatic exponent updater
+callback=@(source,event)local_callback(source,event,ax,app_key);
+state.callback=callback; state.old_fcn=old_fcn;
+setappdata(ax,app_key,state);
+ruler.LimitsChangedFcn=callback;
+
+% Set the current exponent
+local_update(ruler);
+
+end
+
+% Local update callback
+function local_callback(ruler,event,ax,app_key)
+
+% Ignore deleted graphics objects
+if ~ishandle(ruler)||~ishandle(ax)||~isappdata(ax,app_key), return, end
+
+% Update the engineering exponent
+local_update(ruler);
+
+% Run the pre-existing callback if there was one
+state=getappdata(ax,app_key);
+if ~isempty(state.old_fcn)
+    if isa(state.old_fcn,'function_handle')
+        state.old_fcn(ruler,event);
+    elseif iscell(state.old_fcn)
+        feval(state.old_fcn{1},ruler,event,state.old_fcn{2:end});
+    elseif ischar(state.old_fcn)||isstring(state.old_fcn)
+        evalin('base',char(state.old_fcn));
+    end
+end
+
+end
+
+% Local exponent updater
+function local_update(ruler)
+
+% Ignore non-linear axis state after installation
+if ~strcmp(ruler.Scale,'linear'), return, end
 
 % Extract finite non-zero tick values
 ticks=ruler.TickValues;


### PR DESCRIPTION
## Summary

- add `kxtickfix.m`, `kytickfix.m`, and `kztickfix.m`
- set X/Y/Z `NumericRuler.Exponent` to an engineering multiple of three
- install ruler-level `LimitsChangedFcn` callbacks so pan/zoom limit changes refresh the exponent automatically
- preserve and call any pre-existing ruler limit-change callback, and avoid stacking duplicate wrappers on repeated helper calls
- validate numeric linear axes and leave logarithmic/non-numeric axes rejected

## Validation

- `QT_QPA_PLATFORM=offscreen matlab -nojvm -batch "run('/home/kuprov/.openclaw/workspace/tmp/validate_tickfix_auto_20260607.m')"`
- `matlab -nojvm -batch "checkcode('kernel/plotting/kxtickfix.m','kernel/plotting/kytickfix.m','kernel/plotting/kztickfix.m'); fprintf('TALOS_TICKFIX_CHECKCODE_DONE\n');"`
- `git diff --check -- kernel/plotting/kxtickfix.m kernel/plotting/kytickfix.m kernel/plotting/kztickfix.m`
- byte-level source check for two final newlines and no trailing whitespace in all three helper files
