### PR TITLE
kill_spin.m: handle all per-spin subfields of spin_system

### DIFF
--- a/kernel/utilities/kill_spin.m
+++ b/kernel/utilities/kill_spin.m
@@ -17,9 +17,9 @@
 %                     ted spins and all dependent infor-
 %                     mation (basis, assumptions) removed
 %
-% Notes: basis and assumption information is destroyed by this
-%        function; you would need to call basis.m and assume.m
-%        again.
+% Notes: basis, connectivity, symmetry, and assumption information
+%        is destroyed by this function; you would need to call the
+%        basis.m and assume.m functions again.
 %
 % ilya.kuprov@weizmann.ac.il
 % ledwards@cbs.mpg.de
@@ -32,15 +32,18 @@ function spin_system=kill_spin(spin_system,hit_list)
 grumble(spin_system,hit_list)
 
 % Catch logical indexing
-if any(hit_list==0), hit_list=find(hit_list); end
+if islogical(hit_list), hit_list=find(hit_list); end
 
 % Inform the user
 report(spin_system,['removing ' num2str(numel(hit_list)) ...
                     ' spins from the system...']);
 
-% Update isotopes list and its hash
+% Update isotope and particle type lists
 spin_system.comp.isotopes(hit_list)=[];
-if ismember('op_cache',spin_system.sys.enable)
+spin_system.comp.types(hit_list)=[];
+
+% Update the isotope list hash
+if isfield(spin_system.comp,'iso_hash')
     spin_system.comp.iso_hash=md5_hash(spin_system.comp.isotopes);
 end
 
@@ -103,9 +106,16 @@ if ~isempty(spin_system.rlx.weiz_r2d)
     spin_system.rlx.weiz_r2d(:,hit_list)=[];
 end
 
+% Update scalar relaxation source spins
+if ~isempty(spin_system.rlx.srsk_sources)
+    srsk_spins=zeros(1,spin_system.comp.nspins+numel(hit_list));
+    srsk_spins(spin_system.rlx.srsk_sources)=1; srsk_spins(hit_list)=[];
+    spin_system.rlx.srsk_sources=find(srsk_spins);
+end
+
 % Update kinetics parameters
 for n=1:numel(spin_system.chem.parts)
-    subsystem_idx=false(1,spin_system.comp.nspins);
+    subsystem_idx=false(1,spin_system.comp.nspins+numel(hit_list));
     subsystem_idx(spin_system.chem.parts{n})=true();
     subsystem_idx(hit_list)=[];
     spin_system.chem.parts{n}=find(subsystem_idx);
@@ -129,9 +139,27 @@ if isfield(spin_system,'bas')
     report(spin_system,'WARNING - basis set information must be re-created.');
 end
 
+% If any connectivity information is found, destroy it
+if isfield(spin_system.inter,'conmatrix')
+    spin_system.inter=rmfield(spin_system.inter,'conmatrix');
+end
+
+% If any symmetry information is found, destroy it
+if isfield(spin_system.comp,'sym_group')
+    spin_system.comp=rmfield(spin_system.comp,{'sym_group','sym_spins','sym_a1g_only'});
+end
+
 % If any assumption information is found, destroy it
+if isfield(spin_system.inter,'assumptions')
+    spin_system.inter=rmfield(spin_system.inter,'assumptions');
+    report(spin_system,'WARNING - assumption information must be re-created.');
+end
 if isfield(spin_system.inter.zeeman,'strength')
     spin_system.inter.zeeman=rmfield(spin_system.inter.zeeman,'strength');
+    report(spin_system,'WARNING - assumption information must be re-created.');
+end
+if isfield(spin_system.inter.giant,'strength')
+    spin_system.inter.giant=rmfield(spin_system.inter.giant,'strength');
     report(spin_system,'WARNING - assumption information must be re-created.');
 end
 if isfield(spin_system.inter.coupling,'strength')
@@ -148,8 +176,8 @@ if islogical(hit_list)
         error('the size of the hit mask does not match the number of spins in the system.');
     end
 else
-    if (~isnumeric(hit_list))||any(hit_list<1)
-        error('hit_list must be a logical matrix or an array of positive numbers.');
+    if (~isnumeric(hit_list))||any(hit_list<1)||any(mod(hit_list,1)~=0)
+        error('hit_list must be a logical mask or an array of positive integers.');
     end
     if any(hit_list>spin_system.comp.nspins)
         error('at least one number in hit_list exceeds the number of spins.');
@@ -162,4 +190,5 @@ end
 % a bath house.
 %
 % David Hilbert, about Emmy Noether, in 1915.
+
 

--- a/tests/kernel/test_dynamic_spin_edit_suite.m
+++ b/tests/kernel/test_dynamic_spin_edit_suite.m
@@ -34,6 +34,33 @@ result=test_true(result,'kill_spin numeric dimensions',numel(trimmed.inter.coord
                  'coordinate, coupling, and proximity arrays must shrink with the spin count');
 result=test_true(result,'kill_spin chemical part update',isequal(trimmed.chem.parts,{[1 2]}),...
                  'chemical part indices must be renumbered after a spin is removed');
+result=test_true(result,'kill_spin particle types',isequal(trimmed.comp.types,{'S','S'}),...
+                 'particle type codes must shrink with the spin count');
+result=test_true(result,'kill_spin isotope hash',strcmp(trimmed.comp.iso_hash,md5_hash({'1H','13C'})),...
+                 'the isotope list hash must be recomputed after spin removal');
+result=test_true(result,'kill_spin SRSK sources',isequal(trimmed.rlx.srsk_sources,[1 2]),...
+                 'scalar relaxation source spins must be renumbered after spin removal');
+
+% Check chemical part renumbering across multiple subsystems
+multipart=spin_system; multipart.chem.parts={[1 2],3};
+multipart=kill_spin(multipart,3);
+result=test_true(result,'kill_spin multi-part update',isequal(multipart.chem.parts,{[1 2],zeros(1,0)}),...
+                 'killing the last spin must renumber every chemical subsystem without an error');
+
+% Check destruction of stale basis, connectivity, symmetry, and assumption data
+stale=spin_system; stale.bas.formalism='sphten-liouv';
+stale.inter.conmatrix=logical(speye(3));
+stale.comp.sym_group={'S2'}; stale.comp.sym_spins={[2 3]}; stale.comp.sym_a1g_only=true();
+stale.inter.assumptions='nmr';
+stale.inter.zeeman.strength={'secular','secular','secular'};
+stale.inter.giant.strength={[],[],[]};
+stale.inter.coupling.strength=cell(3,3);
+stale=kill_spin(stale,2);
+result=test_true(result,'kill_spin stale metadata',~isfield(stale,'bas')&&...
+                 ~isfield(stale.inter,'conmatrix')&&~isfield(stale.comp,'sym_group')&&...
+                 ~isfield(stale.inter,'assumptions')&&~isfield(stale.inter.zeeman,'strength')&&...
+                 ~isfield(stale.inter.giant,'strength')&&~isfield(stale.inter.coupling,'strength'),...
+                 'basis, connectivity, symmetry, and assumption data must be destroyed on spin removal');
 
 % Check logical spin removal follows the same path
 logical_trimmed=kill_spin(spin_system,[false true false]);
@@ -82,6 +109,7 @@ spin_system.sys.disable={};
 % Define spin identities and basis-independent metadata
 spin_system.comp.nspins=3;
 spin_system.comp.isotopes={'1H','13C','13C'};
+spin_system.comp.types={'S','S','S'};
 spin_system.comp.labels={'h','c1','c2'};
 spin_system.comp.mults=[2 2 2];
 spin_system.comp.iso_hash='unused';
@@ -104,6 +132,7 @@ spin_system.rlx.lind_r2_rates=[];
 spin_system.rlx.srfk_mdepth=[];
 spin_system.rlx.weiz_r1d=[];
 spin_system.rlx.weiz_r2d=[];
+spin_system.rlx.srsk_sources=[1 3];
 
 % Define chemistry arrays affected by spin removal
 spin_system.chem.parts={[1 2 3]};


### PR DESCRIPTION
## Summary

A global analysis of every `spin_system` writer (`create.m`, `assume.m`, `basis.m`, `symmetry.m`, `dipolar.m`, `relaxation.m`) found per-spin state that `kill_spin.m` left stale when deleting spins. The function now:

- trims `comp.types` — per-particle codes ('S' spin, 'C' cavity, 'V' phonon, 'T' transmon); previously left at the wrong length, corrupting boson-mode systems after a kill
- renumbers `rlx.srsk_sources` (same indicator-vector idiom as `chem.rp_electrons`)
- refreshes `comp.iso_hash` whenever the field exists, not only under `op_cache`, so `ham_cache` keys cannot go stale
- destroys stale basis-time artefacts (`inter.conmatrix`, `comp.sym_group/sym_spins/sym_a1g_only`) and assume-time state (`inter.assumptions`, `inter.giant.strength`) alongside `bas` and the other strength fields
- sizes the `chem.parts` scratch mask with the pre-kill spin count, fixing "Matrix index is out of range for deletion" on multi-part chemistry
- normalises logical masks with `islogical` (the old `any(hit_list==0)` test missed all-true masks) and rejects non-integer hit lists in the grumbler

Fields confirmed global and deliberately untouched: `damp_rate`, `dfs`, `tau_c`, Weizmann/Nottingham e/n rates, `order_matrix`, `pbc`; `inter.duffing` is commented out in `create.m`.

## Validation

- `checkcode` clean on both files; regression suite `tests/kernel/test_dynamic_spin_edit_suite.m` extended with fixture fields and assertions for every new behaviour — 14/14 pass on this head
- Structural equivalence: `kill_spin` output is field-for-field identical to a direct `create()` of the reduced system in liquid (Redfield+SRSK), radical-pair, and cavity-mode contexts; essential-electron kills are still refused; strcmp-mask and numeric kills agree; invalid hit lists refused
- Physics: styrene 1D (zeeman-hilb) and MAS powder Floquet fids are bitwise identical after adding-then-killing a dummy spin; natural-abundance sucrose HSQC runs `dilute` → `kill_spin` over 12 isotopomers cleanly; post-basis kill → re-basis → acquire works, with stale metadata verified gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)