### PR TITLE
Stop iterative plot updates moving user-positioned figures in ipcs.m and volplot.m

### DIFF
--- a/experiments/pseudocon/ipcs.m
+++ b/experiments/pseudocon/ipcs.m
@@ -375,7 +375,7 @@ end
                   min([parameters.xyz_all(:,3); a(5)]) max([parameters.xyz_all(:,3); a(6)])]);
         end
         if ismember('diagnostics',parameters.plot)
-            set(groot,'CurrentFigure',2); clf reset; hold on; plot(expt_pcs,theo_pcs,'ro');
+            set(groot,'CurrentFigure',2); clf; hold on; plot(expt_pcs,theo_pcs,'ro');
             plot([min(expt_pcs) max(expt_pcs)],[min(expt_pcs) max(expt_pcs)],'b-');
             annotation('textbox',[0.15 0.7 0.2 0.2],...
                        'String',{['Density integral: '  num2str(normint)],...

--- a/kernel/plotting/volplot.m
+++ b/kernel/plotting/volplot.m
@@ -89,9 +89,7 @@ nx=size(data_cube,3); xmin=axis_ranges(1); xmax=axis_ranges(2);
 ny=size(data_cube,2); ymin=axis_ranges(3); ymax=axis_ranges(4);
 nz=size(data_cube,1); zmin=axis_ranges(5); zmax=axis_ranges(6);
 
-% Clear the current figure without a full reset: on the web figure
-% stack a per-call reset makes the window re-apply stored geometry
-% and jump if the user has moved it during an iterative calculation
+% Clear the figure without the full reset that moves user-positioned windows
 clf; hold on;
 set(gca,'Projection','perspective','Box','on','XGrid','on','YGrid','on',...
         'ZGrid','on','CameraPosition',5*[xmax ymax zmax]); camorbit(15,0);
@@ -126,8 +124,7 @@ end
 % Set blue -> white -> red colormap
 colormap(bwr_cmap());
 
-% Reset the alpha map explicitly, because the figure is no longer
-% fully reset between the calls, then interpolate it
+% Reset the alpha map to its default and interpolate it
 alphamap('default');
 new_alpha=interp1(1:64,alphamap,1:0.25:64,'pchip');
 

--- a/kernel/plotting/volplot.m
+++ b/kernel/plotting/volplot.m
@@ -89,8 +89,10 @@ nx=size(data_cube,3); xmin=axis_ranges(1); xmax=axis_ranges(2);
 ny=size(data_cube,2); ymin=axis_ranges(3); ymax=axis_ranges(4);
 nz=size(data_cube,1); zmin=axis_ranges(5); zmax=axis_ranges(6);
 
-% Get a persistent graphics window
-clf reset; hold on; set(gcf,'Renderer','OpenGL');
+% Clear the current figure without a full reset: on the web figure
+% stack a per-call reset makes the window re-apply stored geometry
+% and jump if the user has moved it during an iterative calculation
+clf; hold on;
 set(gca,'Projection','perspective','Box','on','XGrid','on','YGrid','on',...
         'ZGrid','on','CameraPosition',5*[xmax ymax zmax]); camorbit(15,0);
 
@@ -124,7 +126,9 @@ end
 % Set blue -> white -> red colormap
 colormap(bwr_cmap());
 
-% Interpolate alpha map
+% Reset the alpha map explicitly, because the figure is no longer
+% fully reset between the calls, then interpolate it
+alphamap('default');
 new_alpha=interp1(1:64,alphamap,1:0.25:64,'pchip');
 
 % Scale and filter alpha map


### PR DESCRIPTION
## Problem

When `ipcs.m` runs from the example set (e.g. `s50c_kuprov.m`), it pops two figures and updates them every iteration. If the user moves a figure with the mouse mid-calculation, subsequent updates make the figures jump around the desktop. The no-focus-steal update pattern (`set(groot,'CurrentFigure',...)`) worked correctly up to R2024b.

## Diagnosis

The focus-steal prevention is intact and remains in place. The culprit is `clf reset`, executed on every iteration on both figures: directly in the `ipcs.m` diagnostics update, and inside `volplot.m` for the density figure. Up to R2024b (Java figure stack) `clf reset` honoured its documented exemption and left window geometry alone; on the current web figure stack a full figure reset makes the window re-apply its stored geometry, so a user-moved figure snaps back on every update. Probing on R2026a confirms the `Position` property itself is never rewritten by any call in the sequence — the jumping is purely the interactive geometry re-application of the full reset. Additionally, `volplot.m`'s `set(gcf,'Renderer','OpenGL')` is rejected by the web figure stack with a warning on every call.

## Fix

- Replace the per-call `clf reset` with a plain `clf` in both `volplot.m` and the `ipcs.m` diagnostics update. Plain `clf` clears children — including the per-iteration annotation boxes — without re-initialising window geometry.
- Reset the alpha map explicitly (`alphamap('default')`) before `volplot.m` reads it, since the figure default is no longer restored between calls; the applied alpha values are bit-identical to the previous behaviour (asserted to 1e-14, including after deliberately poisoning the state with a random 253-point map).
- Drop the obsolete OpenGL renderer request; the per-call warning disappears.

## Validation (R2026a)

- Repeated `volplot` and diagnostics updates preserve a moved figure's position; annotation boxes do not accumulate (exactly one after repeated iterations).
- Applied alpha map numerically identical to the previous behaviour; 24 surfaces rendered across repeated calls with correct colormap and 253-point alpha map.
- `checkcode` clean on both files; repository scan confirms these were the only per-iteration `clf reset` sites.
- Caveat: probes ran off-screen, which proves the mechanism (full reset vs children-only clear, state stability, numerical equivalence); the interactive mouse-drag confirmation needs a desktop session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
