### PR TITLE
lcurve.m: condense the operation comments to one line

### DIFF
--- a/kernel/utilities/lcurve.m
+++ b/kernel/utilities/lcurve.m
@@ -47,8 +47,7 @@ function lam_opt=lcurve(lam,err,reg,mode)
 % Check consistency
 grumble(lam,err,reg,mode);
 
-% The corner is only meaningful when the sweep is a trade-off curve;
-% warn rather than bomb out, an expensive sweep is worth inspecting
+% Warn about a sweep that is not a trade-off curve, but do not bomb out
 if any(diff(err)<=0)||any(diff(reg)>=0)
     warning('err should increase and reg should decrease with lam, inspect the sweep.');
 end
@@ -107,14 +106,11 @@ kxlabel('regularisation parameter');
 kylabel('L-curve curvature'); 
 axis tight; kgrid;
 
-% Find the maximum curvature point away from the ends, where the
-% sided finite difference stencils and the spline end conditions
-% are unreliable
+% Find the maximum curvature away from the unreliable stencil ends
 margin=ceil(numel(kappa)/40);
 [~,index]=max(kappa((1+margin):(end-margin))); index=index+margin;
 
-% A corner adjacent to either end means that it is outside the
-% sampled interval and the analysis has not found it
+% A corner at the edge means it is outside the sampled interval
 if (index<=(2*margin))||(index>=(numel(kappa)-2*margin))
     error('L-curve corner is outside the regularisation parameter range, widen it.');
 end


### PR DESCRIPTION
Follow-up to #191: the three comment blocks I added there span two or three lines, against the repository convention that each conceptually distinct operation carries a **one-line** comment. Condensed to one line each; behaviour is unchanged and `checkcode` is clean.

This is the same rule that was flagged on #190. To stop it recurring rather than fixing it case by case, the house-style rules that `checkcode` cannot see — one-line comments, no inline comments, a blank line before each block, no full stop on a one-sentence comment, no comments inside `grumble`, no tabs, two blank lines at end of file — are now enforced mechanically by a checker in my own tooling, run as a mandatory gate on every changed `.m` file. It is calibrated against this codebase and flags all three of my violations here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
