### PR TITLE
Add NGCE relaxation uncertainty output

### DIFF
--- a/examples/relaxation_theory/from_md/ngce_test.m
+++ b/examples/relaxation_theory/from_md/ngce_test.m
@@ -48,19 +48,22 @@ parfor n=1:size(eulers,1)
 end
 
 % Get the GCE relaxation matrix
-R_gce=ngce(spin_system,H0,H1,dt,tau_c,1e-3);
+[R_gce,dR_gce]=ngce(spin_system,H0,H1,dt,tau_c,1e-3);
 
 % Get the answers to the user
 disp('Relaxation superoperator, numerical'); disp(full(R_gce));
+disp('Relaxation superoperator standard deviation of the mean'); disp(full(dR_gce));
 disp('Relaxation superoperator, analytical'); disp(full(R_red));
 
 % Do diagnostic plotting
 kfigure();
 gce_rates=diag(R_gce);
+dR_rates=diag(dR_gce);
 red_rates=diag(R_red);
-min_rate=min([R_gce; R_red]);
-max_rate=max([R_gce; R_red]);
-plot(gce_rates,red_rates,'ro'); hold on;
+min_rate=min([gce_rates-dR_rates; red_rates]);
+max_rate=max([gce_rates+dR_rates; red_rates]);
+errorbar(gce_rates,red_rates,dR_rates,'horizontal',...
+         'LineStyle','none','Marker','o','Color','r'); hold on;
 plot([min_rate max_rate],[min_rate max_rate],'b-');
 axis tight; box on; kgrid;
 kxlabel('numerical relaxation rates');

--- a/examples/relaxation_theory/from_md/sucrose_eight_spins.m
+++ b/examples/relaxation_theory/from_md/sucrose_eight_spins.m
@@ -84,7 +84,7 @@ end
 
 % Get MD relaxation superoperator
 tau_est=inter.tau_c{1}; tic;
-R_gce=ngce(spin_system,H0,H1,dt,tau_est,0);
+[R_gce,dR_gce]=ngce(spin_system,H0,H1,dt,tau_est,0);
 ngce_run_time=toc;
 
 % Load reference frame coordinates
@@ -103,11 +103,15 @@ R_red=relaxation(spin_system);
 
 % Plotting
 kfigure();
-plot(diag(R_gce),diag(R_red),'ro');
+gce_rates=diag(R_gce);
+dR_rates=diag(dR_gce);
+red_rates=diag(R_red);
+errorbar(gce_rates,red_rates,dR_rates,'horizontal',...
+         'LineStyle','none','Marker','o','Color','r');
 kxlabel('Redfield matrix elements, mol. dyn.');
 kylabel('Redfield matrix elements, rot. diff.');
-edges=[min([diag(R_gce); diag(R_red)]),...
-       max([diag(R_gce); diag(R_red)])];
+edges=[min([gce_rates-dR_rates; red_rates]),...
+       max([gce_rates+dR_rates; red_rates])];
 xlim(edges); ylim(edges); 
 kgrid; box on; axis square;
 disp(['NGCE stage run time, seconds: ' ...

--- a/examples/relaxation_theory/from_md/sucrose_three_spins.m
+++ b/examples/relaxation_theory/from_md/sucrose_three_spins.m
@@ -78,7 +78,7 @@ end
 
 % Get MD relaxation superoperator
 tau_est=inter.tau_c{1}; tic;
-R_gce=ngce(spin_system,H0,H1,dt,tau_est,0);
+[R_gce,dR_gce]=ngce(spin_system,H0,H1,dt,tau_est,0);
 ngce_run_time=toc;
 
 % Load reference frame coordinates
@@ -92,11 +92,15 @@ R_red=relaxation(spin_system);
 
 % Plotting
 kfigure();
-plot(diag(R_gce),diag(R_red),'ro');
+gce_rates=diag(R_gce);
+dR_rates=diag(dR_gce);
+red_rates=diag(R_red);
+errorbar(gce_rates,red_rates,dR_rates,'horizontal',...
+         'LineStyle','none','Marker','o','Color','r');
 kxlabel('Redfield matrix elements, mol. dyn.');
 kylabel('Redfield matrix elements, rot. diff.');
-edges=[min([diag(R_gce); diag(R_red)]),...
-       max([diag(R_gce); diag(R_red)])];
+edges=[min([gce_rates-dR_rates; red_rates]),...
+       max([gce_rates+dR_rates; red_rates])];
 xlim(edges); ylim(edges); 
 kgrid; box on; axis square;
 disp(['NGCE stage run time, seconds: ' ...

--- a/kernel/utilities/ngce.m
+++ b/kernel/utilities/ngce.m
@@ -1,7 +1,7 @@
 % Numerical integral route to the Redfield relaxation superopera-
 % tor. Syntax:
 %
-%            R=ngce(spin_system,H0,H1,dt,tau_est,reg)
+%            [R,dR]=ngce(spin_system,H0,H1,dt,tau_est,reg)
 %
 % Parameters:
 %
@@ -27,6 +27,8 @@
 %
 %  R  - laboratory frame relaxation superoperator
 %
+%  dR - standard deviation of the mean of R, element by element
+%
 % Note: enough trajectory points must be present to converge 
 %       the ensemble averages and Redfield's integral.
 %
@@ -38,7 +40,7 @@
 %
 % <https://spindynamics.org/wiki/index.php?title=ngce.m>
 
-function R=ngce(spin_system,H0,H1,dt,tau_est,reg)
+function [R,dR]=ngce(spin_system,H0,H1,dt,tau_est,reg)
 
 % Check consistency
 grumble(H0,H1,dt,tau_est);
@@ -101,9 +103,14 @@ report(spin_system,['trajectory cut into ' ...
 H1=H1(1:nstripes*n_tau_int_steps);
 H1=reshape(H1,[n_tau_int_steps nstripes]);
 
+% Get unit state projector
+U=unit_state(spin_system); UU=U*U';
+
 % Compute trajectory stripe integrals
 report(spin_system,'computing Redfield''s integral...');
-rows=cell(nstripes,1); cols=cell(nstripes,1); vals=cell(nstripes,1);
+calc_err=nargout>1;
+rows=cell(nstripes,1); cols=cell(nstripes,1);
+vals=cell(nstripes,1); vals_sq=cell(nstripes,1);
 parfor s=1:nstripes % Inefficient, investigate
     
     % Get the stripe started
@@ -117,15 +124,34 @@ parfor s=1:nstripes % Inefficient, investigate
                         spin_system.tols.liouv_zero);
         F=F+(f_curr+f_next)/2; f_curr=f_next;
     end
+
+    % Keep real symmetric trace-preserving part
+    F=real(F+F')/2; F=F-(U'*F*U)*UU;
     
     % Get stripe integral as a sparse array
-    [rows{s},cols{s},vals{s}]=find(F/nstripes);
+    [stripe_rows,stripe_cols,stripe_vals]=find(F);
+    rows{s}=stripe_rows; cols{s}=stripe_cols; vals{s}=stripe_vals;
+
+    % Get stripe integral squared element by element
+    if calc_err
+        vals_sq{s}=stripe_vals.^2;
+    end
     
 end
 
 % Assemble the superoperator and keep real symmetric part
 rows=cell2mat(rows); cols=cell2mat(cols); vals=cell2mat(vals);
-R=sparse(rows,cols,vals,size(H0,1),size(H0,2)); R=real(R+R')/2;
+R_sum=sparse(rows,cols,vals,size(H0,1),size(H0,2));
+R=R_sum/nstripes;
+
+% Assemble standard deviation of the mean
+if calc_err
+    vals_sq=cell2mat(vals_sq);
+    R_sq_sum=sparse(rows,cols,vals_sq,size(H0,1),size(H0,2));
+    dR_var=(R_sq_sum-(R_sum.^2)/nstripes)/(nstripes*(nstripes-1));
+    [rows,cols,vals]=find(dR_var);
+    dR=sparse(rows,cols,sqrt(max(real(vals),0)),size(H0,1),size(H0,2));
+end
 
 % Apply regularisation
 if exist('reg','var')&&(reg~=0)
@@ -133,8 +159,7 @@ if exist('reg','var')&&(reg~=0)
 end
 
 % Make sure the unit state is not damped
-U=unit_state(spin_system);
-R=R-(U'*R*U)*(U*U');
+R=R-(U'*R*U)*UU;
 
 end
 

--- a/tests/kernel/test_dynamic_remaining_parallel_suite.m
+++ b/tests/kernel/test_dynamic_remaining_parallel_suite.m
@@ -40,9 +40,11 @@ end
 spin_system=local_liouvillian_system(1);
 H0=sparse(1,1,1e-3,1,1);
 H1=repmat({sparse(1,1)},2001,1);
-R=ngce(spin_system,H0,H1,1,10,0);
+[R,dR]=ngce(spin_system,H0,H1,1,10,0);
 result=test_close(result,'ngce zero stochastic Hamiltonian',R,sparse(1,1),1e-14,1e-14,...
                   'a zero stochastic Hamiltonian trajectory must integrate to a zero relaxation superoperator');
+result=test_close(result,'ngce zero stochastic uncertainty',dR,sparse(1,1),1e-14,1e-14,...
+                  'a zero stochastic Hamiltonian trajectory must have zero relaxation uncertainty');
 
 % Check overwinding diagnostics complete and draw a spectrum for a safe one-dimensional grid
 figures_before=numel(findall(0,'Type','figure'));


### PR DESCRIPTION
## Summary

- adds optional `dR` output to `ngce.m` containing the sparse elementwise standard deviation of the mean for the returned relaxation superoperator
- computes the uncertainty from the same per-stripe Redfield integrals that are averaged to produce `R`
- updates the NGCE examples to request `dR` and plot diagonal-rate uncertainty as horizontal error bars
- extends the compact kernel regression test to check zero stochastic uncertainty

## Validation

- `git diff --check`
- `matlab -nojvm -batch "run('/home/kuprov/.openclaw/workspace/tmp/ngce_dR/validate_ngce_direct.m')"`
- `QT_QPA_PLATFORM=offscreen matlab -nojvm -batch "cd('/home/kuprov/.openclaw/workspace/Spinach'); fix_path('add'); addpath('tests'); result=run_test('dynamic_remaining_parallel_suite'); assert(strcmp(result.status,'PASS')); fprintf('NGCE_TEST_OK\n');"`
- `QT_QPA_PLATFORM=offscreen matlab -nojvm -batch "cd('/home/kuprov/.openclaw/workspace/Spinach'); fix_path('add'); addpath('examples/relaxation_theory/from_md'); ngce_test; close all; fprintf('NGCE_EXAMPLE_OK\n');"`
- `QT_QPA_PLATFORM=offscreen matlab -nojvm -batch "cd('/home/kuprov/.openclaw/workspace/Spinach'); fix_path('add'); files={'kernel/utilities/ngce.m','examples/relaxation_theory/from_md/ngce_test.m','examples/relaxation_theory/from_md/sucrose_three_spins.m','examples/relaxation_theory/from_md/sucrose_eight_spins.m','tests/kernel/test_dynamic_remaining_parallel_suite.m'}; for n=1:numel(files), msgs=checkcode(files{n},'-id'); assert(isempty(msgs),files{n}); end; fprintf('CHECKCODE_OK\n');"`
- `/home/kuprov/.openclaw/workspace/skills/autoreview/scripts/autoreview --mode local --base origin/main`
