### PR TITLE
Complete diamond defect literature citations

### DIFF
--- a/etc/diamond_defects/diamond_nvm_gs.m
+++ b/etc/diamond_defects/diamond_nvm_gs.m
@@ -4,7 +4,8 @@
 %
 % Magnetic parameters from:
 %
-%     S. Felton et al., Phys. Rev. B 79 (2009) 075203
+%     S. Felton et al., Phys. Rev. B 79, 075203 (2009),
+%     <https://doi.org/10.1103/PhysRevB.79.075203>
 %
 % Parameters: 
 % 

--- a/etc/diamond_defects/diamond_p1.m
+++ b/etc/diamond_defects/diamond_p1.m
@@ -2,7 +2,8 @@
 %
 %           [sys,inter]=diamond_p1(parameters)
 %
-% Magnetic parameters from: Nir-Orad et al. PCCP 2024, and
+% Magnetic parameters from: Nir-Arad et al. Phys. Chem. Chem. Phys. 26,
+% 27633 (2024), <https://doi.org/10.1039/d4cp03055a>, and
 % Smith et al. Phys. Rev. 115, 1546 (1959).
 %
 % Parameters:

--- a/etc/diamond_defects/diamond_p1.m
+++ b/etc/diamond_defects/diamond_p1.m
@@ -4,7 +4,8 @@
 %
 % Magnetic parameters from: Nir-Arad et al. Phys. Chem. Chem. Phys. 26,
 % 27633 (2024), <https://doi.org/10.1039/d4cp03055a>, and
-% Smith et al. Phys. Rev. 115, 1546 (1959).
+% Smith et al. Phys. Rev. 115, 1546 (1959),
+% <https://doi.org/10.1103/PhysRev.115.1546>.
 %
 % Parameters:
 %


### PR DESCRIPTION
## Summary

- replace the abbreviated `diamond_p1` PCCP citation with the full journal, volume, page, year, and DOI
- correct the first author's surname to `Nir-Arad`, as recorded by the DOI metadata
- add the missing DOI to the Smith et al. P1 reference
- standardise the Felton et al. `diamond_nvm_gs` citation and add its missing DOI

## Validation

- DOI metadata verified against Crossref records from the Royal Society of Chemistry and American Physical Society
- `git diff --check`
- preservation gate confirming that only the intended citation blocks changed and all executable code is byte-identical to `main`
