### PR TITLE
coherence.m: reinstate coherence-specification grumbler for the new options

### DIFF
--- a/kernel/coherence.m
+++ b/kernel/coherence.m
@@ -114,6 +114,28 @@ end
 if ~iscell(spec)
     error('spec must be a cell array of cell arrays, e.g. {{''13C'',[1 -1]},{''1H'',-1}}');
 end
+for n=1:numel(spec)
+    if (~iscell(spec{n}))||(numel(spec{n})~=2)
+        error('each element of spec must be a two-element cell array.');
+    end
+    if ischar(spec{n}{1})
+        if (~ismember(spec{n}{1},{'all','electrons','nuclei'}))&&...
+           (~ismember(spec{n}{1},spin_system.comp.isotopes))
+            error('spec spin string must be ''all'', ''electrons'', ''nuclei'', or an isotope present in the system.');
+        end
+    elseif isnumeric(spec{n}{1})
+        if (~isreal(spec{n}{1}))||any(spec{n}{1}<1)||...
+           any(mod(spec{n}{1},1)~=0)||any(spec{n}{1}>spin_system.comp.nspins)
+            error('spin numbers in spec must be positive integers within the system bounds.');
+        end
+    else
+        error('spin specification in spec must be ''all'', ''electrons'', ''nuclei'', an isotope string, or a vector of spin numbers.');
+    end
+    if (~isnumeric(spec{n}{2}))||(~isreal(spec{n}{2}))||...
+       any(mod(spec{n}{2},1)~=0)
+        error('coherence orders in spec must be real integers.');
+    end
+end
 end
 
 % There was a time when men were afraid that somebody would reveal

--- a/kernel/coherence.m
+++ b/kernel/coherence.m
@@ -124,16 +124,16 @@ for n=1:numel(spec)
             error('spec spin string must be ''all'', ''electrons'', ''nuclei'', or an isotope present in the system.');
         end
     elseif isnumeric(spec{n}{1})
-        if (~isreal(spec{n}{1}))||any(spec{n}{1}<1)||...
+        if (~isvector(spec{n}{1}))||(~isreal(spec{n}{1}))||any(spec{n}{1}<1)||...
            any(mod(spec{n}{1},1)~=0)||any(spec{n}{1}>spin_system.comp.nspins)
-            error('spin numbers in spec must be positive integers within the system bounds.');
+            error('spin numbers in spec must be a vector of positive integers within the system bounds.');
         end
     else
         error('spin specification in spec must be ''all'', ''electrons'', ''nuclei'', an isotope string, or a vector of spin numbers.');
     end
-    if (~isnumeric(spec{n}{2}))||(~isreal(spec{n}{2}))||...
+    if (~isnumeric(spec{n}{2}))||(~isvector(spec{n}{2}))||(~isreal(spec{n}{2}))||...
        any(mod(spec{n}{2},1)~=0)
-        error('coherence orders in spec must be real integers.');
+        error('coherence orders in spec must be a vector of real integers.');
     end
 end
 end


### PR DESCRIPTION
## Summary

The per-element validation of `spec` in `coherence.m` was removed in 6069df6 when the more sophisticated coherence selection (`'electrons'` / `'nuclei'` keywords) was introduced — the old block only accepted `'all'` or an isotope string and would have rejected the new keywords.

This reinstates the grumbler block, updated for the current option set. For each element of `spec` it now checks:

- the element is a two-element cell `{spin_spec, order_list}`;
- `spin_spec` is `'all'`, `'electrons'`, `'nuclei'`, an isotope present in the system, or a vector of positive-integer spin indices within the system bounds;
- `order_list` is a real, integer coherence-order vector.

## Validation

- `checkcode` clean on `coherence.m`.
- Probe: valid specifications (`'nuclei'`, `'electrons'`, `'all'`, an isotope, and numeric spin vectors) pass and run; seven malformed specifications (unknown isotope, non-integer order, non-integer spin index, out-of-bounds index, one-element cell, three-element cell, non-cell element) are each rejected.
