### PR TITLE
endor_phenyl.m: explicit literature parameters so the S2xS2 symmetry is valid

### DIFF
--- a/examples/esr_liq_pulsed/endor_phenyl.m
+++ b/examples/esr_liq_pulsed/endor_phenyl.m
@@ -20,15 +20,17 @@ sys.magnet=0.33;
 sys.isotopes={'E','1H','1H','1H','1H','1H'};
 
 % Phenyl radical isotropic g-factor
-inter.zeeman.scalar={2.0024 0 0 0 0 0};
+g_phenyl=2.0024;
+inter.zeeman.scalar={g_phenyl 0 0 0 0 0};
 
 % Isotropic proton hyperfine couplings, converted from milliTesla
+% using the phenyl radical g-factor
 inter.coupling.scalar=cell(6,6);
-inter.coupling.scalar{2,1}=mt2hz(1.74);
-inter.coupling.scalar{3,1}=mt2hz(1.74);
-inter.coupling.scalar{4,1}=mt2hz(0.59);
-inter.coupling.scalar{5,1}=mt2hz(0.59);
-inter.coupling.scalar{6,1}=mt2hz(0.19);
+inter.coupling.scalar{2,1}=mt2hz(1.74,g_phenyl);
+inter.coupling.scalar{3,1}=mt2hz(1.74,g_phenyl);
+inter.coupling.scalar{4,1}=mt2hz(0.59,g_phenyl);
+inter.coupling.scalar{5,1}=mt2hz(0.59,g_phenyl);
+inter.coupling.scalar{6,1}=mt2hz(0.19,g_phenyl);
 
 % Basis set
 bas.formalism='sphten-liouv';

--- a/examples/esr_liq_pulsed/endor_phenyl.m
+++ b/examples/esr_liq_pulsed/endor_phenyl.m
@@ -1,6 +1,10 @@
-% Mims ENDOR on a phenyl radical in liquid state. Magnetic parameters taken
-% from a DFT calculation. Full symmetry treatment is performed using S2xS2
-% group direct product.
+% Mims ENDOR on a phenyl radical in liquid state. The g-factor and the
+% isotropic proton hyperfine couplings are specified explicitly from the
+% experimental data of Kasai, Hedaya, and Whipple (J. Am. Chem. Soc.
+% 1969, 91, 4364): a(ortho)=17.4 G, a(meta)=5.9 G, a(para)=1.9 G, and an
+% isotropic g-factor of 2.0024. The two ortho and the two meta protons
+% are magnetically equivalent, so the full symmetry treatment uses an
+% S2 x S2 group direct product.
 %
 % Calculation time: seconds
 %
@@ -9,22 +13,30 @@
 
 function endor_phenyl()
 
-% Ignore coordinate information (HFCs provided)
-options.no_xyz=1;
-
-% Load the spin system (vacuum DFT calculation)
-[sys,inter]=g2spinach(gparse('../standard_systems/phenyl.log'),...
-                     {{'E','E'},{'H','1H'}},[0 0],options);
 % Magnet field
 sys.magnet=0.33;
+
+% Electron and the five ring protons (two ortho, two meta, one para)
+sys.isotopes={'E','1H','1H','1H','1H','1H'};
+
+% Phenyl radical isotropic g-factor
+inter.zeeman.scalar={2.0024 0 0 0 0 0};
+
+% Isotropic proton hyperfine couplings, converted from milliTesla
+inter.coupling.scalar=cell(6,6);
+inter.coupling.scalar{2,1}=mt2hz(1.74);
+inter.coupling.scalar{3,1}=mt2hz(1.74);
+inter.coupling.scalar{4,1}=mt2hz(0.59);
+inter.coupling.scalar{5,1}=mt2hz(0.59);
+inter.coupling.scalar{6,1}=mt2hz(0.19);
 
 % Basis set
 bas.formalism='sphten-liouv';
 bas.approximation='none';
 
-% Symmetry
+% Symmetry: equivalent ortho pair and equivalent meta pair
 bas.sym_group={'S2','S2'};
-bas.sym_spins={[2 5],[3 4]};
+bas.sym_spins={[2 3],[4 5]};
 
 % Sequence parameters
 parameters.offset=0;


### PR DESCRIPTION
## Summary

`endor_phenyl.m` imported its magnetic parameters from a DFT calculation (`phenyl.log`). The DFT hyperfine tensors of the symmetry-related ring protons are only approximately equivalent — related by a spatial rotation and differing slightly even in their isotropic parts — so the declared `S2 x S2` permutation symmetry was not exactly satisfied.

This replaces the DFT import with an explicit specification of the phenyl radical:

- isotropic g-factor `2.0024`;
- isotropic ¹H hyperfine couplings `a(ortho)=17.4 G`, `a(meta)=5.9 G`, `a(para)=1.9 G`,

from the experimental data of Kasai, Hedaya, and Whipple (J. Am. Chem. Soc. 1969, 91, 4364), as tabulated by Barone et al. (J. Chem. Phys. 2013, 138, 234303). The two ortho and the two meta protons are given identical isotropic couplings, so the `S2 x S2` symmetry is now exactly valid.

## Validation

- `checkcode` clean on `endor_phenyl.m`.
- The system builds; the `S2 x S2` permutation symmetry passes strict validation (Zeeman, couplings, isotopes) and the basis factorisation is constructed.

This is the fix for one of the examples flagged by the interaction-symmetry validator (#184). The example is correct on its own; together with #184 it now passes validation instead of erroring.
