### PR TITLE
Add NMRPipe export and Bruker HSQC sequences

### DIFF
--- a/experiments/bruker/hmqcetgp.m
+++ b/experiments/bruker/hmqcetgp.m
@@ -1,0 +1,198 @@
+% Echo/antiecho gradient-selected HMQC pulse sequence, based on the
+% Bruker hmqcetgp pulse program and the standard HMQC sequence from:
+%
+%           https://doi.org/10.1016/0022-2364(83)90241-X
+%
+% The gradient selection is represented analytically by coherence order
+% selection statements
+%
+% Syntax:
+%
+%              fid=hmqcetgp(spin_system,parameters,H,R,K)
+%
+% Parameters:
+%
+%     parameters.sweep              [F1 F2] sweep widths, Hz
+%
+%     parameters.npoints            [F1 F2] numbers of points
+%
+%     parameters.spins              {F1 F2} nuclei (e.g. '13C','1H')
+%
+%     parameters.decouple_f2        nuclei to decouple in F2, e.g.
+%                                   {'15N','13C'}
+%
+%     parameters.decouple_f1        nuclei that receive midpoint
+%                                   180-degree refocusing pulses in
+%                                   F1, e.g. {'1H'}
+%
+%     parameters.J                  working scalar coupling, Hz
+%
+%     H  - Hamiltonian matrix, received from context function
+%
+%     R  - relaxation superoperator, received from context function
+%
+%     K  - kinetics superoperator, received from context function
+%
+% Outputs:
+%
+%     fid.pos,fid.neg -  echo and antiecho components of the
+%                        signal.
+%
+% Note: natural abundance simulations should make use of the isotope
+%       dilution functionality. See dilute.m function.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=hmqcetgp.m>
+
+function fid=hmqcetgp(spin_system,parameters,H,R,K)
+
+% Consistency check
+grumble(spin_system,parameters,H,R,K);
+
+% Compose Liouvillian
+L=H+1i*R+1i*K;
+
+% Coherent evolution timesteps
+timestep=1./parameters.sweep;
+
+% J-coupling evolution time
+delta=abs(1/(2*parameters.J));
+
+% Initial condition
+rho=state(spin_system,'Lz',parameters.spins{2},'cheap');
+
+% Detection state
+coil=state(spin_system,'L+',parameters.spins{2},'cheap');
+
+% Pulse operators
+Cx=operator(spin_system,'Lx',parameters.spins{1});
+Hx=operator(spin_system,'Lx',parameters.spins{2});
+
+% Initial proton pulse
+rho=step(spin_system,Hx,rho,pi/2);
+
+% HMQC transfer evolution
+rho=evolution(spin_system,L,[],rho,delta,1,'final');
+
+% Ideal carbon inversion pulse
+rho=step(spin_system,Cx,rho,pi);
+
+% Carbon excitation pulse
+rho=step(spin_system,Cx,rho,pi/2);
+
+% First half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho,timestep(1)/2,...
+                    parameters.npoints(1)-1,'trajectory');
+
+% F1 dimension refocusing pulses
+for n=1:numel(parameters.decouple_f1)
+    Lp=operator(spin_system,'L+',parameters.decouple_f1{n});
+    rho_stack=step(spin_system,(Lp+Lp')/2,rho_stack,pi);
+end
+
+% Second half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho_stack,timestep(1)/2,...
+                    parameters.npoints(1)-1,'refocus');
+
+% First analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack,{{parameters.spins{1},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack,{{parameters.spins{1},-1}});
+
+% Carbon inversion pulse after the first gradient
+rho_stack_pos=step(spin_system,Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Cx,rho_stack_neg,pi);
+
+% Carbon back-transfer pulse
+rho_stack_pos=step(spin_system,Cx,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Cx,rho_stack_neg,pi/2);
+
+% Second analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack_pos,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack_neg,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+
+% HMQC back-transfer evolution
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta,1,'final');
+
+% Decoupling in F2
+[L,rho_stack_pos]=decouple(spin_system,L,rho_stack_pos,parameters.decouple_f2);
+[L,rho_stack_neg]=decouple(spin_system,L,rho_stack_neg,parameters.decouple_f2);
+
+% Detection
+fid.pos=evolution(spin_system,L,coil,rho_stack_pos,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+fid.neg=evolution(spin_system,L,coil,rho_stack_neg,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+
+end
+
+% Consistency enforcement
+function grumble(spin_system,parameters,H,R,K)
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
+    error('this function is only available for sphten-liouv formalism.');
+end
+if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
+   (~ismatrix(H))||(~ismatrix(R))||(~ismatrix(K))
+    error('H, R and K arguments must be matrices.');
+end
+if (~all(size(H)==size(R)))||(~all(size(R)==size(K)))
+    error('H, R and K matrices must have the same dimension.');
+end
+if ~isfield(parameters,'sweep')
+    error('sweep width should be specified in parameters.sweep variable.');
+elseif numel(parameters.sweep)~=2
+    error('parameters.sweep array should have exactly two elements.');
+elseif (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
+       any(~isfinite(parameters.sweep))||any(parameters.sweep<=0)
+    error('parameters.sweep must contain two positive real numbers.');
+end
+if ~isfield(parameters,'spins')
+    error('working spins should be specified in parameters.spins variable.');
+elseif numel(parameters.spins)~=2
+    error('parameters.spins cell array should have exactly two elements.');
+elseif (~iscell(parameters.spins))||(~ischar(parameters.spins{1}))||...
+       (~ischar(parameters.spins{2}))
+    error('parameters.spins must be a two-element cell array of character strings.');
+elseif strcmp(parameters.spins{1},parameters.spins{2})
+    error('parameters.spins must specify two different isotopes.');
+elseif any(~ismember(parameters.spins,spin_system.comp.isotopes))
+    error('parameters.spins contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f2')
+    error('decoupling channel list should be specified in parameters.decouple_f2 variable.');
+elseif ~iscell(parameters.decouple_f2)
+    error('parameters.decouple_f2 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f2,spin_system.comp.isotopes))
+    error('parameters.decouple_f2 contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f1')
+    error('decoupling channel list should be specified in parameters.decouple_f1 variable.');
+elseif ~iscell(parameters.decouple_f1)
+    error('parameters.decouple_f1 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f1,spin_system.comp.isotopes))
+    error('parameters.decouple_f1 contains isotopes that are not present in the system.');
+elseif ismember(parameters.spins{1},parameters.decouple_f1)
+    error('parameters.decouple_f1 must not contain the active indirect isotope.');
+end
+if ~isfield(parameters,'npoints')
+    error('number of points should be specified in parameters.npoints variable.');
+elseif numel(parameters.npoints)~=2
+    error('parameters.npoints array should have exactly two elements.');
+elseif (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+       any(parameters.npoints<1)||any(mod(parameters.npoints,1)~=0)
+    error('parameters.npoints must contain two positive integers.');
+end
+if ~isfield(parameters,'J')
+    error('scalar coupling should be specified in parameters.J variable.');
+elseif numel(parameters.J)~=1
+    error('parameters.J array should have exactly one element.');
+elseif (~isnumeric(parameters.J))||(~isreal(parameters.J))||...
+       (~isfinite(parameters.J))||(parameters.J==0)
+    error('parameters.J must be a non-zero real scalar.');
+end
+end
+
+

--- a/experiments/bruker/hmqcetgpsi.m
+++ b/experiments/bruker/hmqcetgpsi.m
@@ -1,0 +1,230 @@
+% Sensitivity-improved echo/antiecho gradient-selected HMQC pulse
+% sequence, based on the Bruker hmqcetgpsi pulse program and the
+% standard HMQC sequence from:
+%
+%           https://doi.org/10.1016/0022-2364(83)90241-X
+%           https://doi.org/10.1016/0022-2364(91)90036-S
+%
+% The gradient selection is represented analytically by coherence order
+% selection statements
+%
+% Syntax:
+%
+%              fid=hmqcetgpsi(spin_system,parameters,H,R,K)
+%
+% Parameters:
+%
+%     parameters.sweep              [F1 F2] sweep widths, Hz
+%
+%     parameters.npoints            [F1 F2] numbers of points
+%
+%     parameters.spins              {F1 F2} nuclei (e.g. '13C','1H')
+%
+%     parameters.decouple_f2        nuclei to decouple in F2, e.g.
+%                                   {'15N','13C'}
+%
+%     parameters.decouple_f1        nuclei that receive midpoint
+%                                   180-degree refocusing pulses in
+%                                   F1, e.g. {'1H'}
+%
+%     parameters.J                  working scalar coupling, Hz
+%
+%     H  - Hamiltonian matrix, received from context function
+%
+%     R  - relaxation superoperator, received from context function
+%
+%     K  - kinetics superoperator, received from context function
+%
+% Outputs:
+%
+%     fid.pos,fid.neg -  echo and antiecho components of the
+%                        signal.
+%
+% Note: natural abundance simulations should make use of the isotope
+%       dilution functionality. See dilute.m function.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=hmqcetgpsi.m>
+
+function fid=hmqcetgpsi(spin_system,parameters,H,R,K)
+
+% Consistency check
+grumble(spin_system,parameters,H,R,K);
+
+% Compose Liouvillian
+L=H+1i*R+1i*K;
+
+% Coherent evolution timesteps
+timestep=1./parameters.sweep;
+
+% J-coupling evolution time
+delta=abs(1/(2*parameters.J));
+
+% Initial condition
+rho=state(spin_system,'Lz',parameters.spins{2},'cheap');
+
+% Detection state
+coil=state(spin_system,'L+',parameters.spins{2},'cheap');
+
+% Pulse operators
+Cx=operator(spin_system,'Lx',parameters.spins{1});
+Cy=operator(spin_system,'Ly',parameters.spins{1});
+Hx=operator(spin_system,'Lx',parameters.spins{2});
+Hy=operator(spin_system,'Ly',parameters.spins{2});
+
+% Initial proton pulse
+rho=step(spin_system,Hx,rho,pi/2);
+
+% HMQC transfer evolution
+rho=evolution(spin_system,L,[],rho,delta,1,'final');
+
+% Ideal carbon inversion pulse
+rho=step(spin_system,Cx,rho,pi);
+
+% Carbon excitation pulse
+rho=step(spin_system,Cx,rho,pi/2);
+
+% First half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho,timestep(1)/2,...
+                    parameters.npoints(1)-1,'trajectory');
+
+% F1 dimension refocusing pulses
+for n=1:numel(parameters.decouple_f1)
+    Lp=operator(spin_system,'L+',parameters.decouple_f1{n});
+    rho_stack=step(spin_system,(Lp+Lp')/2,rho_stack,pi);
+end
+
+% Second half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho_stack,timestep(1)/2,...
+                    parameters.npoints(1)-1,'refocus');
+
+% First analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack,{{parameters.spins{1},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack,{{parameters.spins{1},-1}});
+
+% Carbon inversion pulse after the first gradient
+rho_stack_pos=step(spin_system,Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Cx,rho_stack_neg,pi);
+
+% Carbon back-transfer pulse
+rho_stack_pos=step(spin_system,Cx,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Cx,rho_stack_neg,pi/2);
+
+% First sensitivity improvement evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta,1,'final');
+
+% First sensitivity improvement pulse pair
+rho_stack_pos=step(spin_system,Hx,rho_stack_pos,pi/2);
+rho_stack_pos=step(spin_system,Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx,rho_stack_neg,pi/2);
+rho_stack_neg=step(spin_system,Cx,rho_stack_neg,pi);
+
+% Second sensitivity improvement evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta,1,'final');
+
+% Second sensitivity improvement pulse pair
+rho_stack_pos=step(spin_system,Hx,rho_stack_pos,pi);
+rho_stack_pos=step(spin_system,Cy,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Hx,rho_stack_neg,pi);
+rho_stack_neg=step(spin_system,Cy,rho_stack_neg,pi/2);
+
+% Third sensitivity improvement evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta,1,'final');
+
+% Final sensitivity improvement proton pulse
+rho_stack_pos=step(spin_system,Hy,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Hy,rho_stack_neg,pi/2);
+
+% Proton echo pulse before acquisition
+rho_stack_pos=step(spin_system,Hx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx,rho_stack_neg,pi);
+
+% Second analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack_pos,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack_neg,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+
+% Decoupling in F2
+[L,rho_stack_pos]=decouple(spin_system,L,rho_stack_pos,parameters.decouple_f2);
+[L,rho_stack_neg]=decouple(spin_system,L,rho_stack_neg,parameters.decouple_f2);
+
+% Detection
+fid.pos=evolution(spin_system,L,coil,rho_stack_pos,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+fid.neg=evolution(spin_system,L,coil,rho_stack_neg,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+
+end
+
+% Consistency enforcement
+function grumble(spin_system,parameters,H,R,K)
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
+    error('this function is only available for sphten-liouv formalism.');
+end
+if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
+   (~ismatrix(H))||(~ismatrix(R))||(~ismatrix(K))
+    error('H, R and K arguments must be matrices.');
+end
+if (~all(size(H)==size(R)))||(~all(size(R)==size(K)))
+    error('H, R and K matrices must have the same dimension.');
+end
+if ~isfield(parameters,'sweep')
+    error('sweep width should be specified in parameters.sweep variable.');
+elseif numel(parameters.sweep)~=2
+    error('parameters.sweep array should have exactly two elements.');
+elseif (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
+       any(~isfinite(parameters.sweep))||any(parameters.sweep<=0)
+    error('parameters.sweep must contain two positive real numbers.');
+end
+if ~isfield(parameters,'spins')
+    error('working spins should be specified in parameters.spins variable.');
+elseif numel(parameters.spins)~=2
+    error('parameters.spins cell array should have exactly two elements.');
+elseif (~iscell(parameters.spins))||(~ischar(parameters.spins{1}))||...
+       (~ischar(parameters.spins{2}))
+    error('parameters.spins must be a two-element cell array of character strings.');
+elseif strcmp(parameters.spins{1},parameters.spins{2})
+    error('parameters.spins must specify two different isotopes.');
+elseif any(~ismember(parameters.spins,spin_system.comp.isotopes))
+    error('parameters.spins contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f2')
+    error('decoupling channel list should be specified in parameters.decouple_f2 variable.');
+elseif ~iscell(parameters.decouple_f2)
+    error('parameters.decouple_f2 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f2,spin_system.comp.isotopes))
+    error('parameters.decouple_f2 contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f1')
+    error('decoupling channel list should be specified in parameters.decouple_f1 variable.');
+elseif ~iscell(parameters.decouple_f1)
+    error('parameters.decouple_f1 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f1,spin_system.comp.isotopes))
+    error('parameters.decouple_f1 contains isotopes that are not present in the system.');
+elseif ismember(parameters.spins{1},parameters.decouple_f1)
+    error('parameters.decouple_f1 must not contain the active indirect isotope.');
+end
+if ~isfield(parameters,'npoints')
+    error('number of points should be specified in parameters.npoints variable.');
+elseif numel(parameters.npoints)~=2
+    error('parameters.npoints array should have exactly two elements.');
+elseif (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+       any(parameters.npoints<1)||any(mod(parameters.npoints,1)~=0)
+    error('parameters.npoints must contain two positive integers.');
+end
+if ~isfield(parameters,'J')
+    error('scalar coupling should be specified in parameters.J variable.');
+elseif numel(parameters.J)~=1
+    error('parameters.J array should have exactly one element.');
+elseif (~isnumeric(parameters.J))||(~isreal(parameters.J))||...
+       (~isfinite(parameters.J))||(parameters.J==0)
+    error('parameters.J must be a non-zero real scalar.');
+end
+end
+
+

--- a/experiments/bruker/hsqcedetgp.m
+++ b/experiments/bruker/hsqcedetgp.m
@@ -1,0 +1,251 @@
+% Echo/antiecho gradient-selected multiplicity-edited HSQC pulse
+% sequence, based on the Bruker hsqcedetgp pulse program and the
+% standard HSQC sequence from:
+%
+%           https://doi.org/10.1016/0009-2614(80)80041-8
+%           https://doi.org/10.1002/cmr.a.10095
+%           https://doi.org/10.1002/mrc.1260310315
+%
+% The gradient selection is represented analytically by coherence order
+% selection statements
+%
+% Syntax:
+%
+%              fid=hsqcedetgp(spin_system,parameters,H,R,K)
+%
+% Parameters:
+%
+%     parameters.sweep              [F1 F2] sweep widths, Hz
+%
+%     parameters.npoints            [F1 F2] numbers of points
+%
+%     parameters.spins              {F1 F2} nuclei (e.g. '13C','1H')
+%
+%     parameters.decouple_f2        nuclei to decouple in F2, e.g.
+%                                   {'15N','13C'}
+%
+%     parameters.decouple_f1        nuclei that receive midpoint
+%                                   180-degree refocusing pulses in
+%                                   F1, e.g. {'1H','13C'}
+%
+%     parameters.J                  working scalar coupling, Hz
+%
+%     parameters.trim_angle         proton trim pulse angle, rad
+%
+%     parameters.edit_time          multiplicity editing delay, s
+%
+%     H  - Hamiltonian matrix, received from context function
+%
+%     R  - relaxation superoperator, received from context function
+%
+%     K  - kinetics superoperator, received from context function
+%
+% Outputs:
+%
+%     fid.pos,fid.neg -  echo and antiecho components of the
+%                        signal.
+%
+% Note: natural abundance simulations should make use of the isotope
+%       dilution functionality. See dilute.m function.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=hsqcedetgp.m>
+
+function fid=hsqcedetgp(spin_system,parameters,H,R,K)
+
+% Consistency check
+grumble(spin_system,parameters,H,R,K);
+
+% Compose Liouvillian
+L=H+1i*R+1i*K;
+
+% Coherent evolution timesteps
+timestep=1./parameters.sweep;
+
+% J-coupling evolution time
+delta=abs(1/(2*parameters.J));
+
+% Initial condition
+rho=state(spin_system,'Lz',parameters.spins{2},'cheap');
+
+% Detection state
+coil=state(spin_system,'L+',parameters.spins{2},'cheap');
+
+% Pulse operators
+Cx=operator(spin_system,'Lx',parameters.spins{1});
+Hx=operator(spin_system,'Lx',parameters.spins{2});
+Hy=operator(spin_system,'Ly',parameters.spins{2});
+
+% Initial proton pulse
+rho=step(spin_system,Hx,rho,pi/2);
+
+% First INEPT evolution
+rho=evolution(spin_system,L,[],rho,delta/2,1,'final');
+
+% Refocusing pulses
+rho=step(spin_system,Hx+Cx,rho,pi);
+
+% Second INEPT evolution
+rho=evolution(spin_system,L,[],rho,delta/2,1,'final');
+
+% Proton trim pulse
+rho=step(spin_system,Hx,rho,parameters.trim_angle);
+
+% Transfer pulses
+rho=step(spin_system,Hy,rho,pi/2);
+rho=step(spin_system,Cx,rho,pi/2)-step(spin_system,Cx,rho,-pi/2);
+
+% First half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho,timestep(1)/2,...
+                    parameters.npoints(1)-1,'trajectory');
+
+% F1 dimension refocusing pulses
+for n=1:numel(parameters.decouple_f1)
+    Lp=operator(spin_system,'L+',parameters.decouple_f1{n});
+    rho_stack=step(spin_system,(Lp+Lp')/2,rho_stack,pi);
+end
+
+% Second half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho_stack,timestep(1)/2,...
+                    parameters.npoints(1)-1,'refocus');
+
+% First analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack,{{parameters.spins{2},0},...
+                                               {parameters.spins{1},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack,{{parameters.spins{2},0},...
+                                               {parameters.spins{1},-1}});
+
+% First multiplicity editing period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,...
+                        parameters.edit_time,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,...
+                        parameters.edit_time,1,'final');
+
+% Multiplicity editing refocusing pulses
+rho_stack_pos=step(spin_system,Hx+Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx+Cx,rho_stack_neg,pi);
+
+% Second multiplicity editing period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,...
+                        parameters.edit_time,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,...
+                        parameters.edit_time,1,'final');
+
+% Back-transfer pulses
+rho_stack_pos=step(spin_system,Hx+Cx,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Hx+Cx,rho_stack_neg,pi/2);
+
+% First back-transfer evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta/2,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta/2,1,'final');
+
+% Back-transfer refocusing pulses
+rho_stack_pos=step(spin_system,Hx+Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx+Cx,rho_stack_neg,pi);
+
+% Second back-transfer evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta/2,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta/2,1,'final');
+
+% Second analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack_pos,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack_neg,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+
+% Decoupling in F2
+[L,rho_stack_pos]=decouple(spin_system,L,rho_stack_pos,parameters.decouple_f2);
+[L,rho_stack_neg]=decouple(spin_system,L,rho_stack_neg,parameters.decouple_f2);
+
+% Detection
+fid.pos=evolution(spin_system,L,coil,rho_stack_pos,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+fid.neg=evolution(spin_system,L,coil,rho_stack_neg,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+
+end
+
+% Consistency enforcement
+function grumble(spin_system,parameters,H,R,K)
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
+    error('this function is only available for sphten-liouv formalism.');
+end
+if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
+   (~ismatrix(H))||(~ismatrix(R))||(~ismatrix(K))
+    error('H, R and K arguments must be matrices.');
+end
+if (~all(size(H)==size(R)))||(~all(size(R)==size(K)))
+    error('H, R and K matrices must have the same dimension.');
+end
+if ~isfield(parameters,'sweep')
+    error('sweep width should be specified in parameters.sweep variable.');
+elseif numel(parameters.sweep)~=2
+    error('parameters.sweep array should have exactly two elements.');
+elseif (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
+       any(~isfinite(parameters.sweep))||any(parameters.sweep<=0)
+    error('parameters.sweep must contain two positive real numbers.');
+end
+if ~isfield(parameters,'spins')
+    error('working spins should be specified in parameters.spins variable.');
+elseif numel(parameters.spins)~=2
+    error('parameters.spins cell array should have exactly two elements.');
+elseif (~iscell(parameters.spins))||(~ischar(parameters.spins{1}))||...
+       (~ischar(parameters.spins{2}))
+    error('parameters.spins must be a two-element cell array of character strings.');
+elseif strcmp(parameters.spins{1},parameters.spins{2})
+    error('parameters.spins must specify two different isotopes.');
+elseif any(~ismember(parameters.spins,spin_system.comp.isotopes))
+    error('parameters.spins contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f2')
+    error('decoupling channel list should be specified in parameters.decouple_f2 variable.');
+elseif ~iscell(parameters.decouple_f2)
+    error('parameters.decouple_f2 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f2,spin_system.comp.isotopes))
+    error('parameters.decouple_f2 contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f1')
+    error('decoupling channel list should be specified in parameters.decouple_f1 variable.');
+elseif ~iscell(parameters.decouple_f1)
+    error('parameters.decouple_f1 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f1,spin_system.comp.isotopes))
+    error('parameters.decouple_f1 contains isotopes that are not present in the system.');
+elseif ismember(parameters.spins{1},parameters.decouple_f1)
+    error('parameters.decouple_f1 must not contain the active indirect isotope.');
+end
+if ~isfield(parameters,'npoints')
+    error('number of points should be specified in parameters.npoints variable.');
+elseif numel(parameters.npoints)~=2
+    error('parameters.npoints array should have exactly two elements.');
+elseif (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+       any(parameters.npoints<1)||any(mod(parameters.npoints,1)~=0)
+    error('parameters.npoints must contain two positive integers.');
+end
+if ~isfield(parameters,'J')
+    error('scalar coupling should be specified in parameters.J variable.');
+elseif numel(parameters.J)~=1
+    error('parameters.J array should have exactly one element.');
+elseif (~isnumeric(parameters.J))||(~isreal(parameters.J))||...
+       (~isfinite(parameters.J))||(parameters.J==0)
+    error('parameters.J must be a non-zero real scalar.');
+end
+if ~isfield(parameters,'trim_angle')
+    error('trim pulse angle should be specified in parameters.trim_angle variable.');
+elseif numel(parameters.trim_angle)~=1
+    error('parameters.trim_angle array should have exactly one element.');
+elseif (~isnumeric(parameters.trim_angle))||(~isreal(parameters.trim_angle))||...
+       (~isfinite(parameters.trim_angle))
+    error('parameters.trim_angle must be a finite real scalar.');
+end
+if ~isfield(parameters,'edit_time')
+    error('multiplicity editing delay should be specified in parameters.edit_time variable.');
+elseif numel(parameters.edit_time)~=1
+    error('parameters.edit_time array should have exactly one element.');
+elseif (~isnumeric(parameters.edit_time))||(~isreal(parameters.edit_time))||...
+       (~isfinite(parameters.edit_time))||(parameters.edit_time<=0)
+    error('parameters.edit_time must be a positive real scalar.');
+end
+end
+
+

--- a/experiments/bruker/hsqcetgp.m
+++ b/experiments/bruker/hsqcetgp.m
@@ -1,0 +1,227 @@
+% Echo/antiecho gradient-selected HSQC pulse sequence, based on the
+% Bruker hsqcetgp pulse program and the standard HSQC sequence from:
+%
+%           https://doi.org/10.1016/0009-2614(80)80041-8
+%           https://doi.org/10.1002/cmr.a.10095
+%
+% The gradient selection is represented analytically by coherence order
+% selection statements
+%
+% Syntax:
+%
+%              fid=hsqcetgp(spin_system,parameters,H,R,K)
+%
+% Parameters:
+%
+%     parameters.sweep              [F1 F2] sweep widths, Hz
+%
+%     parameters.npoints            [F1 F2] numbers of points
+%
+%     parameters.spins              {F1 F2} nuclei (e.g. '13C','1H')
+%
+%     parameters.decouple_f2        nuclei to decouple in F2, e.g.
+%                                   {'15N','13C'}
+%
+%     parameters.decouple_f1        nuclei that receive midpoint
+%                                   180-degree refocusing pulses in
+%                                   F1, e.g. {'1H','13C'}
+%
+%     parameters.J                  working scalar coupling, Hz
+%
+%     parameters.trim_angle         proton trim pulse angle, rad
+%
+%     H  - Hamiltonian matrix, received from context function
+%
+%     R  - relaxation superoperator, received from context function
+%
+%     K  - kinetics superoperator, received from context function
+%
+% Outputs:
+%
+%     fid.pos,fid.neg -  echo and antiecho components of the
+%                        signal.
+%
+% Note: natural abundance simulations should make use of the isotope
+%       dilution functionality. See dilute.m function.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=hsqcetgp.m>
+
+function fid=hsqcetgp(spin_system,parameters,H,R,K)
+
+% Consistency check
+grumble(spin_system,parameters,H,R,K);
+
+% Compose Liouvillian
+L=H+1i*R+1i*K;
+
+% Coherent evolution timesteps
+timestep=1./parameters.sweep;
+
+% J-coupling evolution time
+delta=abs(1/(2*parameters.J));
+
+% Initial condition
+rho=state(spin_system,'Lz',parameters.spins{2},'cheap');
+
+% Detection state
+coil=state(spin_system,'L+',parameters.spins{2},'cheap');
+
+% Pulse operators
+Cx=operator(spin_system,'Lx',parameters.spins{1});
+Hx=operator(spin_system,'Lx',parameters.spins{2});
+Hy=operator(spin_system,'Ly',parameters.spins{2});
+
+% Initial proton pulse
+rho=step(spin_system,Hx,rho,pi/2);
+
+% First INEPT evolution
+rho=evolution(spin_system,L,[],rho,delta/2,1,'final');
+
+% Refocusing pulses
+rho=step(spin_system,Hx+Cx,rho,pi);
+
+% Second INEPT evolution
+rho=evolution(spin_system,L,[],rho,delta/2,1,'final');
+
+% Proton trim pulse
+rho=step(spin_system,Hx,rho,parameters.trim_angle);
+
+% Transfer pulses
+rho=step(spin_system,Hy,rho,pi/2);
+rho=step(spin_system,Cx,rho,pi/2)-step(spin_system,Cx,rho,-pi/2);
+
+% First half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho,timestep(1)/2,...
+                    parameters.npoints(1)-1,'trajectory');
+
+% F1 dimension refocusing pulses
+for n=1:numel(parameters.decouple_f1)
+    Lp=operator(spin_system,'L+',parameters.decouple_f1{n});
+    rho_stack=step(spin_system,(Lp+Lp')/2,rho_stack,pi);
+end
+
+% Second half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho_stack,timestep(1)/2,...
+                    parameters.npoints(1)-1,'refocus');
+
+% First analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack,{{parameters.spins{2},0},...
+                                               {parameters.spins{1},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack,{{parameters.spins{2},0},...
+                                               {parameters.spins{1},-1}});
+
+% Carbon inversion pulse after the first gradient
+rho_stack_pos=step(spin_system,Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Cx,rho_stack_neg,pi);
+
+% Back-transfer pulses
+rho_stack_pos=step(spin_system,Hx+Cx,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Hx+Cx,rho_stack_neg,pi/2);
+
+% First back-transfer evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta/2,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta/2,1,'final');
+
+% Back-transfer refocusing pulses
+rho_stack_pos=step(spin_system,Hx+Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx+Cx,rho_stack_neg,pi);
+
+% Second back-transfer evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta/2,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta/2,1,'final');
+
+% Second analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack_pos,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack_neg,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+
+% Decoupling in F2
+[L,rho_stack_pos]=decouple(spin_system,L,rho_stack_pos,parameters.decouple_f2);
+[L,rho_stack_neg]=decouple(spin_system,L,rho_stack_neg,parameters.decouple_f2);
+
+% Detection
+fid.pos=evolution(spin_system,L,coil,rho_stack_pos,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+fid.neg=evolution(spin_system,L,coil,rho_stack_neg,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+
+end
+
+% Consistency enforcement
+function grumble(spin_system,parameters,H,R,K)
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
+    error('this function is only available for sphten-liouv formalism.');
+end
+if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
+   (~ismatrix(H))||(~ismatrix(R))||(~ismatrix(K))
+    error('H, R and K arguments must be matrices.');
+end
+if (~all(size(H)==size(R)))||(~all(size(R)==size(K)))
+    error('H, R and K matrices must have the same dimension.');
+end
+if ~isfield(parameters,'sweep')
+    error('sweep width should be specified in parameters.sweep variable.');
+elseif numel(parameters.sweep)~=2
+    error('parameters.sweep array should have exactly two elements.');
+elseif (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
+       any(~isfinite(parameters.sweep))||any(parameters.sweep<=0)
+    error('parameters.sweep must contain two positive real numbers.');
+end
+if ~isfield(parameters,'spins')
+    error('working spins should be specified in parameters.spins variable.');
+elseif numel(parameters.spins)~=2
+    error('parameters.spins cell array should have exactly two elements.');
+elseif (~iscell(parameters.spins))||(~ischar(parameters.spins{1}))||...
+       (~ischar(parameters.spins{2}))
+    error('parameters.spins must be a two-element cell array of character strings.');
+elseif strcmp(parameters.spins{1},parameters.spins{2})
+    error('parameters.spins must specify two different isotopes.');
+elseif any(~ismember(parameters.spins,spin_system.comp.isotopes))
+    error('parameters.spins contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f2')
+    error('decoupling channel list should be specified in parameters.decouple_f2 variable.');
+elseif ~iscell(parameters.decouple_f2)
+    error('parameters.decouple_f2 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f2,spin_system.comp.isotopes))
+    error('parameters.decouple_f2 contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f1')
+    error('decoupling channel list should be specified in parameters.decouple_f1 variable.');
+elseif ~iscell(parameters.decouple_f1)
+    error('parameters.decouple_f1 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f1,spin_system.comp.isotopes))
+    error('parameters.decouple_f1 contains isotopes that are not present in the system.');
+elseif ismember(parameters.spins{1},parameters.decouple_f1)
+    error('parameters.decouple_f1 must not contain the active indirect isotope.');
+end
+if ~isfield(parameters,'npoints')
+    error('number of points should be specified in parameters.npoints variable.');
+elseif numel(parameters.npoints)~=2
+    error('parameters.npoints array should have exactly two elements.');
+elseif (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+       any(parameters.npoints<1)||any(mod(parameters.npoints,1)~=0)
+    error('parameters.npoints must contain two positive integers.');
+end
+if ~isfield(parameters,'J')
+    error('scalar coupling should be specified in parameters.J variable.');
+elseif numel(parameters.J)~=1
+    error('parameters.J array should have exactly one element.');
+elseif (~isnumeric(parameters.J))||(~isreal(parameters.J))||...
+       (~isfinite(parameters.J))||(parameters.J==0)
+    error('parameters.J must be a non-zero real scalar.');
+end
+if ~isfield(parameters,'trim_angle')
+    error('trim pulse angle should be specified in parameters.trim_angle variable.');
+elseif numel(parameters.trim_angle)~=1
+    error('parameters.trim_angle array should have exactly one element.');
+elseif (~isnumeric(parameters.trim_angle))||(~isreal(parameters.trim_angle))||...
+       (~isfinite(parameters.trim_angle))
+    error('parameters.trim_angle must be a finite real scalar.');
+end
+end
+
+

--- a/experiments/bruker/hsqcetgpsi.m
+++ b/experiments/bruker/hsqcetgpsi.m
@@ -1,0 +1,274 @@
+% Sensitivity-improved echo/antiecho gradient-selected HSQC pulse
+% sequence, based on the Bruker hsqcetgpsi pulse program and the
+% standard HSQC sequence from:
+%
+%           https://doi.org/10.1016/0009-2614(80)80041-8
+%           https://doi.org/10.1002/cmr.a.10095
+%           https://doi.org/10.1016/0022-2364(91)90036-S
+%           https://doi.org/10.1021/ja00052a088
+%           https://doi.org/10.1007/BF00175254
+%
+% The gradient selection is represented analytically by coherence order
+% selection statements
+%
+% Syntax:
+%
+%              fid=hsqcetgpsi(spin_system,parameters,H,R,K)
+%
+% Parameters:
+%
+%     parameters.sweep              [F1 F2] sweep widths, Hz
+%
+%     parameters.npoints            [F1 F2] numbers of points
+%
+%     parameters.spins              {F1 F2} nuclei (e.g. '13C','1H')
+%
+%     parameters.decouple_f2        nuclei to decouple in F2, e.g.
+%                                   {'15N','13C'}
+%
+%     parameters.decouple_f1        nuclei that receive midpoint
+%                                   180-degree refocusing pulses in
+%                                   F1, e.g. {'1H','13C'}
+%
+%     parameters.J                  working scalar coupling, Hz
+%
+%     parameters.trim_angle         proton trim pulse angle, rad
+%
+%     parameters.si_time            sensitivity improvement delay, s
+%
+%     H  - Hamiltonian matrix, received from context function
+%
+%     R  - relaxation superoperator, received from context function
+%
+%     K  - kinetics superoperator, received from context function
+%
+% Outputs:
+%
+%     fid.pos,fid.neg -  echo and antiecho components of the
+%                        signal.
+%
+% Note: natural abundance simulations should make use of the isotope
+%       dilution functionality. See dilute.m function.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=hsqcetgpsi.m>
+
+function fid=hsqcetgpsi(spin_system,parameters,H,R,K)
+
+% Consistency check
+grumble(spin_system,parameters,H,R,K);
+
+% Compose Liouvillian
+L=H+1i*R+1i*K;
+
+% Coherent evolution timesteps
+timestep=1./parameters.sweep;
+
+% J-coupling evolution time
+delta=abs(1/(2*parameters.J));
+
+% Initial condition
+rho=state(spin_system,'Lz',parameters.spins{2},'cheap');
+
+% Detection state
+coil=state(spin_system,'L+',parameters.spins{2},'cheap');
+
+% Pulse operators
+Cx=operator(spin_system,'Lx',parameters.spins{1});
+Cy=operator(spin_system,'Ly',parameters.spins{1});
+Hx=operator(spin_system,'Lx',parameters.spins{2});
+Hy=operator(spin_system,'Ly',parameters.spins{2});
+
+% Initial proton pulse
+rho=step(spin_system,Hx,rho,pi/2);
+
+% First INEPT evolution
+rho=evolution(spin_system,L,[],rho,delta/2,1,'final');
+
+% Refocusing pulses
+rho=step(spin_system,Hx+Cx,rho,pi);
+
+% Second INEPT evolution
+rho=evolution(spin_system,L,[],rho,delta/2,1,'final');
+
+% Proton trim pulse
+rho=step(spin_system,Hx,rho,parameters.trim_angle);
+
+% Transfer pulses
+rho=step(spin_system,Hy,rho,pi/2);
+rho=step(spin_system,Cx,rho,pi/2)-step(spin_system,Cx,rho,-pi/2);
+
+% First half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho,timestep(1)/2,...
+                    parameters.npoints(1)-1,'trajectory');
+
+% F1 dimension refocusing pulses
+for n=1:numel(parameters.decouple_f1)
+    Lp=operator(spin_system,'L+',parameters.decouple_f1{n});
+    rho_stack=step(spin_system,(Lp+Lp')/2,rho_stack,pi);
+end
+
+% Second half of F1 evolution
+rho_stack=evolution(spin_system,L,[],rho_stack,timestep(1)/2,...
+                    parameters.npoints(1)-1,'refocus');
+
+% First analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack,{{parameters.spins{2},0},...
+                                               {parameters.spins{1},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack,{{parameters.spins{2},0},...
+                                               {parameters.spins{1},-1}});
+
+% Carbon inversion pulse after the first gradient
+rho_stack_pos=step(spin_system,Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Cx,rho_stack_neg,pi);
+
+% First sensitivity improvement pulse pair
+rho_stack_pos=step(spin_system,Hx,rho_stack_pos,pi/2);
+rho_stack_pos=step(spin_system,Cx,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Hx,rho_stack_neg,pi/2);
+rho_stack_neg=step(spin_system,Cx,rho_stack_neg,pi/2);
+
+% First sensitivity improvement evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,...
+                        parameters.si_time,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,...
+                        parameters.si_time,1,'final');
+
+% Sensitivity improvement refocusing pulses
+rho_stack_pos=step(spin_system,Hx+Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx+Cx,rho_stack_neg,pi);
+
+% Second sensitivity improvement evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,...
+                        parameters.si_time,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,...
+                        parameters.si_time,1,'final');
+
+% Second sensitivity improvement pulse pair
+rho_stack_pos=step(spin_system,Hy,rho_stack_pos,pi/2);
+rho_stack_pos=step(spin_system,Cy,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Hy,rho_stack_neg,pi/2);
+rho_stack_neg=step(spin_system,Cy,rho_stack_neg,pi/2);
+
+% First back-transfer evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta/2,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta/2,1,'final');
+
+% Back-transfer refocusing pulses
+rho_stack_pos=step(spin_system,Hx+Cx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx+Cx,rho_stack_neg,pi);
+
+% Second back-transfer evolution period
+rho_stack_pos=evolution(spin_system,L,[],rho_stack_pos,delta/2,1,'final');
+rho_stack_neg=evolution(spin_system,L,[],rho_stack_neg,delta/2,1,'final');
+
+% Final proton pulse
+rho_stack_pos=step(spin_system,Hx,rho_stack_pos,pi/2);
+rho_stack_neg=step(spin_system,Hx,rho_stack_neg,pi/2);
+
+% Proton echo pulse before acquisition
+rho_stack_pos=step(spin_system,Hx,rho_stack_pos,pi);
+rho_stack_neg=step(spin_system,Hx,rho_stack_neg,pi);
+
+% Second analytical gradient selection
+rho_stack_pos=coherence(spin_system,rho_stack_pos,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+rho_stack_neg=coherence(spin_system,rho_stack_neg,{{parameters.spins{1},0},...
+                                                   {parameters.spins{2},+1}});
+
+% Decoupling in F2
+[L,rho_stack_pos]=decouple(spin_system,L,rho_stack_pos,parameters.decouple_f2);
+[L,rho_stack_neg]=decouple(spin_system,L,rho_stack_neg,parameters.decouple_f2);
+
+% Detection
+fid.pos=evolution(spin_system,L,coil,rho_stack_pos,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+fid.neg=evolution(spin_system,L,coil,rho_stack_neg,...
+                  timestep(2),parameters.npoints(2)-1,'observable');
+
+end
+
+% Consistency enforcement
+function grumble(spin_system,parameters,H,R,K)
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
+    error('this function is only available for sphten-liouv formalism.');
+end
+if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
+   (~ismatrix(H))||(~ismatrix(R))||(~ismatrix(K))
+    error('H, R and K arguments must be matrices.');
+end
+if (~all(size(H)==size(R)))||(~all(size(R)==size(K)))
+    error('H, R and K matrices must have the same dimension.');
+end
+if ~isfield(parameters,'sweep')
+    error('sweep width should be specified in parameters.sweep variable.');
+elseif numel(parameters.sweep)~=2
+    error('parameters.sweep array should have exactly two elements.');
+elseif (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
+       any(~isfinite(parameters.sweep))||any(parameters.sweep<=0)
+    error('parameters.sweep must contain two positive real numbers.');
+end
+if ~isfield(parameters,'spins')
+    error('working spins should be specified in parameters.spins variable.');
+elseif numel(parameters.spins)~=2
+    error('parameters.spins cell array should have exactly two elements.');
+elseif (~iscell(parameters.spins))||(~ischar(parameters.spins{1}))||...
+       (~ischar(parameters.spins{2}))
+    error('parameters.spins must be a two-element cell array of character strings.');
+elseif strcmp(parameters.spins{1},parameters.spins{2})
+    error('parameters.spins must specify two different isotopes.');
+elseif any(~ismember(parameters.spins,spin_system.comp.isotopes))
+    error('parameters.spins contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f2')
+    error('decoupling channel list should be specified in parameters.decouple_f2 variable.');
+elseif ~iscell(parameters.decouple_f2)
+    error('parameters.decouple_f2 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f2,spin_system.comp.isotopes))
+    error('parameters.decouple_f2 contains isotopes that are not present in the system.');
+end
+if ~isfield(parameters,'decouple_f1')
+    error('decoupling channel list should be specified in parameters.decouple_f1 variable.');
+elseif ~iscell(parameters.decouple_f1)
+    error('parameters.decouple_f1 must be a cell array.');
+elseif any(~ismember(parameters.decouple_f1,spin_system.comp.isotopes))
+    error('parameters.decouple_f1 contains isotopes that are not present in the system.');
+elseif ismember(parameters.spins{1},parameters.decouple_f1)
+    error('parameters.decouple_f1 must not contain the active indirect isotope.');
+end
+if ~isfield(parameters,'npoints')
+    error('number of points should be specified in parameters.npoints variable.');
+elseif numel(parameters.npoints)~=2
+    error('parameters.npoints array should have exactly two elements.');
+elseif (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+       any(parameters.npoints<1)||any(mod(parameters.npoints,1)~=0)
+    error('parameters.npoints must contain two positive integers.');
+end
+if ~isfield(parameters,'J')
+    error('scalar coupling should be specified in parameters.J variable.');
+elseif numel(parameters.J)~=1
+    error('parameters.J array should have exactly one element.');
+elseif (~isnumeric(parameters.J))||(~isreal(parameters.J))||...
+       (~isfinite(parameters.J))||(parameters.J==0)
+    error('parameters.J must be a non-zero real scalar.');
+end
+if ~isfield(parameters,'trim_angle')
+    error('trim pulse angle should be specified in parameters.trim_angle variable.');
+elseif numel(parameters.trim_angle)~=1
+    error('parameters.trim_angle array should have exactly one element.');
+elseif (~isnumeric(parameters.trim_angle))||(~isreal(parameters.trim_angle))||...
+       (~isfinite(parameters.trim_angle))
+    error('parameters.trim_angle must be a finite real scalar.');
+end
+if ~isfield(parameters,'si_time')
+    error('sensitivity improvement delay should be specified in parameters.si_time variable.');
+elseif numel(parameters.si_time)~=1
+    error('parameters.si_time array should have exactly one element.');
+elseif (~isnumeric(parameters.si_time))||(~isreal(parameters.si_time))||...
+       (~isfinite(parameters.si_time))||(parameters.si_time<=0)
+    error('parameters.si_time must be a positive real scalar.');
+end
+end
+
+

--- a/interfaces/nmrpipe/fid2pipe.m
+++ b/interfaces/nmrpipe/fid2pipe.m
@@ -1,0 +1,185 @@
+% Exports phase-sensitive 2D Spinach free induction decays into native
+% NMRPipe time-domain files. Syntax:
+%
+%          fid2pipe(spin_system,file_root,fid,parameters,nmrpipe_root)
+%
+% Parameters:
+%
+%    spin_system  - Spinach spin system structure
+%
+%    file_root    - output file name root; the function writes
+%                   <file_root>_pos.fid and <file_root>_neg.fid
+%
+%    fid          - structure with fid.pos and fid.neg complex matrices;
+%                   rows are direct-dimension points, and columns are
+%                   indirect-dimension points
+%
+%    parameters   - pulse sequence parameters structure with fields
+%                   sweep, npoints, offset, and spins
+%
+%    nmrpipe_root - NMRPipe installation root containing com/txt2pipe.tcl
+%                   and nmrbin.linux212_64
+%
+% Outputs:
+%
+%    this function writes two NMRPipe files
+%
+% Note: the exported files preserve the two Spinach echo/anti-echo
+%       components; recombination is done in the accompanying NMRPipe
+%       processing script after the direct-dimension Fourier transform
+%
+% ilya.kuprov@weizmann.ac.il
+
+function fid2pipe(spin_system,file_root,fid,parameters,nmrpipe_root)
+
+% Check consistency
+grumble(spin_system,file_root,fid,parameters,nmrpipe_root);
+
+% Locate the NMRPipe program directories
+nmrbin=fullfile(nmrpipe_root,'nmrbin.linux212_64');
+nmrcom=fullfile(nmrpipe_root,'com');
+nmrtcl=fullfile(nmrpipe_root,'nmrtcl');
+
+% Set the NMRPipe runtime environment
+setenv('PATH',[nmrbin pathsep nmrcom pathsep getenv('PATH')]);
+setenv('LD_LIBRARY_PATH',[fullfile(nmrbin,'lib') pathsep getenv('LD_LIBRARY_PATH')]);
+setenv('TCLPATH',nmrcom);
+setenv('TCL_LIBRARY',fullfile(nmrtcl,'tcl8.4'));
+setenv('TK_LIBRARY',fullfile(nmrtcl,'tk8.4'));
+setenv('BLT_LIBRARY',fullfile(nmrtcl,'blt2.4'));
+setenv('NMRBASE',nmrpipe_root);
+setenv('NMRBIN',nmrbin);
+setenv('NMRTXT',fullfile(nmrpipe_root,'nmrtxt'));
+
+% Set the OpenWindows path if it is present
+if isfolder(fullfile(nmrbin,'openwin'))
+    setenv('OPENWINHOME',fullfile(nmrbin,'openwin'));
+end
+
+% Convert spectrometer frequencies into MHz
+obs_f2=abs(spin(parameters.spins{2})*spin_system.inter.magnet/(2*pi))*1e-6;
+obs_f1=abs(spin(parameters.spins{1})*spin_system.inter.magnet/(2*pi))*1e-6;
+
+% Convert carrier offsets into ppm
+car_f2=parameters.offset(2)/obs_f2;
+car_f1=parameters.offset(1)/obs_f1;
+
+% Get acquisition dimensions
+npts_f2=size(fid.pos,1);
+npts_f1=size(fid.pos,2);
+
+% Export echo and anti-echo components separately
+branches={'pos','neg'};
+for n=1:numel(branches)
+
+    % Select the current component
+    data=fid.(branches{n});
+
+    % Write the text input for txt2pipe
+    txt_file=[file_root '_' branches{n} '.txt'];
+    file_id=fopen(txt_file,'w');
+    if file_id<0
+        error('could not open the temporary text file.');
+    end
+    for k=1:npts_f1
+        for m=1:npts_f2
+            fprintf(file_id,'%d %d %24.16E %24.16E\n',m,k,real(data(m,k)),imag(data(m,k)));
+        end
+    end
+    fclose(file_id);
+
+    % Convert the text file into NMRPipe format
+    pipe_file=[file_root '_' branches{n} '.fid'];
+    command=[fullfile(nmrcom,'txt2pipe.tcl') ' -in ' txt_file ...
+             ' -xy -complex -time -xN ' num2str(2*npts_f2) ...
+             ' -xT ' num2str(npts_f2) ' -xMODE Complex' ...
+             ' -xSW ' num2str(parameters.sweep(2),16) ...
+             ' -xOBS ' num2str(obs_f2,16) ...
+             ' -xCAR ' num2str(car_f2,16) ...
+             ' -xLAB ' parameters.spins{2} ...
+             ' -yN ' num2str(npts_f1) ...
+             ' -yT ' num2str(npts_f1) ' -yMODE Real' ...
+             ' -ySW ' num2str(parameters.sweep(1),16) ...
+             ' -yOBS ' num2str(obs_f1,16) ...
+             ' -yCAR ' num2str(car_f1,16) ...
+             ' -yLAB ' parameters.spins{1} ...
+             ' -ndim 2 -aq2D Real > ' pipe_file];
+    [status,cmdout]=system(command);
+
+    % Remove the temporary text file
+    delete(txt_file);
+
+    % Report NMRPipe conversion failures
+    if status~=0
+        error(['NMRPipe conversion failed: ' cmdout]);
+    end
+
+end
+
+end
+
+% Consistency enforcement
+function grumble(spin_system,file_root,fid,parameters,nmrpipe_root)
+if ~isstruct(spin_system)
+    error('spin_system must be a Spinach spin system structure.');
+end
+if (~isfield(spin_system,'inter'))||(~isfield(spin_system.inter,'magnet'))||...
+   (~isnumeric(spin_system.inter.magnet))||(~isreal(spin_system.inter.magnet))||...
+   (numel(spin_system.inter.magnet)~=1)||(~isfinite(spin_system.inter.magnet))||...
+   (spin_system.inter.magnet==0)
+    error('spin_system.inter.magnet must be a non-zero real scalar.');
+end
+if (~isfield(spin_system,'comp'))||(~isfield(spin_system.comp,'isotopes'))||...
+   (~iscell(spin_system.comp.isotopes))
+    error('spin_system.comp.isotopes must be a cell array.');
+end
+if (~ischar(file_root))||isempty(file_root)||any(isspace(file_root))
+    error('file_root must be a non-empty character string without whitespace.');
+end
+[out_dir,~,~]=fileparts(file_root);
+if (~isempty(out_dir))&&(~isfolder(out_dir))
+    error('file_root directory must exist.');
+end
+if (~isstruct(fid))||(~isfield(fid,'pos'))||(~isfield(fid,'neg'))||...
+   (~isnumeric(fid.pos))||(~isnumeric(fid.neg))||(~ismatrix(fid.pos))||...
+   (~ismatrix(fid.neg))||(~all(size(fid.pos)==size(fid.neg)))||...
+   any(~isfinite(fid.pos(:)))||any(~isfinite(fid.neg(:)))
+    error('fid must contain finite numeric fid.pos and fid.neg matrices of the same size.');
+end
+if (~isstruct(parameters))||(~isfield(parameters,'sweep'))||...
+   (~isfield(parameters,'npoints'))||(~isfield(parameters,'offset'))||...
+   (~isfield(parameters,'spins'))
+    error('parameters must contain sweep, npoints, offset, and spins fields.');
+end
+if (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
+   (numel(parameters.sweep)~=2)||any(~isfinite(parameters.sweep))||...
+   any(parameters.sweep<=0)
+    error('parameters.sweep must contain two positive real numbers.');
+end
+if (~isnumeric(parameters.npoints))||(~isreal(parameters.npoints))||...
+   (numel(parameters.npoints)~=2)||any(~isfinite(parameters.npoints))||...
+   any(parameters.npoints<1)||any(mod(parameters.npoints,1)~=0)
+    error('parameters.npoints must contain two positive integers.');
+end
+if (parameters.npoints(1)~=size(fid.pos,2))||...
+   (parameters.npoints(2)~=size(fid.pos,1))
+    error('parameters.npoints must match the fid.pos and fid.neg dimensions.');
+end
+if (~isnumeric(parameters.offset))||(~isreal(parameters.offset))||...
+   (numel(parameters.offset)~=2)||any(~isfinite(parameters.offset))
+    error('parameters.offset must contain two finite real numbers.');
+end
+if (~iscell(parameters.spins))||(numel(parameters.spins)~=2)||...
+   (~ischar(parameters.spins{1}))||(~ischar(parameters.spins{2}))||...
+   any(~ismember(parameters.spins,spin_system.comp.isotopes))
+    error('parameters.spins must contain two isotope names present in spin_system.');
+end
+if (~ischar(nmrpipe_root))||isempty(nmrpipe_root)||any(isspace(nmrpipe_root))||...
+   (~isfolder(nmrpipe_root))||...
+   (~isfile(fullfile(nmrpipe_root,'com','txt2pipe.tcl')))||...
+   (~isfile(fullfile(nmrpipe_root,'nmrbin.linux212_64','nmrPipe')))
+    error('nmrpipe_root must be a valid NMRPipe installation root.');
+end
+end
+
+

--- a/interfaces/nmrpipe/fid2pipe.m
+++ b/interfaces/nmrpipe/fid2pipe.m
@@ -7,8 +7,9 @@
 %
 %    spin_system  - Spinach spin system structure
 %
-%    file_root    - output file name root; the function writes
-%                   <file_root>_pos.fid and <file_root>_neg.fid
+%    file_root    - output file name root without shell metacharacters;
+%                   the function writes <file_root>_pos.fid and
+%                   <file_root>_neg.fid
 %
 %    fid          - structure with fid.pos and fid.neg complex matrices;
 %                   rows are direct-dimension points, and columns are
@@ -56,13 +57,14 @@ if isfolder(fullfile(nmrbin,'openwin'))
     setenv('OPENWINHOME',fullfile(nmrbin,'openwin'));
 end
 
+
 % Convert spectrometer frequencies into MHz
 obs_f2=abs(spin(parameters.spins{2})*spin_system.inter.magnet/(2*pi))*1e-6;
 obs_f1=abs(spin(parameters.spins{1})*spin_system.inter.magnet/(2*pi))*1e-6;
 
-% Convert carrier offsets into ppm
-car_f2=parameters.offset(2)/obs_f2;
-car_f1=parameters.offset(1)/obs_f1;
+% Convert carrier offsets into signed ppm
+car_f2=hz2ppm(parameters.offset(2),spin_system.inter.magnet,parameters.spins{2});
+car_f1=hz2ppm(parameters.offset(1),spin_system.inter.magnet,parameters.spins{1});
 
 % Get acquisition dimensions
 npts_f2=size(fid.pos,1);
@@ -98,12 +100,12 @@ for n=1:numel(branches)
              ' -xCAR ' num2str(car_f2,16) ...
              ' -xLAB ' parameters.spins{2} ...
              ' -yN ' num2str(npts_f1) ...
-             ' -yT ' num2str(npts_f1) ' -yMODE Real' ...
+             ' -yT ' num2str(npts_f1) ' -yMODE Complex' ...
              ' -ySW ' num2str(parameters.sweep(1),16) ...
              ' -yOBS ' num2str(obs_f1,16) ...
              ' -yCAR ' num2str(car_f1,16) ...
              ' -yLAB ' parameters.spins{1} ...
-             ' -ndim 2 -aq2D Real > ' pipe_file];
+             ' -ndim 2 -aq2D States > ' pipe_file];
     [status,cmdout]=system(command);
 
     % Remove the temporary text file
@@ -133,8 +135,9 @@ if (~isfield(spin_system,'comp'))||(~isfield(spin_system.comp,'isotopes'))||...
    (~iscell(spin_system.comp.isotopes))
     error('spin_system.comp.isotopes must be a cell array.');
 end
-if (~ischar(file_root))||isempty(file_root)||any(isspace(file_root))
-    error('file_root must be a non-empty character string without whitespace.');
+if (~ischar(file_root))||isempty(file_root)||any(isspace(file_root))||...
+   any((~isstrprop(file_root,'alphanum'))&(~ismember(file_root,'/_.-')))
+    error('file_root must be a non-empty character string without shell metacharacters.');
 end
 [out_dir,~,~]=fileparts(file_root);
 if (~isempty(out_dir))&&(~isfolder(out_dir))
@@ -175,10 +178,11 @@ if (~iscell(parameters.spins))||(numel(parameters.spins)~=2)||...
     error('parameters.spins must contain two isotope names present in spin_system.');
 end
 if (~ischar(nmrpipe_root))||isempty(nmrpipe_root)||any(isspace(nmrpipe_root))||...
+   any((~isstrprop(nmrpipe_root,'alphanum'))&(~ismember(nmrpipe_root,'/_.-')))||...
    (~isfolder(nmrpipe_root))||...
    (~isfile(fullfile(nmrpipe_root,'com','txt2pipe.tcl')))||...
    (~isfile(fullfile(nmrpipe_root,'nmrbin.linux212_64','nmrPipe')))
-    error('nmrpipe_root must be a valid NMRPipe installation root.');
+    error('nmrpipe_root must be a valid NMRPipe installation root without shell metacharacters.');
 end
 end
 

--- a/interfaces/nmrpipe/proc_hsqc.com
+++ b/interfaces/nmrpipe/proc_hsqc.com
@@ -10,7 +10,9 @@ set file_root=$1
 set out_file=$2
 set work_dir="${file_root}_nmrpipe_work"
 
-mkdir -p "$work_dir"
+rm -rf -- "$work_dir"
+mkdir -- "$work_dir"
+if ($status != 0) exit 1
 
 if ($?NMRBIN) then
     set nmrpipe="$NMRBIN/nmrPipe"
@@ -20,21 +22,26 @@ else
     set addnmr=addNMR
 endif
 
-$nmrpipe -in "${file_root}_pos.fid"                         \
-| $nmrpipe -fn FT                                            \
+$nmrpipe -in "${file_root}_pos.fid" -fn FT                   \
           -out "$work_dir/pos_f2.ft" -ov
+if ($status != 0) exit 1
 
-$nmrpipe -in "${file_root}_neg.fid"                         \
-| $nmrpipe -fn FT                                            \
-| $nmrpipe -fn SIGN -i                                       \
+$nmrpipe -in "${file_root}_neg.fid" -fn FT                   \
+          -out "$work_dir/neg_f2.ft" -ov
+if ($status != 0) exit 1
+
+$nmrpipe -in "$work_dir/neg_f2.ft" -fn SIGN -i               \
           -out "$work_dir/neg_f2_conj.ft" -ov
+if ($status != 0) exit 1
 
 $addnmr -in1 "$work_dir/pos_f2.ft"                           \
         -in2 "$work_dir/neg_f2_conj.ft"                      \
         -out "$work_dir/states_f2.ft" -add
+if ($status != 0) exit 1
 
 $nmrpipe -in "$work_dir/states_f2.ft"                        \
 | $nmrpipe -fn TP                                            \
 | $nmrpipe -fn FT                                            \
 | $nmrpipe -fn TP                                            \
           -out "$out_file" -ov
+if ($status != 0) exit 1

--- a/interfaces/nmrpipe/proc_hsqc.com
+++ b/interfaces/nmrpipe/proc_hsqc.com
@@ -1,0 +1,40 @@
+#!/usr/bin/env tcsh
+
+if ($#argv != 2) then
+    echo "Usage: proc_hsqc.com file_root output.ft2"
+    echo "Reads file_root_pos.fid and file_root_neg.fid."
+    exit 1
+endif
+
+set file_root=$1
+set out_file=$2
+set work_dir="${file_root}_nmrpipe_work"
+
+mkdir -p "$work_dir"
+
+if ($?NMRBIN) then
+    set nmrpipe="$NMRBIN/nmrPipe"
+    set addnmr="$NMRBIN/addNMR"
+else
+    set nmrpipe=nmrPipe
+    set addnmr=addNMR
+endif
+
+$nmrpipe -in "${file_root}_pos.fid"                         \
+| $nmrpipe -fn FT                                            \
+          -out "$work_dir/pos_f2.ft" -ov
+
+$nmrpipe -in "${file_root}_neg.fid"                         \
+| $nmrpipe -fn FT                                            \
+| $nmrpipe -fn SIGN -i                                       \
+          -out "$work_dir/neg_f2_conj.ft" -ov
+
+$addnmr -in1 "$work_dir/pos_f2.ft"                           \
+        -in2 "$work_dir/neg_f2_conj.ft"                      \
+        -out "$work_dir/states_f2.ft" -add
+
+$nmrpipe -in "$work_dir/states_f2.ft"                        \
+| $nmrpipe -fn TP                                            \
+| $nmrpipe -fn FT                                            \
+| $nmrpipe -fn TP                                            \
+          -out "$out_file" -ov


### PR DESCRIPTION
## Summary

- add `fid2pipe.m` for exporting phase-sensitive 2D Spinach FIDs to NMRPipe time-domain files
- add `proc_hsqc.com` for NMRPipe echo/anti-echo HSQC processing
- add Bruker-style HMQC/HSQC pulse sequences under `experiments/bruker`

## Validation

- `tcsh -n interfaces/nmrpipe/proc_hsqc.com`
- MATLAB Code Analyzer and function-resolution check for:
  - `interfaces/nmrpipe/fid2pipe.m`
  - `experiments/bruker/hmqcetgp.m`
  - `experiments/bruker/hmqcetgpsi.m`
  - `experiments/bruker/hsqcedetgp.m`
  - `experiments/bruker/hsqcetgp.m`
  - `experiments/bruker/hsqcetgpsi.m`
- compact Spinach execution check for all five Bruker pulse sequences
- compact `hsqcetgp` export through `fid2pipe.m`, NMRPipe readback of both branches, and NMRPipe processing through `proc_hsqc.com`

Markers:

- `SPINACH_NMRPIPE_PR_STATIC_OK`
- `SPINACH_NMRPIPE_PR_HSQC_OK`

Note: `git diff --cached --check` reports only the expected `new blank line at EOF` messages for new Spinach `.m` files that intentionally end with the required blank lines.
