### PR TITLE
Clarify dissipative Liouvillian documentation

### DIFF
--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -8,7 +8,11 @@
 %
 %  For Liouville space calculations:
 %
-%      L      - the Liouvillian to be used during evolution
+%      L      - the Liouvillian to be used during evolution. If L
+%               is assembled manually from Hamiltonian commutation
+%               superoperator H, relaxation superoperator R, and
+%               kinetics superoperator K, use L=H+1i*R+1i*K; do
+%               not use H+R+K because R and K are dissipative.
 %
 %      rho    - the initial state vector or a horizontal stack thereof
 %

--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -11,8 +11,7 @@
 %      L      - the Liouvillian to be used during evolution. If L
 %               is assembled manually from Hamiltonian commutation
 %               superoperator H, relaxation superoperator R, and
-%               kinetics superoperator K, use L=H+1i*R+1i*K; do
-%               not use H+R+K because R and K are dissipative.
+%               kinetics superoperator K, use L=H+1i*R+1i*K.
 %
 %      rho    - the initial state vector or a horizontal stack thereof
 %

--- a/kernel/kinetics/kinetics.m
+++ b/kernel/kinetics/kinetics.m
@@ -15,8 +15,7 @@
 %
 %    K            -  kinetics superoperator. If a Liouvillian is
 %                    assembled manually, this dissipative superoperator
-%                    must enter as 1i*K, for example
-%                    L=H+1i*R+1i*K; do not use H+R+K.
+%                    must enter as 1i*K, for example L=H+1i*R+1i*K
 %
 % Note: a large variety of chemical reaction models is supported,
 %       see the chemical kinetics parameters section of the onli-

--- a/kernel/kinetics/kinetics.m
+++ b/kernel/kinetics/kinetics.m
@@ -13,14 +13,17 @@
 %
 % Outputs:
 %
-%    K            -  kinetics superoperator
+%    K            -  kinetics superoperator. If a Liouvillian is
+%                    assembled manually, this dissipative superoperator
+%                    must enter as 1i*K, for example
+%                    L=H+1i*R+1i*K; do not use H+R+K.
 %
 % Note: a large variety of chemical reaction models is supported,
 %       see the chemical kinetics parameters section of the onli-
 %       ne manual.
 %
 % Note: Spinach context functions include kinetics superoperators
-%       into the total Liovillian automatically.
+%       in the total Liouvillian automatically.
 %
 % ilya.kuprov@weizmann.ac.il
 % ledwards@cbs.mpg.de

--- a/kernel/propagator.m
+++ b/kernel/propagator.m
@@ -8,9 +8,7 @@
 %    L          -  Hamiltonian or Liouvillian matrix. If L is
 %                  assembled manually from Hamiltonian commutation
 %                  superoperator H, relaxation superoperator R,
-%                  and kinetics superoperator K, use
-%                  L=H+1i*R+1i*K; do not use H+R+K because R
-%                  and K are dissipative.
+%                  and kinetics superoperator K, use L=H+1i*R+1i*K
 %
 %    timestep   -  propagation time step
 %

--- a/kernel/propagator.m
+++ b/kernel/propagator.m
@@ -5,7 +5,12 @@
 %
 % Parameters:
 %
-%    L          -  Hamiltonian or Liouvillian matrix
+%    L          -  Hamiltonian or Liouvillian matrix. If L is
+%                  assembled manually from Hamiltonian commutation
+%                  superoperator H, relaxation superoperator R,
+%                  and kinetics superoperator K, use
+%                  L=H+1i*R+1i*K; do not use H+R+K because R
+%                  and K are dissipative.
 %
 %    timestep   -  propagation time step
 %

--- a/kernel/relaxation.m
+++ b/kernel/relaxation.m
@@ -13,7 +13,10 @@
 %                    
 % Outputs:
 %
-%     R             - relaxation superoperator
+%     R             - relaxation superoperator. If a Liouvillian is
+%                     assembled manually, this dissipative superoperator
+%                     must enter as 1i*R, for example
+%                     L=H+1i*R+1i*K; do not use H+R+K.
 %
 % Note: a variety of relaxation theories are supported, see the relax-
 %       ation theory parameters section of the online manual.

--- a/kernel/step.m
+++ b/kernel/step.m
@@ -15,8 +15,7 @@
 %                    If L is assembled manually from Hamiltonian
 %                    commutation superoperator H, relaxation
 %                    superoperator R, and kinetics superoperator
-%                    K, use L=H+1i*R+1i*K; do not use H+R+K
-%                    because R and K are dissipative.
+%                    K, use L=H+1i*R+1i*K
 %
 %                    State-dependent evolution generators are 
 %                    supported: if L{1} is a function handle (see

--- a/kernel/step.m
+++ b/kernel/step.m
@@ -12,6 +12,11 @@
 %                    linear rule if two matrices {left, right} 
 %                    are supplied, piecewise-quadratic if three
 %                    matrices {left, midpoint, right} are given.
+%                    If L is assembled manually from Hamiltonian
+%                    commutation superoperator H, relaxation
+%                    superoperator R, and kinetics superoperator
+%                    K, use L=H+1i*R+1i*K; do not use H+R+K
+%                    because R and K are dissipative.
 %
 %                    State-dependent evolution generators are 
 %                    supported: if L{1} is a function handle (see


### PR DESCRIPTION
## Summary

- clarify in `evolution`, `step`, and `propagator` headers that manually assembled dissipative Liouvillians should use `L=H+1i*R+1i*K`, not `H+R+K`
- clarify in `relaxation` and `kinetics` headers that returned dissipative superoperators enter manual Liouvillian assembly as `1i*R` and `1i*K`
- correct `Liovillian` to `Liouvillian` in the `kinetics` header note

Live Wiki updates already made:

- `Relaxation theory parameters`, revision 9866
- `Chemical kinetics parameters`, revision 9865
- `Models of chemical kinetics`, revision 9867

## Validation

- `git diff --check`
- MATLAB validation via `tools/run_matlab_batch_probe.py --script tmp/validate_liouvillian_doc_headers.m --success-marker TALOS_LIOUVILLIAN_DOC_HEADERS_OK`
- structured autoreview: no accepted/actionable findings
- refetched the edited Wiki pages and verified the `L=H+1i*R+1i*K` markers
