### PR TITLE
Add Bruker acquisition parameter translators

### DIFF
--- a/interfaces/bruker/bruker2acq.m
+++ b/interfaces/bruker/bruker2acq.m
@@ -9,9 +9,8 @@
 %                     array of structures ordered from the slowest to
 %                     the directly detected dimension
 %
-%    point_factors  - optional divisor converting Bruker TD values into
-%                     complex time-domain points; defaults to 1 for
-%                     indirect dimensions and 2 for the direct dimension
+%    point_factors  - divisors converting Bruker TD values into complex
+%                     time-domain points, one per acquisition dimension
 %
 % Outputs:
 %
@@ -29,12 +28,6 @@ function parameters=bruker2acq(acqus,point_factors)
 
 % Normalize the dimension list
 if isstruct(acqus), acqus={acqus}; end
-
-% Set default point conversion factors
-if nargin==1
-    point_factors=ones(1,numel(acqus));
-    point_factors(end)=2;
-end
 
 % Check consistency
 grumble(acqus,point_factors);
@@ -58,7 +51,7 @@ for n=1:n_dims
 
     % Point count and transmitter offset
     npoints=getpar(acqus{n},'TD',[])/point_factors(n);
-    offset=getpar(acqus{n},'O1',0);
+    offset=getpar(acqus{n},'O1',[]);
 
     % Store Spinach acquisition settings
     parameters.sweep(n)=sweep;
@@ -101,7 +94,7 @@ for n=1:numel(acqus)
     sw=getpar(acqus{n},'SW',[]);
     sfo1=getpar(acqus{n},'SFO1',[]);
     td=getpar(acqus{n},'TD',[]);
-    o1=getpar(acqus{n},'O1',0);
+    o1=getpar(acqus{n},'O1',[]);
     if isempty(sw_h)&&(isempty(sw)||isempty(sfo1))
         error('each acquisition structure must contain SW_h or both SW and SFO1.');
     end
@@ -118,8 +111,9 @@ for n=1:numel(acqus)
        (~isfinite(td))||(td<=0)||(mod(td,point_factors(n))~=0)
         error('TD values must be positive integers divisible by point_factors.');
     end
-    if (~isnumeric(o1))||(~isreal(o1))||(~isscalar(o1))||(~isfinite(o1))
-        error('O1 values must be real finite scalars.');
+    if isempty(o1)||(~isnumeric(o1))||(~isreal(o1))||...
+       (~isscalar(o1))||(~isfinite(o1))
+        error('each acquisition structure must contain an O1 real finite scalar.');
     end
 end
 end

--- a/interfaces/bruker/bruker2acq.m
+++ b/interfaces/bruker/bruker2acq.m
@@ -1,0 +1,131 @@
+% Translates Bruker acquisition parameters into a Spinach pulse
+% sequence parameter structure. Syntax:
+%
+%             parameters=bruker2acq(acqus,point_factors)
+%
+% Parameters:
+%
+%    acqus          - Bruker acquisition parameter structure, or a cell
+%                     array of structures ordered from the slowest to
+%                     the directly detected dimension
+%
+%    point_factors  - optional divisor converting Bruker TD values into
+%                     complex time-domain points; defaults to 1 for
+%                     indirect dimensions and 2 for the direct dimension
+%
+% Outputs:
+%
+%    parameters     - Spinach parameter structure containing sweep,
+%                     npoints, offset, axis_units, timestep, and acq_time
+%
+% The input structures may use any capitalization of SW_h, SW, SFO1,
+% O1, and TD field names. SW_h is preferred; SW*SFO1 is the fallback.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=bruker2acq.m>
+
+function parameters=bruker2acq(acqus,point_factors)
+
+% Normalize the dimension list
+if isstruct(acqus), acqus={acqus}; end
+
+% Set default point conversion factors
+if nargin==1
+    point_factors=ones(1,numel(acqus));
+    point_factors(end)=2;
+end
+
+% Check consistency
+grumble(acqus,point_factors);
+
+% Preallocate outputs
+n_dims=numel(acqus);
+parameters.sweep=zeros(1,n_dims);
+parameters.npoints=zeros(1,n_dims);
+parameters.offset=zeros(1,n_dims);
+parameters.timestep=zeros(1,n_dims);
+parameters.acq_time=zeros(1,n_dims);
+
+% Translate each acquisition dimension
+for n=1:n_dims
+
+    % Spectral width in Hz
+    sweep=getpar(acqus{n},'SW_h',[]);
+    if isempty(sweep)
+        sweep=getpar(acqus{n},'SW',[])*getpar(acqus{n},'SFO1',[]);
+    end
+
+    % Point count and transmitter offset
+    npoints=getpar(acqus{n},'TD',[])/point_factors(n);
+    offset=getpar(acqus{n},'O1',0);
+
+    % Store Spinach acquisition settings
+    parameters.sweep(n)=sweep;
+    parameters.npoints(n)=npoints;
+    parameters.offset(n)=offset;
+    parameters.timestep(n)=1/sweep;
+    parameters.acq_time(n)=(npoints-1)/sweep;
+
+end
+
+% Default frequency axis convention
+parameters.axis_units='ppm';
+
+end
+
+% Case-insensitive structure field lookup
+function value=getpar(source,name,default)
+fields=fieldnames(source);
+index=find(strcmpi(fields,name),1);
+if isempty(index)
+    value=default;
+else
+    value=source.(fields{index});
+end
+end
+
+% Consistency enforcement
+function grumble(acqus,point_factors)
+if (~iscell(acqus))||isempty(acqus)||any(~cellfun(@isstruct,acqus))
+    error('acqus must be a structure or a non-empty cell array of structures.');
+end
+if (~isnumeric(point_factors))||(~isreal(point_factors))||...
+   (~isrow(point_factors))||(numel(point_factors)~=numel(acqus))||...
+   any(~isfinite(point_factors))||any(point_factors<=0)||...
+   any(mod(point_factors,1)~=0)
+    error('point_factors must contain one positive integer per dimension.');
+end
+for n=1:numel(acqus)
+    sw_h=getpar(acqus{n},'SW_h',[]);
+    sw=getpar(acqus{n},'SW',[]);
+    sfo1=getpar(acqus{n},'SFO1',[]);
+    td=getpar(acqus{n},'TD',[]);
+    o1=getpar(acqus{n},'O1',0);
+    if isempty(sw_h)&&(isempty(sw)||isempty(sfo1))
+        error('each acquisition structure must contain SW_h or both SW and SFO1.');
+    end
+    if (~isempty(sw_h))&&((~isnumeric(sw_h))||(~isreal(sw_h))||...
+       (~isscalar(sw_h))||(~isfinite(sw_h))||(sw_h<=0))
+        error('SW_h values must be positive real finite scalars.');
+    end
+    if isempty(sw_h)&&((~isnumeric(sw))||(~isreal(sw))||(~isscalar(sw))||...
+       (~isfinite(sw))||(sw<=0)||(~isnumeric(sfo1))||(~isreal(sfo1))||...
+       (~isscalar(sfo1))||(~isfinite(sfo1))||(sfo1<=0))
+        error('SW and SFO1 values must be positive real finite scalars.');
+    end
+    if isempty(td)||(~isnumeric(td))||(~isreal(td))||(~isscalar(td))||...
+       (~isfinite(td))||(td<=0)||(mod(td,point_factors(n))~=0)
+        error('TD values must be positive integers divisible by point_factors.');
+    end
+    if (~isnumeric(o1))||(~isreal(o1))||(~isscalar(o1))||(~isfinite(o1))
+        error('O1 values must be real finite scalars.');
+    end
+end
+end
+
+% The nice thing about standards is that there are so many to choose from.
+%
+% Andrew S. Tanenbaum
+
+

--- a/interfaces/bruker/bruker2proc.m
+++ b/interfaces/bruker/bruker2proc.m
@@ -112,9 +112,8 @@ for n=1:numel(procs)
        (~isfinite(wdw))||(mod(wdw,1)~=0)
         error('WDW values must be real finite integer scalars.');
     end
-    if (~isnumeric(lb))||(~isreal(lb))||(~isscalar(lb))||...
-       (~isfinite(lb))||(lb<0)
-        error('LB values must be non-negative real finite scalars.');
+    if (~isnumeric(lb))||(~isreal(lb))||(~isscalar(lb))||(~isfinite(lb))
+        error('LB values must be real finite scalars.');
     end
     axis_fields={axis_edge,obs_freq,proc_sweep};
     if any(cellfun(@isempty,axis_fields))&&(~all(cellfun(@isempty,axis_fields)))

--- a/interfaces/bruker/bruker2proc.m
+++ b/interfaces/bruker/bruker2proc.m
@@ -1,0 +1,138 @@
+% Translates Bruker processing parameters into fields used by Spinach
+% examples for apodisation and Fourier transformation. Syntax:
+%
+%            parameters=bruker2proc(procs,parameters)
+%
+% Parameters:
+%
+%    procs       - Bruker processing parameter structure, or a cell
+%                  array of structures ordered from the slowest to
+%                  the directly detected dimension
+%
+%    parameters  - Spinach pulse sequence parameter structure produced
+%                  by bruker2acq()
+%
+% Outputs:
+%
+%    parameters  - input structure augmented with zerofill and
+%                  apodisation fields; offset is updated from OFFSET,
+%                  SF, and SW_p when those fields are present
+%
+% Bruker WDW values 0 (no window) and 1 (exponential) are supported.
+% Exponential LB values in Hz are converted into the dimensionless
+% coefficient expected by Spinach apodisation().
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=bruker2proc.m>
+
+function parameters=bruker2proc(procs,parameters)
+
+% Normalize the dimension list
+if isstruct(procs), procs={procs}; end
+
+% Check consistency
+grumble(procs,parameters);
+
+% Preallocate outputs
+n_dims=numel(procs);
+parameters.zerofill=zeros(1,n_dims);
+parameters.apodisation=cell(1,n_dims);
+
+% Translate each processing dimension
+for n=1:n_dims
+
+    % Fourier transform size
+    parameters.zerofill(n)=getpar(procs{n},'SI',[]);
+
+    % Processed spectral axis centre
+    axis_edge=getpar(procs{n},'OFFSET',[]);
+    obs_freq=getpar(procs{n},'SF',[]);
+    proc_sweep=getpar(procs{n},'SW_p',[]);
+    if (~isempty(axis_edge))&&(~isempty(obs_freq))&&(~isempty(proc_sweep))
+        parameters.offset(n)=axis_edge*obs_freq-proc_sweep/2;
+    end
+
+    % Apodisation specification
+    window=getpar(procs{n},'WDW',0);
+    switch window
+        case 0
+            parameters.apodisation{n}={'none'};
+        case 1
+            line_broadening=getpar(procs{n},'LB',0);
+            parameters.apodisation{n}={'exp',pi*line_broadening*...
+                                            parameters.acq_time(n)};
+        otherwise
+            error('only Bruker WDW values 0 and 1 are currently supported.');
+    end
+
+end
+
+end
+
+% Case-insensitive structure field lookup
+function value=getpar(source,name,default)
+fields=fieldnames(source);
+index=find(strcmpi(fields,name),1);
+if isempty(index)
+    value=default;
+else
+    value=source.(fields{index});
+end
+end
+
+% Consistency enforcement
+function grumble(procs,parameters)
+if (~iscell(procs))||isempty(procs)||any(~cellfun(@isstruct,procs))
+    error('procs must be a structure or a non-empty cell array of structures.');
+end
+if (~isstruct(parameters))||(~isfield(parameters,'sweep'))||...
+   (~isfield(parameters,'npoints'))||(~isfield(parameters,'offset'))||...
+   (~isfield(parameters,'acq_time'))
+    error('parameters must be a structure produced by bruker2acq().');
+end
+if (numel(parameters.sweep)~=numel(procs))||...
+   (numel(parameters.npoints)~=numel(procs))||...
+   (numel(parameters.offset)~=numel(procs))||...
+   (numel(parameters.acq_time)~=numel(procs))
+    error('the number of processing dimensions must match the acquisition dimensions.');
+end
+for n=1:numel(procs)
+    si=getpar(procs{n},'SI',[]);
+    wdw=getpar(procs{n},'WDW',0);
+    lb=getpar(procs{n},'LB',0);
+    axis_edge=getpar(procs{n},'OFFSET',[]);
+    obs_freq=getpar(procs{n},'SF',[]);
+    proc_sweep=getpar(procs{n},'SW_p',[]);
+    if isempty(si)||(~isnumeric(si))||(~isreal(si))||(~isscalar(si))||...
+       (~isfinite(si))||(si<parameters.npoints(n))||(mod(si,1)~=0)
+        error('SI values must be positive integers not smaller than npoints.');
+    end
+    if (~isnumeric(wdw))||(~isreal(wdw))||(~isscalar(wdw))||...
+       (~isfinite(wdw))||(mod(wdw,1)~=0)
+        error('WDW values must be real finite integer scalars.');
+    end
+    if (~isnumeric(lb))||(~isreal(lb))||(~isscalar(lb))||...
+       (~isfinite(lb))||(lb<0)
+        error('LB values must be non-negative real finite scalars.');
+    end
+    axis_fields={axis_edge,obs_freq,proc_sweep};
+    if any(cellfun(@isempty,axis_fields))&&(~all(cellfun(@isempty,axis_fields)))
+        error('OFFSET, SF, and SW_p must either all be present or all be absent.');
+    end
+    if ~all(cellfun(@isempty,axis_fields))
+        axis_values=[axis_edge obs_freq proc_sweep];
+        if (~isnumeric(axis_values))||(~isreal(axis_values))||...
+           (numel(axis_values)~=3)||any(~isfinite(axis_values))||...
+           (obs_freq<=0)||(proc_sweep<=0)
+            error('OFFSET, SF, and SW_p must be real finite scalars with positive SF and SW_p.');
+        end
+    end
+end
+end
+
+% All models are wrong, but some are useful.
+%
+% George E. P. Box
+
+


### PR DESCRIPTION
## Summary
- add translation of Bruker acquisition fields into Spinach sweep, point-count, offset, timestep, and acquisition-time settings
- add translation of processing size, processed-axis centre, and supported apodisation settings
- support multidimensional parameter structures in Spinach dimension order

## Validation
- MATLAB synthetic two-dimensional acquisition and processing probe
- MATLAB `checkcode` on both new functions