### PR TITLE
Add ValueStore snapshot utilities

### DIFF
--- a/kernel/utilities/load_vstore.m
+++ b/kernel/utilities/load_vstore.m
@@ -1,0 +1,63 @@
+% Loads the current parallel pool ValueStore from a Matlab file.
+% The current store is cleared before the saved keys and values
+% are inserted. Callback functions are session-local and are not
+% loaded. Syntax:
+%
+%                  load_vstore(file_name)
+%
+% Parameters:
+%
+%    file_name - a character string specifying the source MAT file
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=load_vstore.m>
+
+function load_vstore(file_name)
+
+% Check consistency
+grumble(file_name);
+
+% Load the snapshot
+snapshot=load(file_name,'key_set','val_set');
+
+% Check snapshot format
+if (~isfield(snapshot,'key_set'))||(~isfield(snapshot,'val_set'))||...
+   (~isstring(snapshot.key_set))||(~iscell(snapshot.val_set))||...
+   (~isequal(size(snapshot.key_set),size(snapshot.val_set)))
+    error('the file must contain a ValueStore snapshot from save_vstore.');
+end
+
+% Get the current parallel pool
+current_pool=gcp('nocreate');
+if isempty(current_pool)
+    error('no current parallel pool found.');
+end
+
+% Get the current ValueStore
+store=current_pool.ValueStore;
+
+% Remove current keys
+old_keys=keys(store);
+if ~isempty(old_keys)
+    remove(store,old_keys);
+end
+
+% Insert saved keys and values
+if ~isempty(snapshot.key_set)
+    put(store,snapshot.key_set,snapshot.val_set);
+end
+
+end
+
+% Consistency enforcement
+function grumble(file_name)
+if (~ischar(file_name))||(~isrow(file_name))||isempty(file_name)
+    error('file_name must be a non-empty character string.');
+end
+if ~isfile(file_name)
+    error('file_name does not point to an existing file.');
+end
+end
+
+

--- a/kernel/utilities/save_vstore.m
+++ b/kernel/utilities/save_vstore.m
@@ -1,0 +1,50 @@
+% Saves the current parallel pool ValueStore into a Matlab file.
+% The snapshot contains keys and values only; callback functions
+% are session-local and are not stored. Syntax:
+%
+%                  save_vstore(file_name)
+%
+% Parameters:
+%
+%    file_name - a character string specifying the destination
+%                MAT file
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=save_vstore.m>
+
+function save_vstore(file_name)
+
+% Check consistency
+grumble(file_name);
+
+% Get the current parallel pool
+current_pool=gcp('nocreate');
+if isempty(current_pool)
+    error('no current parallel pool found.');
+end
+
+% Get the current ValueStore
+store=current_pool.ValueStore;
+
+% Get all keys and values
+key_set=keys(store);
+if isempty(key_set)
+    val_set=cell(size(key_set));
+else
+    val_set=get(store,key_set);
+end
+
+% Save the snapshot
+save(file_name,'key_set','val_set','-v7.3'); drawnow;
+
+end
+
+% Consistency enforcement
+function grumble(file_name)
+if (~ischar(file_name))||(~isrow(file_name))||isempty(file_name)
+    error('file_name must be a non-empty character string.');
+end
+end
+
+


### PR DESCRIPTION
This PR adds two Spinach utility functions for snapshotting the current parallel pool `ValueStore` through the MATLAB API:

- `save_vstore.m` stores the current pool store keys and values in a MAT file.
- `load_vstore.m` clears the current pool store and restores keys and values from such a snapshot.

Callbacks are deliberately not stored because they are session-local. I used the MATLAB API route rather than archiving the underlying on-disk store directory because the directory location and format are not a documented cross-platform interface.

Validation:

- Direct MATLAB round trip on a `Threads` parallel pool using the production `save_vstore.m` and `load_vstore.m`; marker `TALOS_VSTORE_PR_VALIDATION_OK`.
- `git diff --cached --check` reported only the expected Spinach new-file two-blank-lines-at-EOF warnings.
