### PR TITLE
Preallocate COMSOL plotting arrays

### DIFF
--- a/interfaces/comsol/conc_plot.m
+++ b/interfaces/comsol/conc_plot.m
@@ -78,31 +78,36 @@ else
 
 end
 
-% Loop over cells
-V=zeros(0,3); patch_idx=0; FRGB=ones(0,3);
-F=nan(0,spin_system.mesh.vor.max_cell_size+1);
-for n=1:spin_system.mesh.vor.ncells
+% Find cells with significant bar heights
+active_cells=find(abs(conc)>1e-3*diff(spin_system.mesh.zext));
+cell_sizes=cellfun(@numel,spin_system.mesh.vor.cells(active_cells));
+total_vertices=sum(cell_sizes);
 
-    % For significant bar heights
-    if abs(conc(n))>1e-3*diff(spin_system.mesh.zext)
+% Preallocate cap geometry and colours
+V=zeros(total_vertices,3);
+F=nan(numel(active_cells),spin_system.mesh.vor.max_cell_size+1);
+FRGB=zeros(numel(active_cells),3);
+vertex_offset=0;
 
-        % Get the vertices of the Voronoi cell
-        vor_cell_x=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},1);
-        vor_cell_y=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},2);
-        vor_cell_z=conc(n)*ones(size(vor_cell_x));
-        V=[V; vor_cell_x(:) vor_cell_y(:) vor_cell_z(:)]; %#ok<AGROW> 
-        
-        % Build the face connectivity index
-        F_current=nan([1 spin_system.mesh.vor.max_cell_size+1]);
-        new_face=[1:numel(vor_cell_z) 1]+patch_idx;
-        F_current(1:numel(new_face))=new_face;
-        F=[F; F_current]; patch_idx=new_face(end-1);      %#ok<AGROW>
+% Build lids and bottoms
+for m=1:numel(active_cells)
 
-        % Add the colour spec
-        FRGB=[FRGB; RGB(n,:)];                            %#ok<AGROW>
-        
-    end
-    
+    % Get the vertices of the Voronoi cell
+    n=active_cells(m); nvert=cell_sizes(m);
+    vor_cell_x=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},1);
+    vor_cell_y=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},2);
+    vor_cell_z=conc(n)*ones(size(vor_cell_x));
+    vertex_range=vertex_offset+(1:nvert);
+    V(vertex_range,:)=[vor_cell_x(:) vor_cell_y(:) vor_cell_z(:)];
+
+    % Build the face connectivity index
+    face=[1:nvert 1]+vertex_offset;
+    F(m,1:numel(face))=face;
+
+    % Add the colour spec and advance the vertex offset
+    FRGB(m,:)=RGB(n,:);
+    vertex_offset=vertex_offset+nvert;
+
 end
 
 % Draw lids and bottoms of the bars as a multifaceted patch
@@ -113,42 +118,37 @@ patch('Faces',F,'Vertices',V,'FaceColor','flat',...
       'FaceVertexCData',FRGB,'EdgeColor','black',...
       'LineWidth',0.125,'LineJoin','round');
 
-% Loop over cells
-V=zeros(0,3); patch_idx=0; 
-F=nan(0,5); FRGB=ones(0,3);
-for n=1:spin_system.mesh.vor.ncells
+% Preallocate side geometry and colours
+V=zeros(2*total_vertices,3);
+F=zeros(total_vertices,5);
+FRGB=zeros(total_vertices,3);
+vertex_offset=0; face_offset=0;
 
-    % For significant bar heights
-    if abs(conc(n))>1e-3*diff(spin_system.mesh.zext)
+% Build sides
+for m=1:numel(active_cells)
 
-        % Get the vertices of the Voronoi cell
-        vor_cell_x=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},1);
-        vor_cell_y=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},2);
-        vor_cell_z=conc(n)*ones(size(vor_cell_x));
-        V=[V; vor_cell_x(:) vor_cell_y(:)   vor_cell_z(:); 
-              vor_cell_x(:) vor_cell_y(:) 0*vor_cell_z(:)]; %#ok<AGROW> 
-        nvert=numel(vor_cell_z);
-        
-        % Build the face connectivity index
-        F_current=nan(nvert,5); FRGB_current=nan(nvert,3);
-        for k=1:(nvert-1)
+    % Get the vertices of the Voronoi cell
+    n=active_cells(m); nvert=cell_sizes(m);
+    vor_cell_x=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},1);
+    vor_cell_y=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},2);
+    vor_cell_z=conc(n)*ones(size(vor_cell_x));
+    top_range=vertex_offset+(1:nvert);
+    bottom_range=vertex_offset+nvert+(1:nvert);
+    V(top_range,:)=[vor_cell_x(:) vor_cell_y(:) vor_cell_z(:)];
+    V(bottom_range,:)=[vor_cell_x(:) vor_cell_y(:) zeros(nvert,1)];
 
-            % Build each wall
-            F_current(k,:)=[k k+1 k+nvert+1 k+nvert k]+patch_idx;
+    % Build all walls for this cell
+    local_idx=(1:nvert)';
+    next_idx=[(2:nvert)';1];
+    face_range=face_offset+(1:nvert);
+    F(face_range,:)=[local_idx next_idx next_idx+nvert ...
+                     local_idx+nvert local_idx]+vertex_offset;
+    FRGB(face_range,:)=repmat(RGB(n,:),nvert,1);
 
-            % Add the colour spec
-            FRGB_current(k,:)=RGB(n,:);
+    % Advance the vertex and face offsets
+    vertex_offset=vertex_offset+2*nvert;
+    face_offset=face_offset+nvert;
 
-        end
-        F_current(nvert,:)=[nvert 1 nvert+1 2*nvert nvert]+patch_idx;
-        FRGB_current(nvert,:)=RGB(n,:);
-        
-        % Add walls to the total
-        patch_idx=patch_idx+2*nvert;
-        F=[F; F_current]; FRGB=[FRGB; FRGB_current]; %#ok<AGROW>
-        
-    end
-    
 end
 
 % Draw the sides of the bars as a multifaceted patch
@@ -192,4 +192,3 @@ end
 %
 % Vikings, about Christians,
 % in The Northman (2022)
-

--- a/interfaces/comsol/mesh_preplot.m
+++ b/interfaces/comsol/mesh_preplot.m
@@ -51,12 +51,20 @@ end
 mesh.plot.rec_a=A; mesh.plot.rec_b=B;
 
 % Prepare Voronoi cell array for plotting
-A=[]; B=[];
+cell_sizes=cellfun(@numel,mesh.vor.cells);
+array_size=sum(cell_sizes)+2*numel(mesh.vor.cells);
+A=nan(array_size,1); B=nan(array_size,1); array_offset=0;
 for n=1:numel(mesh.vor.cells)
-    A=[A; mesh.vor.vertices(mesh.vor.cells{n},1); ...
-          mesh.vor.vertices(mesh.vor.cells{n}(1),1); NaN]; %#ok<AGROW> 
-    B=[B; mesh.vor.vertices(mesh.vor.cells{n},2); ...
-          mesh.vor.vertices(mesh.vor.cells{n}(1),2); NaN]; %#ok<AGROW> 
+    cell_idx=mesh.vor.cells{n}; nvert=cell_sizes(n);
+    boundary_range=array_offset+(1:(nvert+1));
+    A(boundary_range)=[mesh.vor.vertices(cell_idx,1); ...
+                       mesh.vor.vertices(cell_idx(1),1)];
+    B(boundary_range)=[mesh.vor.vertices(cell_idx,2); ...
+                       mesh.vor.vertices(cell_idx(1),2)];
+    array_offset=array_offset+nvert+2;
+end
+if isempty(cell_sizes)
+    A=[]; B=[];
 end
 mesh.plot.vor_a=A; mesh.plot.vor_b=B;
 
@@ -76,4 +84,3 @@ end
 % and a comedy for those who think.
 %
 % Jean de la Bruyere
-

--- a/tests/kernel/test_plotting_helpers_offscreen.m
+++ b/tests/kernel/test_plotting_helpers_offscreen.m
@@ -45,6 +45,9 @@ result=local_test_plot_3d(result,spin_system);
 % Exercise MRI and volume plotting utilities
 result=local_test_misc_plots(result);
 
+% Exercise COMSOL mesh and concentration plotting
+result=local_test_comsol_plots(result);
+
 end
 
 
@@ -241,6 +244,103 @@ surf_obj=findobj(fig,'Type','surface');
 result=test_true(result,'volplot surfaces',numel(surf_obj)>=1,...
                  'volplot creates semitransparent surfaces for non-zero volume slices');
 close(fig);
+
+end
+
+
+function result=local_test_comsol_plots(result)
+
+% Build a compact mesh with heterogeneous Voronoi cells
+vertices=[0 0;1 0;0 1;1 0;2 0;2 1;1 1;3 0;3 1;2 1];
+cells={[1 2 3],[4 5 6 7],[8 9 10]};
+mesh.x=vertices(:,1); mesh.y=vertices(:,2);
+mesh.idx.edges=[1 2];
+mesh.idx.triangles=[1 2 3];
+mesh.idx.rectangles=[1 2 4 3];
+mesh.vor.vertices=vertices;
+mesh.vor.cells=cells;
+mesh.vor.ncells=numel(cells);
+mesh.vor.max_cell_size=4;
+
+% Check precomputed Voronoi plotting arrays and separators
+mesh=mesh_preplot(mesh);
+expected_x=[0;1;0;0;NaN;1;2;2;1;1;NaN;3;3;2;3;NaN];
+expected_y=[0;0;1;0;NaN;0;0;1;1;0;NaN;0;1;1;0;NaN];
+result=test_true(result,'mesh_preplot Voronoi x values',isequaln(mesh.plot.vor_a,expected_x),...
+                 'mesh_preplot preserves each cell boundary and its NaN separator');
+result=test_true(result,'mesh_preplot Voronoi y values',isequaln(mesh.plot.vor_b,expected_y),...
+                 'mesh_preplot preserves y coordinates for heterogeneous cells');
+
+% Preserve the empty-tessellation output shape
+empty_mesh=mesh; empty_mesh.vor.cells={};
+empty_mesh=mesh_preplot(empty_mesh);
+result=test_true(result,'mesh_preplot empty Voronoi arrays',...
+                 isequal(size(empty_mesh.plot.vor_a),[0 0])&&...
+                 isequal(size(empty_mesh.plot.vor_b),[0 0]),...
+                 'empty tessellations retain the original empty matrix shape');
+
+% Plot two active concentration bars and leave the third inactive
+spin_system.mesh=mesh;
+spin_system.mesh.zext=[-1 1];
+concentrations=[1;-0.5;0];
+fig=figure('Visible','off');
+conc_plot(spin_system,concentrations);
+patch_obj=findobj(fig,'Type','patch');
+vertex_counts=arrayfun(@(obj)size(get(obj,'Vertices'),1),patch_obj);
+side_patch=patch_obj(vertex_counts==14);
+cap_patches=patch_obj(vertex_counts==7);
+cap_a_vertices=get(cap_patches(1),'Vertices');
+if any(cap_a_vertices(:,3))
+    top_patch=cap_patches(1); bottom_patch=cap_patches(2);
+else
+    top_patch=cap_patches(2); bottom_patch=cap_patches(1);
+end
+
+% Check cap geometry, connectivity, and per-cell colours
+expected_cap_vertices=[vertices(cells{1},:) ones(3,1);...
+                       vertices(cells{2},:) -0.5*ones(4,1)];
+expected_cap_faces=[1 2 3 1 NaN;4 5 6 7 4];
+result=test_true(result,'conc_plot patch partition',...
+                 isscalar(side_patch)&&numel(cap_patches)==2,...
+                 'conc_plot creates one side patch and two cap patches');
+result=test_close(result,'conc_plot top vertices',get(top_patch,'Vertices'),...
+                  expected_cap_vertices,1e-12,1e-12,...
+                  'top cap vertices preserve active cell order and concentrations');
+result=test_true(result,'conc_plot cap faces',...
+                 isequaln(get(top_patch,'Faces'),expected_cap_faces),...
+                 'cap connectivity closes each heterogeneous Voronoi cell');
+result=test_close(result,'conc_plot bottom vertices',get(bottom_patch,'Vertices'),...
+                  [expected_cap_vertices(:,1:2) zeros(7,1)],1e-12,1e-12,...
+                  'bottom caps reuse the active cell geometry at zero height');
+result=test_close(result,'conc_plot cap colours',get(top_patch,'FaceVertexCData'),...
+                  0.5*ones(2,3),1e-12,1e-12,...
+                  'neutral colours are retained for each active cap');
+
+% Check side geometry, connectivity, and per-face colours
+expected_side_vertices=[vertices(cells{1},:) ones(3,1);...
+                        vertices(cells{1},:) zeros(3,1);...
+                        vertices(cells{2},:) -0.5*ones(4,1);...
+                        vertices(cells{2},:) zeros(4,1)];
+expected_side_faces=[1 2 5 4 1;2 3 6 5 2;3 1 4 6 3;...
+                     7 8 12 11 7;8 9 13 12 8;...
+                     9 10 14 13 9;10 7 11 14 10];
+result=test_close(result,'conc_plot side vertices',get(side_patch,'Vertices'),...
+                  expected_side_vertices,1e-12,1e-12,...
+                  'side vertices retain paired top and bottom cell boundaries');
+result=test_close(result,'conc_plot side faces',get(side_patch,'Faces'),...
+                  expected_side_faces,1e-12,1e-12,...
+                  'side connectivity closes every wall without cross-cell indices');
+result=test_close(result,'conc_plot side colours',get(side_patch,'FaceVertexCData'),...
+                  0.5*ones(7,3),1e-12,1e-12,...
+                  'each side face retains its source cell colour');
+close(fig);
+
+% Guard the performance fix against reintroducing growing arrays
+conc_source=fileread(which('conc_plot'));
+mesh_source=fileread(which('mesh_preplot'));
+result=test_true(result,'COMSOL plotting preallocation',...
+                 ~contains(conc_source,'AGROW')&&~contains(mesh_source,'AGROW'),...
+                 'COMSOL plotting loops must not suppress array-growth warnings');
 
 end
 


### PR DESCRIPTION
## Summary

- precompute active Voronoi cell sizes and allocate cap and side patch arrays once
- fill wall connectivity and per-face colours through bounded offset ranges
- preallocate the Voronoi polyline arrays used by `mesh_plot` in `mesh_preplot`
- preserve the previous empty-tessellation shape and add offscreen regression coverage

`mesh_plot` now consumes arrays produced by `mesh_preplot`, so the remaining mesh-side reallocations described in the issue live in that preprocessing function.

Fixes #21.

## Validation

- MATLAB R2025a `checkcode` on both production files and the changed test: no messages
- `run_test('kernel/plotting_helpers_offscreen')`: passed, including 12 COMSOL assertions for heterogeneous cells, inactive cells, empty tessellations, cap/side topology, vertices, and colours
- direct MATLAB probes for a single triangular cell and a zero-active-cell input: passed
- `git diff --check`
- local 3000-cell median benchmark (informational, not a test):
  - `conc_plot`: 0.275 s to 0.174 s, about 37% faster
  - `mesh_preplot`: 7.41 ms to 6.76 ms, about 9% faster

## AI assistance

AI tools assisted with issue investigation and drafting. I reviewed the complete diff and ran all MATLAB validation and benchmarks listed above.