### PR TITLE
merge_inp.m: handle all legal sys and inter input subfields

### DIFF
--- a/kernel/utilities/merge_inp.m
+++ b/kernel/utilities/merge_inp.m
@@ -25,7 +25,10 @@
 %       any difference is treated as an error. Nested groups
 %       (zeeman, coupling, giant, suscept, chem) and every field
 %       must be present in all subsystems or in none. An error is
-%       thrown for unhandled subfields.
+%       thrown for unhandled subfields. Coordinates and suscepti-
+%       bility centres from all subsystems are assumed to refer
+%       to one common frame of reference; spin index lists are
+%       returned as row vectors.
 %
 % ilya.kuprov@weizmann.ac.il
 % a.acharya@soton.ac.uk
@@ -63,8 +66,9 @@ for n=1:numel(inter_common)
     [inter,inter_parts]=merge_like_magnet(inter,inter_parts,inter_common{n});
 end
 
-% Fields that are per chemical species when chemistry is present
-if group_check(inter_parts,'chem')
+% Fields that are per chemical species when a species split is present
+if group_check(inter_parts,'chem')&&...
+   all(cellfun(@(x)isfield(x.chem,'parts'),inter_parts))
     [inter,inter_parts]=merge_like_isotopes(inter,inter_parts,'tau_c');
     [inter,inter_parts]=merge_like_isotopes(inter,inter_parts,'order_matrix');
 else
@@ -351,14 +355,15 @@ end
 function [spec,spec_parts]=merge_like_sources(spec,spec_parts,field_name,part_sizes)
 offsets=cumsum([0 part_sizes(1:end-1)]);
 if isfield(spec_parts{1},field_name)
-    spec.(field_name)=spec_parts{1}.(field_name);
+    spec.(field_name)=reshape(spec_parts{1}.(field_name),1,[]);
     spec_parts{1}=rmfield(spec_parts{1},field_name);
     for n=2:numel(spec_parts)
         if isfield(spec_parts{n},field_name)
             if ~isfield(spec,field_name)
                 error([field_name ' is not present in all subsystems.']);
             else
-                spec.(field_name)=[spec.(field_name) spec_parts{n}.(field_name)+offsets(n)];
+                spec.(field_name)=[spec.(field_name) ...
+                                   reshape(spec_parts{n}.(field_name),1,[])+offsets(n)];
                 spec_parts{n}=rmfield(spec_parts{n},field_name);
             end
         else
@@ -380,14 +385,15 @@ end
 function [spec,spec_parts]=merge_like_parts(spec,spec_parts,field_name,part_sizes)
 offsets=cumsum([0 part_sizes(1:end-1)]);
 if isfield(spec_parts{1},field_name)
-    spec.(field_name)=spec_parts{1}.(field_name);
+    spec.(field_name)=reshape(spec_parts{1}.(field_name),1,[]);
     spec_parts{1}=rmfield(spec_parts{1},field_name);
     for n=2:numel(spec_parts)
         if isfield(spec_parts{n},field_name)
             if ~isfield(spec,field_name)
                 error([field_name ' is not present in all subsystems.']);
             else
-                shifted=cellfun(@(x)x+offsets(n),spec_parts{n}.(field_name),...
+                shifted=cellfun(@(x)x+offsets(n),...
+                                reshape(spec_parts{n}.(field_name),1,[]),...
                                 'UniformOutput',false);
                 spec.(field_name)=[spec.(field_name) shifted];
                 spec_parts{n}=rmfield(spec_parts{n},field_name);

--- a/kernel/utilities/merge_inp.m
+++ b/kernel/utilities/merge_inp.m
@@ -18,8 +18,14 @@
 %
 %    inter       - resulting inter structure
 %
-% Note: incomplete, an error is thrown for unhandled subfields,
-%       extend as appropriate.
+% Note: extensive fields are concatenated with spin and chemical
+%       subsystem indices offset as appropriate; non-extensive
+%       fields (magnet, temperature, relaxation settings, etc.)
+%       must be identical in all subsystems that supply them, and
+%       any difference is treated as an error. Nested groups
+%       (zeeman, coupling, giant, suscept, chem) and every field
+%       must be present in all subsystems or in none. An error is
+%       thrown for unhandled subfields.
 %
 % ilya.kuprov@weizmann.ac.il
 % a.acharya@soton.ac.uk
@@ -29,40 +35,128 @@
 function [sys,inter]=merge_inp(sys_parts,inter_parts)
 
 % Check consistency
-grumble(sys_parts,inter_parts); 
+grumble(sys_parts,inter_parts);
+
+% Count the spins in each subsystem
+part_sizes=cellfun(@(x)numel(x.isotopes),sys_parts);
 
 % Create structure stubs
 sys.stub=1; inter.stub=1;
 
-% Fields containing common scalars that are equal 
-[sys,sys_parts]=merge_like_magnet(sys,sys_parts,'magnet');
+% Fields containing common values that must be equal
+sys_common={'magnet','output','scratch','enable',...
+            'disable','tols','parallel','parprops'};
+for n=1:numel(sys_common)
+    [sys,sys_parts]=merge_like_magnet(sys,sys_parts,sys_common{n});
+end
 
 % Fields containing row cell arrays
 [sys,sys_parts]=merge_like_isotopes(sys,sys_parts,'isotopes');
 [sys,sys_parts]=merge_like_isotopes(sys,sys_parts,'labels');
 
+% Fields containing common values that must be equal
+inter_common={'relaxation','rlx_keep','rlx_dfs','equilibrium',...
+              'temperature','damp_rate','srfk_tau_c',...
+              'weiz_r1e','weiz_r2e','weiz_r1n','weiz_r2n',...
+              'nott_r1e','nott_r2e','nott_r1n','nott_r2n','pbc'};
+for n=1:numel(inter_common)
+    [inter,inter_parts]=merge_like_magnet(inter,inter_parts,inter_common{n});
+end
+
+% Fields that are per chemical species when chemistry is present
+if group_check(inter_parts,'chem')
+    [inter,inter_parts]=merge_like_isotopes(inter,inter_parts,'tau_c');
+    [inter,inter_parts]=merge_like_isotopes(inter,inter_parts,'order_matrix');
+else
+    [inter,inter_parts]=merge_like_magnet(inter,inter_parts,'tau_c');
+    [inter,inter_parts]=merge_like_magnet(inter,inter_parts,'order_matrix');
+end
+
 % Fields containing column cell arrays
 [inter,inter_parts]=merge_like_coords(inter,inter_parts,'coordinates');
 
+% Fields containing per-spin relaxation rates
+inter_rates={'r1_rates','r2_rates','lind_r1_rates','lind_r2_rates'};
+for n=1:numel(inter_rates)
+    [inter,inter_parts]=merge_like_rates(inter,inter_parts,inter_rates{n});
+end
+
+% Fields containing square arrays over spin pairs
+inter_square={'srfk_mdepth','weiz_r1d','weiz_r2d'};
+for n=1:numel(inter_square)
+    [inter,inter_parts]=merge_like_couplings(inter,inter_parts,inter_square{n});
+end
+
+% Fields containing spin index vectors
+[inter,inter_parts]=merge_like_sources(inter,inter_parts,'srsk_sources',part_sizes);
+
+% Fields containing cell arrays of spin index vectors
+[inter,inter_parts]=merge_like_parts(inter,inter_parts,'ignore',part_sizes);
+
 % Zeeman interaction specifications
-zeeman_parts=strip(inter_parts,'zeeman'); zeeman.stub=1;
-zeeman=merge_like_isotopes(zeeman,zeeman_parts,'matrix');
-zeeman=merge_like_isotopes(zeeman,zeeman_parts,'scalar');
-zeeman=merge_like_isotopes(zeeman,zeeman_parts,'eigs');
-zeeman=merge_like_isotopes(zeeman,zeeman_parts,'euler');
-zeeman=rmfield(zeeman,'stub'); inter.zeeman=zeeman;
-inter_parts=cellfun(@(x)rmfield(x,'zeeman'),...
-                    inter_parts,'UniformOutput',false);
+if group_check(inter_parts,'zeeman')
+    zeeman_parts=strip(inter_parts,'zeeman'); zeeman.stub=1;
+    [zeeman,zeeman_parts]=merge_like_isotopes(zeeman,zeeman_parts,'matrix');
+    [zeeman,zeeman_parts]=merge_like_isotopes(zeeman,zeeman_parts,'scalar');
+    [zeeman,zeeman_parts]=merge_like_isotopes(zeeman,zeeman_parts,'eigs');
+    [zeeman,zeeman_parts]=merge_like_isotopes(zeeman,zeeman_parts,'euler');
+    group_gate(zeeman_parts,'zeeman');
+    zeeman=rmfield(zeeman,'stub'); inter.zeeman=zeeman;
+    inter_parts=cellfun(@(x)rmfield(x,'zeeman'),...
+                        inter_parts,'UniformOutput',false);
+end
 
 % Coupling specifications
-coupling_parts=strip(inter_parts,'coupling'); coupling.stub=1;
-coupling=merge_like_couplings(coupling,coupling_parts,'matrix');
-coupling=merge_like_couplings(coupling,coupling_parts,'scalar');
-coupling=merge_like_couplings(coupling,coupling_parts,'eigs');
-coupling=merge_like_couplings(coupling,coupling_parts,'euler');
-coupling=rmfield(coupling,'stub'); inter.coupling=coupling;
-inter_parts=cellfun(@(x)rmfield(x,'coupling'),...
-                    inter_parts,'UniformOutput',false);
+if group_check(inter_parts,'coupling')
+    coupling_parts=strip(inter_parts,'coupling'); coupling.stub=1;
+    [coupling,coupling_parts]=merge_like_couplings(coupling,coupling_parts,'matrix');
+    [coupling,coupling_parts]=merge_like_couplings(coupling,coupling_parts,'scalar');
+    [coupling,coupling_parts]=merge_like_couplings(coupling,coupling_parts,'eigs');
+    [coupling,coupling_parts]=merge_like_couplings(coupling,coupling_parts,'euler');
+    group_gate(coupling_parts,'coupling');
+    coupling=rmfield(coupling,'stub'); inter.coupling=coupling;
+    inter_parts=cellfun(@(x)rmfield(x,'coupling'),...
+                        inter_parts,'UniformOutput',false);
+end
+
+% Giant spin interaction specifications
+if group_check(inter_parts,'giant')
+    giant_parts=strip(inter_parts,'giant'); giant.stub=1;
+    [giant,giant_parts]=merge_like_isotopes(giant,giant_parts,'coeff');
+    [giant,giant_parts]=merge_like_isotopes(giant,giant_parts,'euler');
+    group_gate(giant_parts,'giant');
+    giant=rmfield(giant,'stub'); inter.giant=giant;
+    inter_parts=cellfun(@(x)rmfield(x,'giant'),...
+                        inter_parts,'UniformOutput',false);
+end
+
+% Magnetic susceptibility centre specifications
+if group_check(inter_parts,'suscept')
+    suscept_parts=strip(inter_parts,'suscept'); suscept.stub=1;
+    [suscept,suscept_parts]=merge_like_isotopes(suscept,suscept_parts,'chi');
+    [suscept,suscept_parts]=merge_like_isotopes(suscept,suscept_parts,'xyz');
+    group_gate(suscept_parts,'suscept');
+    suscept=rmfield(suscept,'stub'); inter.suscept=suscept;
+    inter_parts=cellfun(@(x)rmfield(x,'suscept'),...
+                        inter_parts,'UniformOutput',false);
+end
+
+% Chemical process specifications
+if group_check(inter_parts,'chem')
+    chem_parts=strip(inter_parts,'chem'); chem.stub=1;
+    [chem,chem_parts]=merge_like_parts(chem,chem_parts,'parts',part_sizes);
+    [chem,chem_parts]=merge_like_couplings(chem,chem_parts,'rates');
+    [chem,chem_parts]=merge_like_isotopes(chem,chem_parts,'concs');
+    [chem,chem_parts]=merge_like_couplings(chem,chem_parts,'flux_rate');
+    [chem,chem_parts]=merge_like_magnet(chem,chem_parts,'flux_type');
+    [chem,chem_parts]=merge_like_magnet(chem,chem_parts,'rp_theory');
+    [chem,chem_parts]=merge_like_sources(chem,chem_parts,'rp_electrons',part_sizes);
+    [chem,chem_parts]=merge_like_magnet(chem,chem_parts,'rp_rates');
+    group_gate(chem_parts,'chem');
+    chem=rmfield(chem,'stub'); inter.chem=chem;
+    inter_parts=cellfun(@(x)rmfield(x,'chem'),...
+                        inter_parts,'UniformOutput',false);
+end
 
 % Catch unhandled subfields
 for n=1:numel(sys_parts)
@@ -81,12 +175,30 @@ sys=rmfield(sys,'stub'); inter=rmfield(inter,'stub');
 
 end
 
+% Check that a nested group is present in all subsystems or none
+function group_present=group_check(parts_array,group_name)
+present=cellfun(@(x)isfield(x,group_name),parts_array);
+if any(present)&&(~all(present))
+    error([group_name ' specification must be present in all subsystems or none.']);
+end
+group_present=all(present);
+end
+
+% Catch unhandled subfields inside a nested group
+function group_gate(group_parts,group_name)
+for n=1:numel(group_parts)
+    if ~isempty(fieldnames(group_parts{n}))
+        error(['unhandled subfield in inter.' group_name '.']);
+    end
+end
+end
+
 % Strip a common field from an array of structures
 function parts_array=strip(parts_array,field_name)
     parts_array=cellfun(@(x)x.(field_name),parts_array,'UniformOutput',false);
 end
 
-% Merge subsystem fields assuming they hold an optional common scalar
+% Merge subsystem fields assuming they hold an optional common value
 function [spec,spec_parts]=merge_like_magnet(spec,spec_parts,field_name)
 if isfield(spec_parts{1},field_name)
     spec.(field_name)=spec_parts{1}.(field_name);
@@ -94,7 +206,7 @@ if isfield(spec_parts{1},field_name)
     for n=2:numel(spec_parts)
         if isfield(spec_parts{n},field_name)
             if (~isfield(spec,field_name))||...
-               (spec_parts{n}.(field_name)~=spec.(field_name))
+               (~isequal(spec_parts{n}.(field_name),spec.(field_name)))
                 error(['values of ' field_name ' are not present or not the same in all subsystems.']);
             else
                 spec_parts{n}=rmfield(spec_parts{n},field_name);
@@ -170,7 +282,35 @@ else
 end
 end
 
-% Merge subsystem fields assuming optional square cell arrays
+% Merge subsystem fields assuming optional per-spin rate arrays
+function [spec,spec_parts]=merge_like_rates(spec,spec_parts,field_name)
+if isfield(spec_parts{1},field_name)
+    spec.(field_name)=spec_parts{1}.(field_name)(:);
+    spec_parts{1}=rmfield(spec_parts{1},field_name);
+    for n=2:numel(spec_parts)
+        if isfield(spec_parts{n},field_name)
+            if ~isfield(spec,field_name)
+                error([field_name ' is not present in all subsystems.']);
+            else
+                spec.(field_name)=[spec.(field_name); spec_parts{n}.(field_name)(:)];
+                spec_parts{n}=rmfield(spec_parts{n},field_name);
+            end
+        else
+            if isfield(spec,field_name)
+                error([field_name ' is not present in all subsystems.']);
+            end
+        end
+    end
+else
+    for n=2:numel(spec_parts)
+        if isfield(spec_parts{n},field_name)
+            error([field_name ' is not present in all subsystems.']);
+        end
+    end
+end
+end
+
+% Merge subsystem fields assuming optional square arrays
 function [spec,spec_parts]=merge_like_couplings(spec,spec_parts,field_name)
 if isfield(spec_parts{1},field_name)
     spec.(field_name)=spec_parts{1}.(field_name);
@@ -179,8 +319,77 @@ if isfield(spec_parts{1},field_name)
         if isfield(spec_parts{n},field_name)
             if ~isfield(spec,field_name)
                 error([field_name ' is not present in all subsystems.']);
+            elseif iscell(spec.(field_name))~=iscell(spec_parts{n}.(field_name))
+                error([field_name ' must be of the same type in all subsystems.']);
+            elseif iscell(spec.(field_name))
+                old_block=spec.(field_name); new_block=spec_parts{n}.(field_name);
+                merged=cell(size(old_block,1)+size(new_block,1));
+                merged(1:size(old_block,1),1:size(old_block,1))=old_block;
+                merged((size(old_block,1)+1):end,(size(old_block,1)+1):end)=new_block;
+                spec.(field_name)=merged;
+                spec_parts{n}=rmfield(spec_parts{n},field_name);
             else
                 spec.(field_name)=blkdiag(spec.(field_name),spec_parts{n}.(field_name));
+                spec_parts{n}=rmfield(spec_parts{n},field_name);
+            end
+        else
+            if isfield(spec,field_name)
+                error([field_name ' is not present in all subsystems.']);
+            end
+        end
+    end
+else
+    for n=2:numel(spec_parts)
+        if isfield(spec_parts{n},field_name)
+            error([field_name ' is not present in all subsystems.']);
+        end
+    end
+end
+end
+
+% Merge subsystem fields assuming optional spin index vectors
+function [spec,spec_parts]=merge_like_sources(spec,spec_parts,field_name,part_sizes)
+offsets=cumsum([0 part_sizes(1:end-1)]);
+if isfield(spec_parts{1},field_name)
+    spec.(field_name)=spec_parts{1}.(field_name);
+    spec_parts{1}=rmfield(spec_parts{1},field_name);
+    for n=2:numel(spec_parts)
+        if isfield(spec_parts{n},field_name)
+            if ~isfield(spec,field_name)
+                error([field_name ' is not present in all subsystems.']);
+            else
+                spec.(field_name)=[spec.(field_name) spec_parts{n}.(field_name)+offsets(n)];
+                spec_parts{n}=rmfield(spec_parts{n},field_name);
+            end
+        else
+            if isfield(spec,field_name)
+                error([field_name ' is not present in all subsystems.']);
+            end
+        end
+    end
+else
+    for n=2:numel(spec_parts)
+        if isfield(spec_parts{n},field_name)
+            error([field_name ' is not present in all subsystems.']);
+        end
+    end
+end
+end
+
+% Merge subsystem fields assuming optional cell arrays of spin index vectors
+function [spec,spec_parts]=merge_like_parts(spec,spec_parts,field_name,part_sizes)
+offsets=cumsum([0 part_sizes(1:end-1)]);
+if isfield(spec_parts{1},field_name)
+    spec.(field_name)=spec_parts{1}.(field_name);
+    spec_parts{1}=rmfield(spec_parts{1},field_name);
+    for n=2:numel(spec_parts)
+        if isfield(spec_parts{n},field_name)
+            if ~isfield(spec,field_name)
+                error([field_name ' is not present in all subsystems.']);
+            else
+                shifted=cellfun(@(x)x+offsets(n),spec_parts{n}.(field_name),...
+                                'UniformOutput',false);
+                spec.(field_name)=[spec.(field_name) shifted];
                 spec_parts{n}=rmfield(spec_parts{n},field_name);
             end
         else
@@ -203,6 +412,19 @@ function grumble(sys_parts,inter_parts)
 if (~iscell(sys_parts))||(~iscell(inter_parts))
     error('both inputs must be cell arrays of data structures.');
 end
+if numel(sys_parts)~=numel(inter_parts)
+    error('sys_parts and inter_parts must have the same number of elements.');
+end
+if isempty(sys_parts)
+    error('at least one subsystem must be supplied.');
+end
+if any(cellfun(@(x)(~isstruct(x)),sys_parts))||...
+   any(cellfun(@(x)(~isstruct(x)),inter_parts))
+    error('all elements of sys_parts and inter_parts must be structures.');
+end
+if any(cellfun(@(x)(~isfield(x,'isotopes')),sys_parts))
+    error('every sys structure must contain an isotopes subfield.');
+end
 end
 
 % Dicebant ergo Pilato pontifices Judaeorum: "Noli scribere
@@ -210,4 +432,5 @@ end
 % Respondit Pilatus: "Quod scripsi, scripsi."
 %
 % Ioannes 19:21-22
+
 

--- a/tests/kernel/test_dynamic_spin_edit_suite.m
+++ b/tests/kernel/test_dynamic_spin_edit_suite.m
@@ -95,7 +95,57 @@ result=test_true(result,'merge_inp sys fields',sys.magnet==14.1&&...
 result=test_true(result,'merge_inp coordinates',numel(inter.coordinates)==3&&...
                  isequal(inter.coordinates{1},[0 0 0])&&isequal(inter.coordinates{3},[0 1 0]),...
                  'merge_inp must concatenate coordinate column-cell fields in subsystem order');
+result=test_true(result,'merge_inp common values',isequal(inter.temperature,298)&&...
+                 isequal(inter.relaxation,{'redfield'})&&isequal(sys.enable,{'greedy'}),...
+                 'merge_inp must keep non-extensive fields that are identical in all subsystems');
+result=test_true(result,'merge_inp square blocks',isequal(size(inter.coupling.scalar),[3 3])&&...
+                 isequal(inter.coupling.scalar{2,3},5.0)&&isempty(inter.coupling.scalar{1,3})&&...
+                 isequal(inter.srfk_mdepth{3,2},7.0)&&isempty(inter.srfk_mdepth{1,2})&&...
+                 isequal(inter.weiz_r1d,blkdiag(0.1,[0 0.2; 0.2 0])),...
+                 'merge_inp must block-merge square fields with empty cell or zero numeric padding');
+result=test_true(result,'merge_inp rate arrays',isequal(inter.r1_rates,{0.1;0.2;0.3})&&...
+                 isequal(inter.r2_rates,{1.1;1.2;1.3}),...
+                 'merge_inp must merge per-spin rate cell arrays of either orientation into columns');
+result=test_true(result,'merge_inp index offsets',isequal(inter.srsk_sources,[1 3])&&...
+                 isequal(inter.ignore,{[2 3]})&&isequal(inter.chem.parts,{1,[2 3]})&&...
+                 isequal(inter.chem.rates,zeros(2))&&isequal(inter.chem.concs,[1 1]),...
+                 'merge_inp must offset spin and subsystem indices by preceding spin counts');
+result=test_true(result,'merge_inp suscept centres',isequal(inter.suscept.chi,{0.01*eye(3)})&&...
+                 isequal(inter.suscept.xyz,{[5 5 5]}),...
+                 'merge_inp must concatenate susceptibility centre lists across subsystems');
 
+% Check that non-extensive differences and malformed inputs are refused
+[sys_parts,inter_parts]=local_merge_parts();
+inter_parts{2}.temperature=300;
+result=test_true(result,'merge_inp value mismatch',local_merge_fails(sys_parts,inter_parts),...
+                 'differing non-extensive field values must be refused');
+[sys_parts,inter_parts]=local_merge_parts();
+inter_parts{2}=rmfield(inter_parts{2},'chem');
+result=test_true(result,'merge_inp partial group',local_merge_fails(sys_parts,inter_parts),...
+                 'a nested group present in only some subsystems must be refused');
+[sys_parts,inter_parts]=local_merge_parts();
+inter_parts{1}.bogus=1;
+result=test_true(result,'merge_inp unknown field',local_merge_fails(sys_parts,inter_parts),...
+                 'unknown inter subfields must be refused');
+[sys_parts,inter_parts]=local_merge_parts();
+inter_parts{2}.zeeman.bogus=1;
+result=test_true(result,'merge_inp unknown group field',local_merge_fails(sys_parts,inter_parts),...
+                 'unknown subfields inside nested groups must be refused');
+[sys_parts,inter_parts]=local_merge_parts();
+sys_parts{2}=rmfield(sys_parts{2},'isotopes');
+result=test_true(result,'merge_inp missing isotopes',local_merge_fails(sys_parts,inter_parts),...
+                 'sys structures without isotope lists must be refused');
+
+end
+
+
+% Check that a merge attempt throws an error
+function failed=local_merge_fails(sys_parts,inter_parts)
+try
+    merge_inp(sys_parts,inter_parts); failed=false();
+catch
+    failed=true();
+end
 end
 
 
@@ -160,17 +210,45 @@ function [sys_parts,inter_parts]=local_merge_parts()
 sys_parts{1}.magnet=14.1;
 sys_parts{1}.isotopes={'1H'};
 sys_parts{1}.labels={'h'};
+sys_parts{1}.enable={'greedy'};
 inter_parts{1}.coordinates={[0 0 0]};
+inter_parts{1}.temperature=298;
+inter_parts{1}.relaxation={'redfield'};
 inter_parts{1}.zeeman=struct();
-inter_parts{1}.coupling=struct();
+inter_parts{1}.coupling.scalar={0.0};
+inter_parts{1}.r1_rates={0.1};
+inter_parts{1}.r2_rates={1.1};
+inter_parts{1}.srfk_mdepth=cell(1,1);
+inter_parts{1}.weiz_r1d=0.1;
+inter_parts{1}.srsk_sources=1;
+inter_parts{1}.ignore={};
+inter_parts{1}.suscept.chi={0.01*eye(3)};
+inter_parts{1}.suscept.xyz={[5 5 5]};
+inter_parts{1}.chem.parts={1};
+inter_parts{1}.chem.rates=0;
+inter_parts{1}.chem.concs=1;
 
 % Build second subsystem input structures
 sys_parts{2}.magnet=14.1;
 sys_parts{2}.isotopes={'13C','15N'};
 sys_parts{2}.labels={'c','n'};
+sys_parts{2}.enable={'greedy'};
 inter_parts{2}.coordinates={[1 0 0];[0 1 0]};
+inter_parts{2}.temperature=298;
+inter_parts{2}.relaxation={'redfield'};
 inter_parts{2}.zeeman=struct();
-inter_parts{2}.coupling=struct();
+inter_parts{2}.coupling.scalar={0.0 5.0; 0.0 0.0};
+inter_parts{2}.r1_rates={0.2;0.3};
+inter_parts{2}.r2_rates={1.2;1.3};
+inter_parts{2}.srfk_mdepth={[] []; 7.0 []};
+inter_parts{2}.weiz_r1d=[0 0.2; 0.2 0];
+inter_parts{2}.srsk_sources=2;
+inter_parts{2}.ignore={[1 2]};
+inter_parts{2}.suscept.chi={};
+inter_parts{2}.suscept.xyz={};
+inter_parts{2}.chem.parts={[1 2]};
+inter_parts{2}.chem.rates=0;
+inter_parts{2}.chem.concs=1;
 
 end
 

--- a/tests/kernel/test_dynamic_spin_edit_suite.m
+++ b/tests/kernel/test_dynamic_spin_edit_suite.m
@@ -114,6 +114,21 @@ result=test_true(result,'merge_inp suscept centres',isequal(inter.suscept.chi,{0
                  isequal(inter.suscept.xyz,{[5 5 5]}),...
                  'merge_inp must concatenate susceptibility centre lists across subsystems');
 
+% Check column-oriented subsystem lists and partless chemistry
+[sys_parts,inter_parts]=local_merge_parts();
+inter_parts{2}.chem.parts={1;2};
+[~,inter]=merge_inp(sys_parts,inter_parts);
+result=test_true(result,'merge_inp column parts',isequal(inter.chem.parts,{1,2,3}),...
+                 'column-oriented chemical part lists must merge into offset row lists');
+[sys_parts,inter_parts]=local_merge_parts();
+inter_parts{1}.chem=struct('rp_theory','haberkorn','rp_electrons',1,'rp_rates',[1e6 2e6]);
+inter_parts{2}.chem=struct('rp_theory','haberkorn','rp_electrons',1,'rp_rates',[1e6 2e6]);
+inter_parts{1}.tau_c={1e-9}; inter_parts{2}.tau_c={1e-9};
+[~,inter]=merge_inp(sys_parts,inter_parts);
+result=test_true(result,'merge_inp partless chem',isequal(inter.tau_c,{1e-9})&&...
+                 isequal(inter.chem.rp_electrons,[1 2]),...
+                 'chemistry without a species split must keep tau_c common and offset electron indices');
+
 % Check that non-extensive differences and malformed inputs are refused
 [sys_parts,inter_parts]=local_merge_parts();
 inter_parts{2}.temperature=300;


### PR DESCRIPTION
## Summary

A global analysis of `create.m`'s input parser (plus `tolerances.m` for `sys.tols`) established the complete legal input field set for `sys` and `inter`; `merge_inp.m` now covers all of it. Extensive fields concatenate with index offsets; differences in non-extensive fields are treated as errors.

- **sys:** `magnet`, `output`, `scratch`, `enable`, `disable`, `tols`, `parallel`, `parprops` must be identical in all subsystems; `isotopes`/`labels` concatenate
- **inter common values** (identical or error, compared with `isequal` rather than the scalar-only `~=`): `relaxation`, `rlx_keep`, `rlx_dfs`, `equilibrium`, `temperature`, `damp_rate`, `srfk_tau_c`, weiz/nott electron and nuclear rates, `pbc`
- **`tau_c` and `order_matrix`** concatenate per chemical species when the `chem` group is present, and are common values otherwise — matching create.m's validation of their element counts against the number of chemical parts
- **per-spin fields:** `coordinates` (column concat), `r1/r2/lind` rates (column-normalised concat, covering both row- and column-cell user idioms found in shipped examples), `srfk_mdepth`/`weiz_r1d`/`weiz_r2d` (block merge), `srsk_sources`/`ignore` (spin index offsets)
- **nested groups** `zeeman`, `coupling`, `giant`, `suscept`, `chem`: present in all subsystems or none; `chem` merges `parts`/`rp_electrons` with spin index offsets, `rates`/`flux_rate` as blocks, `concs` by concatenation

Two latent defects fixed:
1. Square cell arrays (`coupling.scalar/matrix/eigs/euler`, `srfk_mdepth`) were merged with `blkdiag`, which pads off-diagonal blocks with numeric scalar zeros inside cells instead of empty cells; block placement with empty padding is now used (`blkdiag` is retained for numeric arrays, where zero padding is correct).
2. Unknown subfields inside nested groups (e.g. a typo in `inter.zeeman.*`) were silently dropped; each group now has its own fail-closed gate.

The grumbler now requires equal fragment counts, structure elements, and an isotope list in every `sys` fragment.

## Validation

- `checkcode` clean on both files; `tests/kernel/test_dynamic_spin_edit_suite.m` extended with a rich two-fragment fixture and twelve new assertions including five refusal paths (value mismatch, partial group, unknown field, unknown group field, missing isotopes) — 24/24 pass on this head after rebasing onto the merged PR #187 suite
- Structural equivalence: `create()` of merged fragments is field-for-field identical to `create()` of the hand-combined specification in liquid (chem + SRSK + t1_t2 rates), radical-pair (recombining electron pair split across fragments), cavity-mode (`C4`), giant-spin (`E8`), and susceptibility-centre contexts
- Physics: merged-vs-direct 1D fids bitwise identical (relative difference 0.0); `dac_reaction` five-fragment merge builds cleanly (30 spins, basis dimension 30466); the full `diels_alder_zmag` example (four-fragment merge, 22 spins, nonlinear kinetics via `react_gen`) runs with mass conservation below 1e-6 and finite trajectories

🤖 Generated with [Claude Code](https://claude.com/claude-code)