### PR TITLE
Correct the L-curve regularisation axis in the PCS examples and harden the corner search

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ https://spindynamics.org/wiki/index.php?title=Main_Page
 
 Spinach requires Matlab R2024b or later with the following toolboxes: Parallel Computing, 
 Deep Learning, Reinforcement Lerning, Optimisation, Statistics and Machine Learning, 
-Aerospace, Mapping.
+Aerospace, Mapping, Curve Fitting.

--- a/examples/nmr_paramag/carb_anh/s166c_lcurve.m
+++ b/examples/nmr_paramag/carb_anh/s166c_lcurve.m
@@ -50,7 +50,7 @@ parfor n=1:30 %#ok<*PFOUS,*PFBNS>
 end
 
 % L-curve analysis
-kfigure(); S=lcurve(lam,err,reg./lam,'log'); drawnow;
+kfigure(); S=lcurve(lam,err,reg,'log'); drawnow;
 disp(['Suggested smoothing parameter: ' num2str(S)]);
 
 end

--- a/examples/nmr_paramag/carb_anh/s217c_lcurve.m
+++ b/examples/nmr_paramag/carb_anh/s217c_lcurve.m
@@ -50,7 +50,7 @@ parfor n=1:30 %#ok<*PFOUS,*PFBNS>
 end
 
 % L-curve analysis
-kfigure(); S=lcurve(lam,err,reg./lam,'log'); drawnow;
+kfigure(); S=lcurve(lam,err,reg,'log'); drawnow;
 disp(['Suggested smoothing parameter: ' num2str(S)]);
 
 end

--- a/examples/nmr_paramag/carb_anh/s220c_lcurve.m
+++ b/examples/nmr_paramag/carb_anh/s220c_lcurve.m
@@ -50,7 +50,7 @@ parfor n=1:30 %#ok<*PFOUS,*PFBNS>
 end
 
 % L-curve analysis
-kfigure(); S=lcurve(lam,err,reg./lam,'log'); drawnow;
+kfigure(); S=lcurve(lam,err,reg,'log'); drawnow;
 disp(['Suggested smoothing parameter: ' num2str(S)]);
 
 end

--- a/examples/nmr_paramag/carb_anh/s50c_lcurve.m
+++ b/examples/nmr_paramag/carb_anh/s50c_lcurve.m
@@ -50,7 +50,7 @@ parfor n=1:30 %#ok<*PFOUS,*PFBNS>
 end
 
 % L-curve analysis
-kfigure(); S=lcurve(lam,err,reg./lam,'log'); drawnow;
+kfigure(); S=lcurve(lam,err,reg,'log'); drawnow;
 disp(['Suggested smoothing parameter: ' num2str(S)]);
 
 end

--- a/kernel/utilities/lcurve.m
+++ b/kernel/utilities/lcurve.m
@@ -4,19 +4,39 @@
 %
 % Parameters:
 %
-%       lam - row vector of regularisation parameters
+%       lam - row vector of regularisation parameters, must
+%             be positive and in ascending order
 %
-%       err - row vector of least squares errors
+%       err - row vector of least squares errors, must be
+%             positive and increasing with lam
 %
-%       reg - row vector of regularisation functional values
+%       reg - row vector of regularisation functional values,
+%             must be positive and decreasing with lam. This
+%             is the regularisation functional itself, not the
+%             penalty term of the error functional: when the
+%             optimiser reports lam*||L*x||^2, divide it by lam
+%             once before calling this function
 %
 %      mode - 'log' for logarithmic coordinates and 'linear'
 %             for linear ones; 'log' is recommended
 %
 % Outputs:
-%   
-%   lam_opt - the regularisation parameter at the point 
+%
+%   lam_opt - the regularisation parameter at the point
 %             of the maximum curvature of the L-curve
+%
+% Notes: the corner is the point of the greatest curvature, which for a
+%        smooth asymmetric bend is not the intersection of the asymptotes;
+%        the criterion locates the regularisation parameter to within a
+%        factor of a few and is not convergent in the zero noise limit
+%        (Vogel, SIAM J. Numer. Anal. 34, 1996). Treat the answer as an
+%        order of magnitude estimate and inspect the plotted curve.
+%
+%        The curvature maximum must fall inside the sampled interval; if
+%        it falls on either end, the corner is outside the range and this
+%        function refuses to return the endpoint as an answer.
+%
+%        This function requires the Curve Fitting Toolbox.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -26,6 +46,12 @@ function lam_opt=lcurve(lam,err,reg,mode)
 
 % Check consistency
 grumble(lam,err,reg,mode);
+
+% The corner is only meaningful when the sweep is a trade-off curve;
+% warn rather than bomb out, an expensive sweep is worth inspecting
+if any(diff(err)<=0)||any(diff(reg)>=0)
+    warning('err should increase and reg should decrease with lam, inspect the sweep.');
+end
 
 % Move to logarithmic coordinates
 log_lam=log10(lam); log_err=log10(err); log_reg=log10(reg);
@@ -81,8 +107,20 @@ kxlabel('regularisation parameter');
 kylabel('L-curve curvature'); 
 axis tight; kgrid;
 
-% Find the optimum point
-[~,index]=max(kappa); lam_opt=lam(index);
+% Find the maximum curvature point away from the ends, where the
+% sided finite difference stencils and the spline end conditions
+% are unreliable
+margin=ceil(numel(kappa)/40);
+[~,index]=max(kappa((1+margin):(end-margin))); index=index+margin;
+
+% A corner adjacent to either end means that it is outside the
+% sampled interval and the analysis has not found it
+if (index<=(2*margin))||(index>=(numel(kappa)-2*margin))
+    error('L-curve corner is outside the regularisation parameter range, widen it.');
+end
+
+% Report the optimum point
+lam_opt=lam(index);
 subplot(1,2,1); plot(err(index),reg(index),'ro');
 subplot(1,2,2); plot(lam(index),kappa(index),'ro');
 
@@ -90,23 +128,29 @@ end
 
 % Consistency enforcement
 function grumble(lam,err,reg,mode)
-if (~isnumeric(lam))||(~isreal(lam))||...
-   (any(~isfinite(lam)))||(size(lam,1)~=1)
-    error('lam must be a row vector of real numbers.');
+if (~isnumeric(lam))||(~isreal(lam))||(any(~isfinite(lam)))||...
+   (size(lam,1)~=1)||any(lam<=0)
+    error('lam must be a row vector of positive real numbers.');
 end
-if (~isnumeric(err))||(~isreal(err))||...
-   (any(~isfinite(err)))||(size(err,1)~=1)
-    error('err must be a row vector of real numbers.');
+if (~isnumeric(err))||(~isreal(err))||(any(~isfinite(err)))||...
+   (size(err,1)~=1)||any(err<=0)
+    error('err must be a row vector of positive real numbers.');
 end
-if (~isnumeric(reg))||(~isreal(reg))||...
-   (any(~isfinite(reg)))||(size(reg,1)~=1)
-    error('reg must be a row vector of real numbers.');
+if (~isnumeric(reg))||(~isreal(reg))||(any(~isfinite(reg)))||...
+   (size(reg,1)~=1)||any(reg<=0)
+    error('reg must be a row vector of positive real numbers.');
 end
 if (numel(lam)~=numel(err))||(numel(err)~=numel(reg))
     error('lam, err and reg must have the same number of elements.');
 end
-if ~ischar(mode)
-    error('mode must be a character string.');
+if numel(lam)<6
+    error('at least six regularisation parameter values are required.');
+end
+if any(diff(lam)<=0)
+    error('lam must be in ascending order.');
+end
+if (~ischar(mode))||(~ismember(mode,{'log','linear'}))
+    error('mode must be either ''log'' or ''linear''.');
 end
 end
 


### PR DESCRIPTION
Addresses the L-curve issues found in the audit of `lcurve.m` and its five callers, in the order of severity.

## 1. The regularisation axis was wrong in four examples

`ipcs.m` returns `reg_b = tikhonov_scaling*lambda*||L*den||^2`, i.e. the Tikhonov penalty *with* lambda in it. One division by lambda recovers the regularisation functional that belongs on the L-curve axis, and the examples already did that inside the sweep — then divided by lambda a second time at the call site:

```matlab
reg(n)=reg(n)/lam(n);                        % correct
S=lcurve(lam,err,reg./lam,'log');            % divided again
```

`examples/nmr_paramag/calbindin/tm_1igv_lcurve.m` divides once and passes `reg` straight through, which is correct; the four `carb_anh` examples now do the same. This is not a harmless rescaling: a constant factor translates the log-log curve and leaves the curvature untouched, but dividing by lambda is a shear, which changes the shape and moves the corner.

## 2. A curvature maximum on the boundary is no longer reported as a corner

`[~,index]=max(kappa)` had no guard against the maximum falling at either end of the sampled interval. Demonstrated on an analytic L-curve whose corner sits at `lambda=1`: sampling only `[10^1.5, 10^4]` made the function return exactly `10^1.5`, the range minimum, silently. On a ground-truth Tikhonov problem it returned the first grid point on a wide sweep and the last on a narrow one, with no interior curvature maxima at all in the wide case. The ends are also where the sided finite-difference stencils and the spline end conditions are least reliable: peak curvature magnitude in the outer 2.5% of the resampled grid was 26.0 against 10.9 across the entire interior.

The search now excludes a margin at each end, and a maximum adjacent to the boundary raises an error asking for a wider range. Both diagnostic plots are drawn before that check, so the user still sees the L-curve and its curvature.

## 3. Input validation

The first operation on the data is `log10`, but `grumble` only checked real, finite, and row-shaped. A negative least-squares error and a zero regularisation functional were both accepted, producing complex logarithms and `-Inf`, a near-singular spline solve with `RCOND = 7e-19`, and still a returned number. Note that `reg=0` is not hypothetical: `ipcs` returns `reg_b=0` whenever `lambda=0`. Positivity is now required for all three vectors, `mode` is validated in `grumble` as the house style requires, and ascending `lam` and a minimum of six points are enforced.

## 4. Non-monotonic sweeps warn instead of aborting

The corner is only meaningful if the error increases and the regularisation functional decreases with lambda. `ipcs` is a constrained non-convex problem solved with `fmincon`, so this is not guaranteed. A warning is issued rather than an error, deliberately: these sweeps cost hours of GPU time and should not be discarded at the plotting stage.

## 5. Documentation

The header now states that `reg` is the functional and not the penalty term, that the corner is the point of greatest curvature rather than the intersection of the asymptotes and therefore locates lambda only to within a factor of a few, that the criterion is not convergent in the zero-noise limit (Vogel, SIAM J. Numer. Anal. 34, 1996), and that the Curve Fitting Toolbox is required — `spapi`, `optknt`, and `fnval` all come from it, and it was missing from the README toolbox list.

## Validation (R2026a)

Probed against an analytic L-curve with an exactly known corner: corner recovery unchanged at 0.48 decades from the true corner (that offset is intrinsic to the maximum-curvature definition, not to this change), out-of-range corner refused with the intended message, six invalid inputs rejected with the intended messages, a non-monotonic sweep warns and still returns a result, a valid call is warning free, and `checkcode` is clean.

Not done: the real sweeps were not executed — `s220c_lcurve` is 30 GPU `ipcs` solves at 64^3 inside a `parfor`. The double-division defect is established by reading `ipcs.m` and does not depend on running them, but the size of the resulting shift in lambda on the deposited datasets is unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
