### PR TITLE
Reduce grid_kron quaternion tiling width

### DIFF
--- a/kernel/grids/grid_kron.m
+++ b/kernel/grids/grid_kron.m
@@ -37,7 +37,7 @@ quats1=angle2quat(angles1(:,1),angles1(:,2),angles1(:,3),'ZYZ');
 quats2=angle2quat(angles2(:,1),angles2(:,2),angles2(:,3),'ZYZ');
 
 % Build a table of quaternion products
-quats=[kron(quats1,ones(size(quats2,1),1)) kron(ones(size(quats1,1)),quats2)];
+quats=[kron(quats1,ones(size(quats2,1),1)) kron(ones(size(quats1,1),1),quats2)];
 
 % Multiply up quaternions
 quats=[quats(:,1).*quats(:,5)-quats(:,2).*quats(:,6)-quats(:,3).*quats(:,7)-quats(:,4).*quats(:,8),...


### PR DESCRIPTION
## Summary

This reduces the width of the second quaternion tiling block in `grid_kron.m`.

The previous expression used `ones(size(quats1,1))`, making an `n1`-by-`n1` block. Only the first four columns were used by the subsequent quaternion multiplication. The patched expression uses `ones(size(quats1,1),1)`, preserving the same row tiling while avoiding the unused columns.

## Validation

- `python3 tools/run_matlab_batch_probe.py --script /home/kuprov/.openclaw/workspace/tmp/self_improvement/2026-06-10-grid-kron/validate_grid_kron.m --log /home/kuprov/.openclaw/workspace/tmp/self_improvement/2026-06-10-grid-kron/validate_grid_kron.log --success-marker GRID_KRON_TILING_FIX_OK`
- `git diff --check -- kernel/grids/grid_kron.m`

The MATLAB validation compares the patched function against the legacy quaternion-table formula and confirms identical angles and weights for the tested grids. It also records the synthetic 64-by-32 tiling case shrinking from `2048 x 256` to `2048 x 4` in the second block.
