### PR TITLE
Add Solomon-Bloembergen-Morgan relaxation rates

### DIFF
--- a/etc/textbook/rlx_sbm.m
+++ b/etc/textbook/rlx_sbm.m
@@ -1,0 +1,121 @@
+% Solomon-Bloembergen-Morgan nuclear relaxation rates due to a
+% paramagnetic centre. Syntax:
+%
+%       [r1,r2]=rlx_sbm(B0,nucleus,dist,a_iso,e_spin,g_eff,tau_c,tau_e)
+%
+% Parameters:
+%
+%    B0       - magnet field, Tesla
+%
+%    nucleus  - nuclear isotope, e.g. '1H' or '13C'
+%
+%    dist     - electron-nucleus distance, Angstrom
+%
+%    a_iso    - isotropic hyperfine coupling, rad/s
+%
+%    e_spin   - effective electron spin quantum number
+%
+%    g_eff    - effective electron g-factor
+%
+%    tau_c    - dipolar correlation times [tau_c1 tau_c2], seconds
+%
+%    tau_e    - electron correlation times [tau_e1 tau_e2], seconds
+%
+% Outputs:
+%
+%    r1       - longitudinal rates [dipolar contact], Hz
+%
+%    r2       - transverse rates [dipolar contact], Hz
+%
+% The spectral density convention is J(omega,tau)=tau/(1+omega^2*tau^2).
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=rlx_sbm.m>
+
+function [r1,r2]=rlx_sbm(B0,nucleus,dist,a_iso,e_spin,g_eff,tau_c,tau_e)
+
+% Check consistency
+grumble(B0,nucleus,dist,a_iso,e_spin,g_eff,tau_c,tau_e);
+
+% Physical constants
+mu0=1.25663706127e-6;
+muB=9.2740100657e-24;
+hbar=6.62607015e-34/(2*pi);
+
+% Larmor frequencies
+omega_i=abs(spin(nucleus)*B0);
+omega_s=abs(g_eff*muB*B0/hbar);
+
+% Dipolar relaxation prefactor
+spin_sq=e_spin*(e_spin+1);
+dist=dist*1e-10;
+pref_dd=(mu0/(4*pi))^2*(spin(nucleus)*g_eff*muB)^2*spin_sq/dist^6;
+
+% Dipolar longitudinal relaxation rate
+r1_dd=(2/15)*pref_dd*(3*tau_c(1)/(1+(omega_i*tau_c(1))^2)+...
+                      6*tau_c(2)/(1+((omega_i+omega_s)*tau_c(2))^2)+...
+                        tau_c(2)/(1+((omega_i-omega_s)*tau_c(2))^2));
+
+% Dipolar transverse relaxation rate
+r2_dd=(1/15)*pref_dd*(4*tau_c(1)+...
+                      3*tau_c(1)/(1+(omega_i*tau_c(1))^2)+...
+                      6*tau_c(2)/(1+(omega_s*tau_c(2))^2)+...
+                      6*tau_c(2)/(1+((omega_i+omega_s)*tau_c(2))^2)+...
+                        tau_c(2)/(1+((omega_i-omega_s)*tau_c(2))^2));
+
+% Contact longitudinal relaxation rate
+r1_sc=(2/3)*a_iso^2*spin_sq*tau_e(2)/...
+      (1+((omega_i-omega_s)*tau_e(2))^2);
+
+% Contact transverse relaxation rate
+r2_sc=(1/3)*a_iso^2*spin_sq*(tau_e(1)+tau_e(2)/...
+      (1+((omega_i-omega_s)*tau_e(2))^2));
+
+% Package contributions by mechanism
+r1=[r1_dd r1_sc];
+r2=[r2_dd r2_sc];
+
+end
+
+% Consistency enforcement
+function grumble(B0,nucleus,dist,a_iso,e_spin,g_eff,tau_c,tau_e)
+if (~isnumeric(B0))||(~isreal(B0))||(~isscalar(B0))||...
+   (~isfinite(B0))||(B0<=0)
+    error('B0 must be a positive real finite scalar.');
+end
+if (~ischar(nucleus))||isempty(regexp(nucleus,'^\d+[A-Z][a-z]?\d*$','once'))
+    error('nucleus must be a character string specifying a nuclear isotope.');
+end
+spin(nucleus);
+if (~isnumeric(dist))||(~isreal(dist))||(~isscalar(dist))||...
+   (~isfinite(dist))||(dist<=0)
+    error('dist must be a positive real finite scalar.');
+end
+if (~isnumeric(a_iso))||(~isreal(a_iso))||(~isscalar(a_iso))||...
+   (~isfinite(a_iso))
+    error('a_iso must be a real finite scalar.');
+end
+if (~isnumeric(e_spin))||(~isreal(e_spin))||(~isscalar(e_spin))||...
+   (~isfinite(e_spin))||(e_spin<=0)||(mod(2*e_spin,1)~=0)
+    error('e_spin must be a positive integer or half-integer scalar.');
+end
+if (~isnumeric(g_eff))||(~isreal(g_eff))||(~isscalar(g_eff))||...
+   (~isfinite(g_eff))||(g_eff<=0)
+    error('g_eff must be a positive real finite scalar.');
+end
+if (~isnumeric(tau_c))||(~isreal(tau_c))||(~isrow(tau_c))||...
+   (numel(tau_c)~=2)||any(~isfinite(tau_c))||any(tau_c<=0)
+    error('tau_c must be a row vector containing two positive real finite numbers.');
+end
+if (~isnumeric(tau_e))||(~isreal(tau_e))||(~isrow(tau_e))||...
+   (numel(tau_e)~=2)||any(~isfinite(tau_e))||any(tau_e<=0)
+    error('tau_e must be a row vector containing two positive real finite numbers.');
+end
+end
+
+% Any sufficiently advanced incompetence is indistinguishable from malice.
+%
+% Grey's law
+
+

--- a/etc/textbook/rlx_sbm.m
+++ b/etc/textbook/rlx_sbm.m
@@ -1,7 +1,7 @@
 % Solomon-Bloembergen-Morgan nuclear relaxation rates due to a
 % paramagnetic centre. Syntax:
 %
-%       [r1,r2]=rlx_sbm(B0,nucleus,dist,a_iso,e_spin,g_eff,tau_c,tau_e)
+%       [r1,r2]=rlx_sbm(B0,nucleus,dist,a_iso,e_spin,g_eff,t1e,t2e,tau_r)
 %
 % Parameters:
 %
@@ -17,9 +17,11 @@
 %
 %    g_eff    - effective electron g-factor
 %
-%    tau_c    - dipolar correlation times [tau_c1 tau_c2], seconds
+%    t1e      - longitudinal electron relaxation time, seconds
 %
-%    tau_e    - electron correlation times [tau_e1 tau_e2], seconds
+%    t2e      - transverse electron relaxation time, seconds
+%
+%    tau_r    - rotational correlation time, seconds
 %
 % Outputs:
 %
@@ -33,10 +35,10 @@
 %
 % <https://spindynamics.org/wiki/index.php?title=rlx_sbm.m>
 
-function [r1,r2]=rlx_sbm(B0,nucleus,dist,a_iso,e_spin,g_eff,tau_c,tau_e)
+function [r1,r2]=rlx_sbm(B0,nucleus,dist,a_iso,e_spin,g_eff,t1e,t2e,tau_r)
 
 % Check consistency
-grumble(B0,nucleus,dist,a_iso,e_spin,g_eff,tau_c,tau_e);
+grumble(B0,nucleus,dist,a_iso,e_spin,g_eff,t1e,t2e,tau_r);
 
 % Physical constants
 mu0=1.25663706127e-6;
@@ -47,30 +49,34 @@ hbar=6.62607015e-34/(2*pi);
 omega_i=abs(spin(nucleus)*B0);
 omega_s=abs(g_eff*muB*B0/hbar);
 
+% Effective dipolar correlation times
+tau_c1=1/(1/tau_r+1/t1e);
+tau_c2=1/(1/tau_r+1/t2e);
+
 % Dipolar relaxation prefactor
 spin_sq=e_spin*(e_spin+1);
 dist=dist*1e-10;
 pref_dd=(mu0/(4*pi))^2*(spin(nucleus)*g_eff*muB)^2*spin_sq/dist^6;
 
 % Dipolar longitudinal relaxation rate
-r1_dd=(2/15)*pref_dd*(3*tau_c(1)/(1+(omega_i*tau_c(1))^2)+...
-                      6*tau_c(2)/(1+((omega_i+omega_s)*tau_c(2))^2)+...
-                        tau_c(2)/(1+((omega_i-omega_s)*tau_c(2))^2));
+r1_dd=(2/15)*pref_dd*(3*tau_c1/(1+(omega_i*tau_c1)^2)+...
+                      6*tau_c2/(1+((omega_i+omega_s)*tau_c2)^2)+...
+                        tau_c2/(1+((omega_i-omega_s)*tau_c2)^2));
 
 % Dipolar transverse relaxation rate
-r2_dd=(1/15)*pref_dd*(4*tau_c(1)+...
-                      3*tau_c(1)/(1+(omega_i*tau_c(1))^2)+...
-                      6*tau_c(2)/(1+(omega_s*tau_c(2))^2)+...
-                      6*tau_c(2)/(1+((omega_i+omega_s)*tau_c(2))^2)+...
-                        tau_c(2)/(1+((omega_i-omega_s)*tau_c(2))^2));
+r2_dd=(1/15)*pref_dd*(4*tau_c1+...
+                      3*tau_c1/(1+(omega_i*tau_c1)^2)+...
+                      6*tau_c2/(1+(omega_s*tau_c2)^2)+...
+                      6*tau_c2/(1+((omega_i+omega_s)*tau_c2)^2)+...
+                        tau_c2/(1+((omega_i-omega_s)*tau_c2)^2));
 
 % Contact longitudinal relaxation rate
-r1_sc=(2/3)*a_iso^2*spin_sq*tau_e(2)/...
-      (1+((omega_i-omega_s)*tau_e(2))^2);
+r1_sc=(2/3)*a_iso^2*spin_sq*t2e/...
+      (1+((omega_i-omega_s)*t2e)^2);
 
 % Contact transverse relaxation rate
-r2_sc=(1/3)*a_iso^2*spin_sq*(tau_e(1)+tau_e(2)/...
-      (1+((omega_i-omega_s)*tau_e(2))^2));
+r2_sc=(1/3)*a_iso^2*spin_sq*(t1e+t2e/...
+      (1+((omega_i-omega_s)*t2e)^2));
 
 % Package contributions by mechanism
 r1=[r1_dd r1_sc];
@@ -79,7 +85,7 @@ r2=[r2_dd r2_sc];
 end
 
 % Consistency enforcement
-function grumble(B0,nucleus,dist,a_iso,e_spin,g_eff,tau_c,tau_e)
+function grumble(B0,nucleus,dist,a_iso,e_spin,g_eff,t1e,t2e,tau_r)
 if (~isnumeric(B0))||(~isreal(B0))||(~isscalar(B0))||...
    (~isfinite(B0))||(B0<=0)
     error('B0 must be a positive real finite scalar.');
@@ -104,13 +110,17 @@ if (~isnumeric(g_eff))||(~isreal(g_eff))||(~isscalar(g_eff))||...
    (~isfinite(g_eff))||(g_eff<=0)
     error('g_eff must be a positive real finite scalar.');
 end
-if (~isnumeric(tau_c))||(~isreal(tau_c))||(~isrow(tau_c))||...
-   (numel(tau_c)~=2)||any(~isfinite(tau_c))||any(tau_c<=0)
-    error('tau_c must be a row vector containing two positive real finite numbers.');
+if (~isnumeric(t1e))||(~isreal(t1e))||(~isscalar(t1e))||...
+   (~isfinite(t1e))||(t1e<=0)
+    error('t1e must be a positive real finite scalar.');
 end
-if (~isnumeric(tau_e))||(~isreal(tau_e))||(~isrow(tau_e))||...
-   (numel(tau_e)~=2)||any(~isfinite(tau_e))||any(tau_e<=0)
-    error('tau_e must be a row vector containing two positive real finite numbers.');
+if (~isnumeric(t2e))||(~isreal(t2e))||(~isscalar(t2e))||...
+   (~isfinite(t2e))||(t2e<=0)
+    error('t2e must be a positive real finite scalar.');
+end
+if (~isnumeric(tau_r))||(~isreal(tau_r))||(~isscalar(tau_r))||...
+   (~isfinite(tau_r))||(tau_r<=0)
+    error('tau_r must be a positive real finite scalar.');
 end
 end
 

--- a/examples/nmr_paramag/sbm_dyl1_h1.m
+++ b/examples/nmr_paramag/sbm_dyl1_h1.m
@@ -15,15 +15,13 @@ nucleus='1H';
 % Paramagnetic centre parameters
 e_spin=15/2;
 g_eff=4/3;
+t1e=0.2e-12;
+t2e=0.2e-12;
 tau_r=140e-12;
-tau_e=[0.2e-12 0.2e-12];
 
 % H1 position relative to the metal centre
 dist=4.3702201672;
 a_iso=0;
-
-% Combined correlation times
-tau_c=1./(1/tau_r+1./tau_e);
 
 % Preallocate relaxation rates
 r1=zeros(size(fields));
@@ -32,7 +30,7 @@ r2=zeros(size(fields));
 % Compute field dependence
 for n=1:numel(fields)
     [r1_parts,r2_parts]=rlx_sbm(fields(n),nucleus,dist,a_iso,...
-                                e_spin,g_eff,tau_c,tau_e);
+                                e_spin,g_eff,t1e,t2e,tau_r);
     r1(n)=sum(r1_parts);
     r2(n)=sum(r2_parts);
 end

--- a/examples/nmr_paramag/sbm_dyl1_h1.m
+++ b/examples/nmr_paramag/sbm_dyl1_h1.m
@@ -1,0 +1,50 @@
+% Field dependence of proton relaxation near the dysprosium centre
+% in the DyL1 complex. Molecular and relaxation parameters correspond
+% to a room-temperature proton NMR experiment.
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function sbm_dyl1_h1()
+
+% Experiment parameters
+fields=1.0:0.25:20.0;
+nucleus='1H';
+
+% Paramagnetic centre parameters
+e_spin=15/2;
+g_eff=4/3;
+tau_r=140e-12;
+tau_e=[0.2e-12 0.2e-12];
+
+% H1 position relative to the metal centre
+dist=4.3702201672;
+a_iso=0;
+
+% Combined correlation times
+tau_c=1./(1/tau_r+1./tau_e);
+
+% Preallocate relaxation rates
+r1=zeros(size(fields));
+r2=zeros(size(fields));
+
+% Compute field dependence
+for n=1:numel(fields)
+    [r1_parts,r2_parts]=rlx_sbm(fields(n),nucleus,dist,a_iso,...
+                                e_spin,g_eff,tau_c,tau_e);
+    r1(n)=sum(r1_parts);
+    r2(n)=sum(r2_parts);
+end
+
+% Plot relaxation rates
+kfigure();
+semilogy(fields,r1,'b-',fields,r2,'r-');
+kxlabel('Magnetic field, Tesla');
+kylabel('Relaxation rate, Hz');
+klegend({'R_1','R_2'},'Location','northwest');
+kgrid();
+
+end
+
+


### PR DESCRIPTION
## Summary
- add a textbook Solomon-Bloembergen-Morgan relaxation-rate calculator
- accept the primitive electron-relaxation and rotational parameters `t1e`, `t2e`, and `tau_r`, and derive the effective dipolar correlation times internally
- report dipolar and contact contributions to nuclear R1 and R2 separately
- add a room-temperature DyL1 proton field-scan example using the clarified interface

## Validation
- MATLAB numerical probe against `rlx_dip` in the electron-spin limit
- focused MATLAB comparison of the refactored production function with the pre-refactor formulas using distinct T1e and T2e values; maximum relative error zero
- validation checks for all three replacement inputs
- MATLAB execution of `sbm_dyl1_h1` with invisible figures and finite positive R1/R2 curves
- MATLAB `checkcode` on both changed files
