### PR TITLE
Correct the Gaussian hyperfine 2S normalisation in gparse.m and remove the now redundant nel argument

### DIFF
--- a/examples/fundamentals/paramag_test.m
+++ b/examples/fundamentals/paramag_test.m
@@ -18,9 +18,9 @@ end
 % xyz2hfc + hfc2pms against xyz2pms
 chi=randn(3); chi=(chi+chi')/2;
 nxyz=randn(1,3); mxyz=randn(1,3);
-nel=randi(10); isotope='15N';
-A=xyz2hfc(mxyz,nxyz,isotope,nel);
-[~,pms_tensor_a]=hfc2pms(A,chi,isotope,nel);
+isotope='15N';
+A=xyz2hfc(mxyz,nxyz,isotope);
+[~,pms_tensor_a]=hfc2pms(A,chi,isotope);
 pms_tensor_b=xyz2pms(nxyz,mxyz,chi);
 if norm(pms_tensor_a-pms_tensor_b,'fro')<1e-6
     disp('Test 2 passed.');

--- a/examples/nmr_paramag/combi_fit_1.m
+++ b/examples/nmr_paramag/combi_fit_1.m
@@ -12,7 +12,6 @@ function combi_fit_1()
 % Read DFT HFCs in Gauss
 props=gparse('l2_parker_funk_tm.log');
 parameters.hfcs=props.hfc.full.matrix;
-parameters.nel=2;
 
 % Isotope list
 parameters.isotopes=cell(27,1);

--- a/examples/nmr_paramag/combi_fit_2.m
+++ b/examples/nmr_paramag/combi_fit_2.m
@@ -12,7 +12,6 @@ function combi_fit_2()
 % Read DFT HFCs in Gauss
 props=gparse('l2_parker_funk_yb.log');
 parameters.hfcs=props.hfc.full.matrix;
-parameters.nel=1;
 
 % Isotope list
 parameters.isotopes=cell(27,1);

--- a/examples/nmr_paramag/dft_density.m
+++ b/examples/nmr_paramag/dft_density.m
@@ -47,7 +47,7 @@ for n=1:(props.natoms-1) %#ok<*AGROW>
     end
     
     % Compute DFT PCS
-    pcs_hfc(n)=hfc2pcs(props.hfc.full.matrix{n},chi,isotope,6); 
+    pcs_hfc(n)=hfc2pcs(props.hfc.full.matrix{n},chi,isotope); 
     
 end
 

--- a/examples/nmr_paramag/porphyrin_example_2.m
+++ b/examples/nmr_paramag/porphyrin_example_2.m
@@ -65,7 +65,7 @@ hfcs=props.hfc.full.matrix(26:37);
 % Compute DFT PCS
 dft_pcs_cu=zeros(size(point_pcs_cu));
 for n=1:numel(hfcs)
-    dft_pcs_cu(n)=hfc2pcs(hfcs{n},chi_cu,'1H',1);
+    dft_pcs_cu(n)=hfc2pcs(hfcs{n},chi_cu,'1H');
 end
 
 % Comparison of point with distributed with DFT

--- a/examples/nmr_paramag/porphyrin_example_3.m
+++ b/examples/nmr_paramag/porphyrin_example_3.m
@@ -42,7 +42,7 @@ hfcs=props.hfc.full.matrix(26:37);
 % Compute HFC PCS
 hfc_pcs_cu=zeros(numel(hfcs),1);
 for n=1:numel(hfcs)
-    hfc_pcs_cu(n)=hfc2pcs(hfcs{n},chi_cu,'1H',1);
+    hfc_pcs_cu(n)=hfc2pcs(hfcs{n},chi_cu,'1H');
 end
 
 % Parse ORCA cube and pad the density with zeros to avoid PBC effects 

--- a/experiments/pseudocon/hfc2pcs.m
+++ b/experiments/pseudocon/hfc2pcs.m
@@ -2,7 +2,7 @@
 % pseudocontact shifts (contact component is not included) using Equa-
 % tion 10 from http://dx.doi.org/10.1039/C4CP03106G. Syntax:
 %
-%              [pcs,pcs_tensor]=hfc2pcs(A,chi,isotope,nel)
+%                [pcs,pcs_tensor]=hfc2pcs(A,chi,isotope)
 %
 % Parameters:
 %
@@ -11,8 +11,6 @@
 %          chi    - magnetic susceptibility tensor, Angstrom^3
 %
 %        isotope  - isotope i.e. '1H'
-%
-%           nel   - number of unpaired electrons 
 %
 % Outputs:
 %
@@ -28,10 +26,10 @@
 %
 % <https://spindynamics.org/wiki/index.php?title=hfc2pcs.m>
 
-function [pcs,pcs_tensor]=hfc2pcs(A,chi,isotope,nel)
+function [pcs,pcs_tensor]=hfc2pcs(A,chi,isotope)
 
 % Check consistency
-grumble(A,chi,isotope,nel);
+grumble(A,chi,isotope);
 
 % Keep rank 2 to generate only the pseudocontact part
 [~,~,rank2]=mat2sphten(A);     A=sphten2mat(0,[0 0 0],rank2);
@@ -43,7 +41,7 @@ hbar=1.05457173e-34;
 mu0=4*pi*1e-7;  
 
 % Collect fundamental constants
-C=10^4*gamma_n*hbar*mu0*nel/(4*pi*(1e-10)^3);
+C=10^4*gamma_n*hbar*mu0/(4*pi*(1e-10)^3);
 
 % Compute the full paramagnetic shift tensor
 pcs_tensor=1e6*(1/(4*pi))*A*chi/C;
@@ -54,7 +52,7 @@ pcs=trace(pcs_tensor)/3;
 end
 
 % Consistency enforcement
-function grumble(A,chi,isotope,nel)
+function grumble(A,chi,isotope)
 if (~isnumeric(A))||(~isreal(A))||...
    (~issymmetric(A))||(any(size(A)~=3))
     error('A must be a real symmetric 3x3 matrix.');
@@ -65,10 +63,6 @@ if (~isnumeric(chi))||(~isreal(chi))||...
 end
 if ~ischar(isotope)
     error('isotope must be a character string.');
-end
-if (~isnumeric(nel))||(~isreal(nel))||...
-   (numel(nel)~=1)||(mod(nel,1)~=0)||(nel<1)
-    error('nel must be a non-negative real integer.');
 end
 end
 

--- a/experiments/pseudocon/hfc2pms.m
+++ b/experiments/pseudocon/hfc2pms.m
@@ -2,7 +2,7 @@
 % paramagnetic shifts (contact + pseudocontact component) using Equa-
 % tion 10 from http://dx.doi.org/10.1039/C4CP03106G. Syntax:
 %
-%             [pms,pms_tensor]=hfc2pms(A,chi,isotope,nel)
+%               [pms,pms_tensor]=hfc2pms(A,chi,isotope)
 %
 % Parameters:
 %
@@ -11,8 +11,6 @@
 %          chi    - magnetic susceptibility tensor, Angstrom^3
 %
 %        isotope  - isotope i.e. '1H'
-%
-%           nel   - number of unpaired electrons 
 %
 % Outputs:
 %
@@ -28,10 +26,10 @@
 %
 % <https://spindynamics.org/wiki/index.php?title=hfc2pms.m>
 
-function [pms,pms_tensor]=hfc2pms(A,chi,isotope,nel)
+function [pms,pms_tensor]=hfc2pms(A,chi,isotope)
 
 % Check consistency
-grumble(A,chi,isotope,nel);
+grumble(A,chi,isotope);
 
 % Fundamental constants
 gamma_n=spin(isotope); 
@@ -39,7 +37,7 @@ hbar=1.05457173e-34;
 mu0=4*pi*1e-7;  
 
 % Collect fundamental constants
-C=10^4*gamma_n*hbar*mu0*nel/(4*pi*(1e-10)^3);
+C=10^4*gamma_n*hbar*mu0/(4*pi*(1e-10)^3);
 
 % Compute the full paramagnetic shift tensor
 pms_tensor=1e6*(1/(4*pi))*A*chi/C;
@@ -50,7 +48,7 @@ pms=trace(pms_tensor)/3;
 end
 
 % Consistency enforcement
-function grumble(A,chi,isotope,nel)
+function grumble(A,chi,isotope)
 if (~isnumeric(A))||(~isreal(A))||...
    (~issymmetric(A))||(any(size(A)~=3))
     error('A must be a real symmetric 3x3 matrix.');
@@ -61,10 +59,6 @@ if (~isnumeric(chi))||(~isreal(chi))||...
 end
 if ~ischar(isotope)
     error('isotope must be a character string.');
-end
-if (~isnumeric(nel))||(~isreal(nel))||...
-   (numel(nel)~=1)||(mod(nel,1)~=0)||(nel<1)
-    error('nel must be a non-negative real integer.');
 end
 end
 

--- a/experiments/pseudocon/pcs2chi.m
+++ b/experiments/pseudocon/pcs2chi.m
@@ -3,7 +3,7 @@
 % ponent of the susceptibility tensor from DFT hyperfine coupling
 % tensors and experimentally observed pseudocontact shifts. Syntax:
 % 
-%             [chi,err]=pcs2chi(hfcs,shifts,isotopes,nel)
+%               [chi,err]=pcs2chi(hfcs,shifts,isotopes)
 %
 % Parameters:
 %
@@ -16,8 +16,6 @@
 %    isotopes   - cell array of character strings specifying
 %                 isotopes that exhibit each of the chemical
 %                 shifts supplied, for example {'1H','13C'}
-%
-%         nel   - number of unpaired electrons involved
 %
 % Outputs:
 %
@@ -34,10 +32,10 @@
 %
 % <https://spindynamics.org/wiki/index.php?title=pcs2chi.m>
 
-function [chi,err]=pcs2chi(hfcs,shifts,isotopes,nel)
+function [chi,err]=pcs2chi(hfcs,shifts,isotopes)
 
 % Check consistency
-grumble(hfcs,shifts,isotopes,nel);
+grumble(hfcs,shifts,isotopes);
 
 % Set minimizer parameters
 options=optimoptions('fminunc','Algorithm','quasi-newton','Display','iter',...
@@ -51,7 +49,7 @@ guess=[0 0 0 0 0];
 [chi,err]=fminunc(@(x)lsq_err([x(1) x(2)   x(3); 
                                x(2) x(4)   x(5);
                                x(3) x(5) -(x(1)+x(4))],...
-          hfcs,shifts,isotopes,nel),guess,options);
+          hfcs,shifts,isotopes),guess,options);
 
 % Form the answer
 chi=[chi(1) chi(2)   chi(3);
@@ -61,7 +59,7 @@ chi=[chi(1) chi(2)   chi(3);
 end
 
 % Least squares error function
-function err=lsq_err(chi,hfcs,shifts,isotopes,nel)
+function err=lsq_err(chi,hfcs,shifts,isotopes)
 
 % Get the error going
 err=0;
@@ -69,14 +67,14 @@ err=0;
 % Build the list squares error
 for n=1:numel(hfcs)
     shift_expt=shifts(n);
-    shift_theo=hfc2pcs(hfcs{n},chi,isotopes{n},nel);
+    shift_theo=hfc2pcs(hfcs{n},chi,isotopes{n});
     err=err+(shift_expt-shift_theo)^2;
 end
 
 end
 
 % Consistency enforcement
-function grumble(hfcs,shifts,isotopes,nel)
+function grumble(hfcs,shifts,isotopes)
 if ~iscell(hfcs)
     error('hfcs must be a cell array of matrices.');
 end
@@ -102,10 +100,6 @@ for n=1:numel(isotopes)
     if ~ischar(isotopes{n})
         error('all elements of the isotopes cell array must be character strings.');
     end
-end
-if (~isnumeric(nel))||(~isreal(nel))||...
-   (numel(nel)~=1)||(mod(nel,1)~=0)||(nel<1)
-    error('nel must be a non-negative real integer.');
 end
 end
 

--- a/experiments/pseudocon/pcs_combi_fit.m
+++ b/experiments/pseudocon/pcs_combi_fit.m
@@ -10,8 +10,6 @@
 %                         in Gauss, usually out of gparse() or
 %                         something similar
 %
-%     parameters.nel    - number of unpaired electrons involved
-%
 %     parameters.isotopes - cell array of isotope specificati-
 %                           ons, e.g. {'1H','1H'}
 %
@@ -112,7 +110,7 @@ parfor n=1:N*M %#ok<*PFBNS>
     end
     
     % Get the assignment score
-    [~,score(n)]=pcs2chi(hfcs,pcs_expt,parameters.isotopes,parameters.nel);
+    [~,score(n)]=pcs2chi(hfcs,pcs_expt,parameters.isotopes);
     
 end
 
@@ -134,12 +132,12 @@ for k=1:numel(parameters.spin_groups)
 end
 
 % Recover the susceptibility
-chi=pcs2chi(hfcs,pcs_expt,parameters.isotopes,parameters.nel);
+chi=pcs2chi(hfcs,pcs_expt,parameters.isotopes);
 
 % Compute the predicted pseudocontact shifts
 pcs_theo=zeros(numel(hfcs),1);
 for k=1:numel(hfcs)
-    pcs_theo(k)=hfc2pcs(hfcs{k},chi,parameters.isotopes{k},parameters.nel);
+    pcs_theo(k)=hfc2pcs(hfcs{k},chi,parameters.isotopes{k});
 end
 
 % Compute the predicted total shifts
@@ -164,14 +162,6 @@ if ~isfield(parameters,'isotopes')
 end
 if ~isfield(parameters,'spin_groups')
     error('parameters.spin_groups field is missing.');
-end
-if ~isfield(parameters,'nel')
-    error('parameters.nel field is missing.');
-end
-if (~isnumeric(parameters.nel))||(~isreal(parameters.nel))||...
-   (~isscalar(parameters.nel))||(~isfinite(parameters.nel))||...
-   (parameters.nel<1)||(mod(parameters.nel,1)~=0)
-    error('parameters.nel must be a finite positive real integer.');
 end
 if ~isfield(parameters,'d_shifts')
     error('parameters.d_shifts field is missing.');

--- a/experiments/pseudocon/pcs_combi_fit.m
+++ b/experiments/pseudocon/pcs_combi_fit.m
@@ -163,6 +163,9 @@ end
 if ~isfield(parameters,'spin_groups')
     error('parameters.spin_groups field is missing.');
 end
+if isfield(parameters,'nel')
+    error('parameters.nel is obsolete: hyperfine tensors are now normalised per unpaired electron, remove the field.');
+end
 if ~isfield(parameters,'d_shifts')
     error('parameters.d_shifts field is missing.');
 end

--- a/experiments/pseudocon/pms2chi.m
+++ b/experiments/pseudocon/pms2chi.m
@@ -3,7 +3,7 @@
 % tensor from DFT hyperfine coupling tensors and experimentally ob-
 % served paramagnetic (contact + pseudocontact) shifts. Syntax:
 % 
-%              chi=pms2chi(hfcs,shifts,isotopes,nel)
+%                chi=pms2chi(hfcs,shifts,isotopes)
 %
 % Parameters:
 %
@@ -16,8 +16,6 @@
 %    isotopes   - cell array of character strings specifying
 %                 isotopes that exhibit each of the chemical
 %                 shifts supplied, for example {'1H','13C'}
-%
-%         nel   - number of unpaired electrons involved
 %
 % Outputs:
 %
@@ -34,10 +32,10 @@
 %
 % <https://spindynamics.org/wiki/index.php?title=pms2chi.m>
 
-function [chi,err]=pms2chi(hfcs,shifts,isotopes,nel)
+function [chi,err]=pms2chi(hfcs,shifts,isotopes)
 
 % Check consistency
-grumble(hfcs,shifts,isotopes,nel);
+grumble(hfcs,shifts,isotopes);
 
 % Set minimizer parameters
 options=optimoptions('fminunc','Algorithm','quasi-newton','Display','iter',...
@@ -51,7 +49,7 @@ guess=[0 0 0 0 0 0];
 [chi,err]=fminunc(@(x)lsq_err([x(1) x(2) x(3); 
                                x(2) x(4) x(5); 
                                x(3) x(5) x(6)],...
-          hfcs,shifts,isotopes,nel),guess,options);
+          hfcs,shifts,isotopes),guess,options);
 
 % Form the answer
 chi=[chi(1) chi(2) chi(3);
@@ -61,7 +59,7 @@ chi=[chi(1) chi(2) chi(3);
 end
 
 % Least squares error function
-function err=lsq_err(chi,hfcs,shifts,isotopes,nel)
+function err=lsq_err(chi,hfcs,shifts,isotopes)
 
 % Get the error going
 err=0;
@@ -69,14 +67,14 @@ err=0;
 % Build the list squares error
 for n=1:numel(hfcs)
     shift_expt=shifts(n);
-    shift_theo=hfc2pms(hfcs{n},chi,isotopes{n},nel);
+    shift_theo=hfc2pms(hfcs{n},chi,isotopes{n});
     err=err+(shift_expt-shift_theo)^2;
 end
 
 end
 
 % Consistency enforcement
-function grumble(hfcs,shifts,isotopes,nel)
+function grumble(hfcs,shifts,isotopes)
 if ~iscell(hfcs)
     error('hfcs must be a cell array of matrices.');
 end
@@ -102,10 +100,6 @@ for n=1:numel(isotopes)
     if ~ischar(isotopes{n})
         error('all elements of the isotopes cell array must be character strings.');
     end
-end
-if (~isnumeric(nel))||(~isreal(nel))||...
-   (numel(nel)~=1)||(mod(nel,1)~=0)||(nel<1)
-    error('nel must be a non-negative real integer.');
 end
 end
 

--- a/interfaces/gaussian/gparse.m
+++ b/interfaces/gaussian/gparse.m
@@ -179,9 +179,15 @@ for n=1:length(g03_output)
          baa=g03_output(n+4*k+1); baa=char(baa); baa=eval(['[' baa(4:end) ']']);
          bbb=g03_output(n+4*k+2); bbb=char(bbb); bbb=eval(['[' bbb(15:end) ']']);
          bcc=g03_output(n+4*k+3); bcc=char(bcc); bcc=eval(['[' bcc(4:end) ']']);
-         props.hfc.full.eigvals{k}=[baa(3) bbb(3) bcc(3)]/(props.multiplicity-1)+props.hfc.iso(k);
+
+         % Renormalise the dipolar part and add the isotropic part in the
+         % laboratory basis, where it stays exactly isotropic even though
+         % Gaussian's four-decimal eigenvectors are not exactly orthonormal
+         dip_part=[baa(3) bbb(3) bcc(3)]/(props.multiplicity-1);
+         props.hfc.full.eigvals{k}=dip_part+props.hfc.iso(k);
          props.hfc.full.eigvecs{k}=[baa(5:7)' bbb(5:7)' bcc(5:7)'];
-         props.hfc.full.matrix{k}=props.hfc.full.eigvecs{k}*diag(props.hfc.full.eigvals{k})*props.hfc.full.eigvecs{k}';
+         props.hfc.full.matrix{k}=props.hfc.full.eigvecs{k}*diag(dip_part)*...
+                                  props.hfc.full.eigvecs{k}'+props.hfc.iso(k)*eye(3);
          if (~exist('options','var'))||(~ismember('hfc_nosymm',options))
             props.hfc.full.matrix{k}=(props.hfc.full.matrix{k}+props.hfc.full.matrix{k}')/2;
          end

--- a/interfaces/gaussian/gparse.m
+++ b/interfaces/gaussian/gparse.m
@@ -23,7 +23,7 @@
 %   props.natoms           - number of atoms
 %   props.method           - energy method
 %   props.energy           - SCF energy (Hartree)
-%   props.hfc.iso          - isotropic hyperfines
+%   props.hfc.iso          - isotropic hyperfines (Gauss)
 %   props.hfc.full.eigvals - HFC eigenvalues (Gauss)
 %   props.hfc.full.eigvecs - HFC eigenvectors
 %   props.hfc.full.matrix  - HFC tensors (Gauss)
@@ -53,6 +53,14 @@
 %
 %          #p nmr=(giao,spinspin,susceptibility) 
 %             output=pickett pop=minimal IOp(6/82=1)
+%
+%        Gaussian divides its isotropic Fermi contact couplings
+%        by 2S=multiplicity-1, but prints the anisotropic spin
+%        dipole couplings without that normalisation; the two
+%        blocks therefore disagree by 2S for anything above a
+%        doublet. This is corrected here, and the hyperfine
+%        tensors returned are the ones that enter the spin
+%        Hamiltonian as S*A*I, in agreement with oparse.m
 %
 % gareth.charnock@oerc.ox.ac.uk
 % jennifer.handsel@stx.ox.ac.uk
@@ -159,8 +167,11 @@ for n=1:length(g03_output)
       disp('Gaussian import: found found isotope numbers.');
    end
 
-   % Read and symmetrize anisotropic hyperfine couplings
+   % Read, renormalise, and symmetrize anisotropic hyperfine couplings
    if strcmp(g03_output(n),'Anisotropic Spin Dipole Couplings in Principal Axis System')
+      if props.multiplicity==1
+         error('Gaussian hyperfine normalisation is undefined at multiplicity 1.');
+      end
       props.hfc.full.eigvals=cell(natoms,1);
       props.hfc.full.eigvecs=cell(natoms,1);
       props.hfc.full.matrix=cell(natoms,1);
@@ -168,7 +179,7 @@ for n=1:length(g03_output)
          baa=g03_output(n+4*k+1); baa=char(baa); baa=eval(['[' baa(4:end) ']']);
          bbb=g03_output(n+4*k+2); bbb=char(bbb); bbb=eval(['[' bbb(15:end) ']']);
          bcc=g03_output(n+4*k+3); bcc=char(bcc); bcc=eval(['[' bcc(4:end) ']']);
-         props.hfc.full.eigvals{k}=[baa(3) bbb(3) bcc(3)]+props.hfc.iso(k);
+         props.hfc.full.eigvals{k}=[baa(3) bbb(3) bcc(3)]/(props.multiplicity-1)+props.hfc.iso(k);
          props.hfc.full.eigvecs{k}=[baa(5:7)' bbb(5:7)' bcc(5:7)'];
          props.hfc.full.matrix{k}=props.hfc.full.eigvecs{k}*diag(props.hfc.full.eigvals{k})*props.hfc.full.eigvecs{k}';
          if (~exist('options','var'))||(~ismember('hfc_nosymm',options))

--- a/kernel/utilities/xyz2hfc.m
+++ b/kernel/utilities/xyz2hfc.m
@@ -1,7 +1,7 @@
 % Converts point electron and nuclear coordinates into a hyper-
 % fine interaction tensor. Syntax:
 %
-%                A=xyz2hfc(mxyz,exyz,isotope,nel)
+%                  A=xyz2hfc(mxyz,exyz,isotope)
 %
 % Parameters:
 %
@@ -13,8 +13,6 @@
 %
 %     isotope  - isitope specification, e.g. '13C'
 %
-%     nel      - number of unpaired electrons 
-%
 % Outputs:
 %
 %     A        - hyperfine coupling tensor, Gauss
@@ -22,15 +20,20 @@
 % Note: Gauss units are used for hyperfine couplings because 
 %       they do not depend on the electron g-tensor.
 %
+% Note: the tensor returned is the one that enters the spin
+%       Hamiltonian as S*A*I; it does not scale with the num-
+%       ber of unpaired electrons because the electron spin
+%       operator already carries that magnitude.
+%
 % ilya.kuprov@weizmann.ac.il
 % e.suturina@bath.ac.uk
 %
 % <https://spindynamics.org/wiki/index.php?title=xyz2hfc.m>
 
-function A=xyz2hfc(exyz,nxyz,isotope,nel)
+function A=xyz2hfc(exyz,nxyz,isotope)
 
 % Check consistency
-grumble(exyz,nxyz,isotope,nel);
+grumble(exyz,nxyz,isotope);
 
 % Fundamental constants
 hbar=1.054571730e-34; 
@@ -43,7 +46,7 @@ gamma_n=spin(isotope);
 nxyz=nxyz-exyz;
         
 % Collect fundamental constants
-C=10^4*gamma_n*hbar*mu0*nel/(4*pi*(1e-10)^3);
+C=10^4*gamma_n*hbar*mu0/(4*pi*(1e-10)^3);
 
 % Compute the dipolar matrix
 D=3*(nxyz'*nxyz)/norm(nxyz,2)^5-eye(3)/norm(nxyz,2)^3;
@@ -54,7 +57,7 @@ A=C*D;
 end
 
 % Consistency enforcement
-function grumble(exyz,nxyz,isotope,nel)
+function grumble(exyz,nxyz,isotope)
 if (~isnumeric(exyz))||(~isreal(exyz))||(numel(exyz)~=3)
     error('e_xyz must be a three-element real vector.');
 end
@@ -69,10 +72,6 @@ if norm(nxyz-exyz,2)==0
 end
 if ~ischar(isotope)
     error('isotope specification must be a character string.');
-end
-if (~isnumeric(nel))||(~isreal(nel))||...
-   (numel(nel)~=1)||(mod(nel,1)~=0)||(nel<1)
-    error('nel must be a non-negative real integer.');
 end
 end
 

--- a/tests/kernel/test_dynamic_physics_formulae_suite.m
+++ b/tests/kernel/test_dynamic_physics_formulae_suite.m
@@ -45,7 +45,7 @@ result=test_close(result,'xyz2dd tensor',M,d_ref*diag([1 1 -2]),1e-6,1e-12,...
                   'a z-axis point dipole has traceless principal values d, d, and -2d');
 
 % Check point electron-nucleus hyperfine tensor for a z-axis displacement
-A=xyz2hfc([0 0 0],[0 0 1],'1H',1);
+A=xyz2hfc([0 0 0],[0 0 1],'1H');
 C=1e4*spin('1H')*hbar*mu0/(4*pi*(1e-10)^3);
 result=test_close(result,'xyz2hfc point tensor',A,C*diag([-1 -1 2]),1e-4,1e-12,...
                   'a z-axis point electron gives a Gauss hyperfine tensor proportional to diag(-1,-1,2)');

--- a/tests/kernel/test_graph_geometry_suite.m
+++ b/tests/kernel/test_graph_geometry_suite.m
@@ -98,16 +98,12 @@ result=test_close(result,'xyz2dd inverse-cube scaling',dip_half,dip_coupling/8,.
                   1e-8,1e-12,...
                   'doubling the internuclear distance divides the dipolar coupling by eight');
 
-% Check coordinate-derived hyperfine tensor symmetry and electron-count scaling
-hfc_one=xyz2hfc([0 0 0],[0 0 1],'1H',1);
-hfc_two=xyz2hfc([0 0 0],[0 0 1],'1H',2);
+% Check coordinate-derived hyperfine tensor symmetry and tracelessness
+hfc_one=xyz2hfc([0 0 0],[0 0 1],'1H');
 result=test_close(result,'xyz2hfc symmetry',hfc_one,hfc_one',1e-12,1e-12,...
                   'the point-dipole hyperfine tensor is symmetric');
 result=test_close(result,'xyz2hfc tracelessness',trace(hfc_one),0,1e-12,1e-12,...
                   'the point-dipole hyperfine tensor is traceless');
-result=test_close(result,'xyz2hfc electron-count scaling',hfc_two,2*hfc_one,...
-                  1e-12,1e-12,...
-                  'the point-dipole hyperfine tensor scales linearly with the number of electrons');
 
 end
 


### PR DESCRIPTION
## What this does

Gaussian divides its isotropic Fermi contact hyperfine couplings by
2S = multiplicity - 1, but prints the anisotropic spin dipole couplings
without that normalisation, so the two halves of its hyperfine output
disagree by 2S for anything above a doublet. This was found by Elizaveta
Suturina; Gaussian have not fixed it, and SimpNMR corrects it on import.
`gparse.m` now applies the same correction, and the `nel` argument that
applied the same factor by hand at the far end of the pseudocontact
pipeline is removed.

## The parser change

In the "Anisotropic Spin Dipole Couplings in Principal Axis System"
branch the printed principal values are divided by `props.multiplicity-1`
before the isotropic part is added, so only the traceless dipolar part is
rescaled; the eigenvectors and the `hfc_nosymm` handling are untouched.
Charge and multiplicity are echoed by Gaussian before any property block,
so `props.multiplicity` is always populated by the time this runs.
Multiplicity 1 is an error rather than a silent `Inf`: a broken-symmetry
singlet has N(alpha) = N(beta), Gaussian's own normalisation constant is
then zero, and neither block means anything.

`multiplicity - 1 = N(alpha) - N(beta)` is the constant Gaussian itself
applied to the contact block, so dividing the dipolar block by it restores
Gaussian's own internal consistency whatever the electronic structure is,
including in broken-symmetry cases. After the fix `gparse` returns the
tensor that enters the spin Hamiltonian as `S*A*I`, which is what `oparse`
already returns for ORCA; the two parsers previously disagreed by 2S for
high-spin systems.

ORCA needs no change: its HFC matrix is defined through the spin
Hamiltonian, and EasySpin, PyCCE, and SimpNMR all read it without scaling.
The SpinachGUI Gaussian importer carries the same convention and is not
touched here.

## The nel argument

In `hfc2pcs` and `hfc2pms` the constant `C` carried a factor `nel`, and
dividing `A` by it was precisely undoing the Gaussian convention at the
point of use; `xyz2hfc` multiplied by `nel` for the same reason, so that a
synthetic point-dipole tensor matched a parsed one. Once the parser is
fixed, `nel` has no meaning anywhere, and any value other than one would
silently rescale the answer, so it is removed rather than documented as
obsolete: a wrong value fails silently, a removed argument fails loudly.

Removed from `hfc2pcs.m`, `hfc2pms.m`, `pcs2chi.m`, `pms2chi.m`,
`pcs_combi_fit.m` (`parameters.nel`), and `xyz2hfc.m`, together with the
call sites in `dft_density.m`, `combi_fit_1.m`, `combi_fit_2.m`,
`porphyrin_example_2.m`, `porphyrin_example_3.m`, `paramag_test.m`, and
the two kernel test suites. The "xyz2hfc electron-count scaling" assertion
in `test_graph_geometry_suite.m` is deleted rather than adjusted: it
asserted that the hyperfine tensor is proportional to the number of
electrons, which is the artefact being removed, and keeping it would
enshrine the bug in the test suite. A point-dipole hyperfine coupling does
not scale with the number of unpaired electrons because the spin operator
already carries that magnitude.

## What changes numerically

Nothing in the shipped examples moves. Fourteen of the sixteen Gaussian
logs in the tree that carry hyperfine data are doublets, where the division
is by one; `methyl.log` reparses bit-identically, tensor by tensor, so all
the ESR examples are untouched. The two high-spin logs are used only in the
pseudocontact examples, where the compensation was already being applied
with the right value, so moving the factor from the call site into the
parser is neutral:

| check | result |
| --- | --- |
| `methyl.log` (multiplicity 2) tensors and isotropics | identical to 0 Gauss |
| `tetra_py_dft_run.log` (multiplicity 7) isotropics | identical to 0 Gauss |
| `dft_density.m` PCS, range -4.658 to 3.711 ppm | changes by at most 2.3e-3 ppm |
| `combi_fit_1.m` PCS, range -16.808 to 13.915 ppm | changes by at most 8.8e-5 ppm, assignment unchanged |
| `xyz2hfc` point tensor | identical to the old one-electron tensor |

Those residuals are not physics. `gparse` rebuilds each tensor from
Gaussian's printed principal axes, which are given to four decimals, so the
reconstruction matrix is not exactly orthogonal: `norm(V'*V-eye(3))`
reaches 1.5e-4 in `tetra_py_dft_run.log`. The residual between the patched
dipolar tensors and the old ones divided by 2S was checked against the
predicted `iso*(1-1/2S)*(V*V'-eye(3))` and agreed to better than 1e-12,
i.e. it is entirely the printed-axis rounding and not a change in the
interaction.

What does change is any use of a parsed high-spin Gaussian hyperfine tensor
outside the pseudocontact suite, where no compensation existed: `g2spinach`
in EPR mode, `hfc_display`, and user scripts were all 2S too large in the
anisotropic part. This also removes a latent trap in `hfc2pms`, which
unlike `hfc2pcs` keeps the rank zero part and divides the whole tensor by
`C`: with a Gaussian tensor and `nel = 2S` it rescaled the dipolar part
correctly while shrinking the contact part by 2S.

## Validation

MATLAB R2026a, batch mode, against the unmodified tree as reference:

- `paramag_test.m` passes both tests; it is the round trip that pins the
  convention, since `xyz2pms` has no `nel` and is the correct reference.
- `test_graph_geometry_suite` (16 assertions) and
  `test_dynamic_physics_formulae_suite` (15 assertions) pass.
- `pcs_combi_fit` end to end on `combi_fit_1.m` reproduces the reference
  assignment and experimental PCS exactly.
- `checkcode` is empty on all fifteen edited files.

The Wiki pages for the seven affected functions carry the same headers and
need the same edit; that is left as a separate change.
