### PR TITLE
Validate parameters.needs in context function grumblers

### DIFF
--- a/kernel/contexts/crystal.m
+++ b/kernel/contexts/crystal.m
@@ -241,10 +241,10 @@ for n=1:numel(parameters.rframes)
     end
 end
 
-if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs(:)))
     error('parameters.needs must be a cell array of character strings.');
 end
-if any(~ismember(parameters.needs,{'zeeman_op','aniso_eq'}))
+if any(~ismember(parameters.needs(:),{'zeeman_op','aniso_eq'}))
     error('parameters.needs may only contain ''zeeman_op'' and ''aniso_eq'' in this context.');
 end
 

--- a/kernel/contexts/crystal.m
+++ b/kernel/contexts/crystal.m
@@ -241,6 +241,13 @@ for n=1:numel(parameters.rframes)
     end
 end
 
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+    error('parameters.needs must be a cell array of character strings.');
+end
+if any(~ismember(parameters.needs,{'zeeman_op','aniso_eq'}))
+    error('parameters.needs may only contain ''zeeman_op'' and ''aniso_eq'' in this context.');
+end
+
 end
 
 % Why do they always teach us that it's easy and evil to do what we 

--- a/kernel/contexts/doublerot.m
+++ b/kernel/contexts/doublerot.m
@@ -472,10 +472,10 @@ for n=1:numel(parameters.rframes)
     end
 end
 
-if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs(:)))
     error('parameters.needs must be a cell array of character strings.');
 end
-if any(~ismember(parameters.needs,{'iso_eq'}))
+if any(~ismember(parameters.needs(:),{'iso_eq'}))
     error('parameters.needs may only contain ''iso_eq'' in this context.');
 end
 

--- a/kernel/contexts/doublerot.m
+++ b/kernel/contexts/doublerot.m
@@ -472,6 +472,13 @@ for n=1:numel(parameters.rframes)
     end
 end
 
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+    error('parameters.needs must be a cell array of character strings.');
+end
+if any(~ismember(parameters.needs,{'iso_eq'}))
+    error('parameters.needs may only contain ''iso_eq'' in this context.');
+end
+
 end
 
 % Show me a hero and I'll write you a tragedy.

--- a/kernel/contexts/floquet.m
+++ b/kernel/contexts/floquet.m
@@ -387,6 +387,13 @@ if ~isa(pulse_sequence,'function_handle')
     error('pulse_sequence argument must be a function handle.');
 end
 
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+    error('parameters.needs must be a cell array of character strings.');
+end
+if any(~ismember(parameters.needs,{'iso_eq'}))
+    error('parameters.needs may only contain ''iso_eq'' in this context.');
+end
+
 end
 
 % If you've got a good idea then go ahead and do it. It's always

--- a/kernel/contexts/floquet.m
+++ b/kernel/contexts/floquet.m
@@ -387,10 +387,10 @@ if ~isa(pulse_sequence,'function_handle')
     error('pulse_sequence argument must be a function handle.');
 end
 
-if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs(:)))
     error('parameters.needs must be a cell array of character strings.');
 end
-if any(~ismember(parameters.needs,{'iso_eq'}))
+if any(~ismember(parameters.needs(:),{'iso_eq'}))
     error('parameters.needs may only contain ''iso_eq'' in this context.');
 end
 

--- a/kernel/contexts/gridfree.m
+++ b/kernel/contexts/gridfree.m
@@ -319,6 +319,13 @@ elseif numel(parameters.offset)~=numel(parameters.spins)
     error('parameters.offset variable must have the same number of elements as parameters.spins.');
 end
 
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+    error('parameters.needs must be a cell array of character strings.');
+end
+if any(~ismember(parameters.needs,{'iso_eq'}))
+    error('parameters.needs may only contain ''iso_eq'' in this context.');
+end
+
 end
 
 % No god and no religion can survive ridicule. No political church, 

--- a/kernel/contexts/gridfree.m
+++ b/kernel/contexts/gridfree.m
@@ -319,10 +319,10 @@ elseif numel(parameters.offset)~=numel(parameters.spins)
     error('parameters.offset variable must have the same number of elements as parameters.spins.');
 end
 
-if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs(:)))
     error('parameters.needs must be a cell array of character strings.');
 end
-if any(~ismember(parameters.needs,{'iso_eq'}))
+if any(~ismember(parameters.needs(:),{'iso_eq'}))
     error('parameters.needs may only contain ''iso_eq'' in this context.');
 end
 

--- a/kernel/contexts/liquid.m
+++ b/kernel/contexts/liquid.m
@@ -220,6 +220,13 @@ for n=1:numel(parameters.rframes)
     end
 end
 
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+    error('parameters.needs must be a cell array of character strings.');
+end
+if any(~ismember(parameters.needs,{'rdc','zeeman_op','rho_eq'}))
+    error('parameters.needs may only contain ''rdc'', ''zeeman_op'', and ''rho_eq'' in this context.');
+end
+
 end
 
 % A man who can conceive a thing as beautiful as this should never 

--- a/kernel/contexts/liquid.m
+++ b/kernel/contexts/liquid.m
@@ -220,10 +220,10 @@ for n=1:numel(parameters.rframes)
     end
 end
 
-if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs(:)))
     error('parameters.needs must be a cell array of character strings.');
 end
-if any(~ismember(parameters.needs,{'rdc','zeeman_op','rho_eq'}))
+if any(~ismember(parameters.needs(:),{'rdc','zeeman_op','rho_eq'}))
     error('parameters.needs may only contain ''rdc'', ''zeeman_op'', and ''rho_eq'' in this context.');
 end
 

--- a/kernel/contexts/powder.m
+++ b/kernel/contexts/powder.m
@@ -408,6 +408,12 @@ end
 
 % Additional needs
 if isfield(parameters,'needs')
+    if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+        error('parameters.needs must be a cell array of character strings.');
+    end
+    if any(~ismember(parameters.needs,{'zeeman_op','iso_eq','aniso_eq'}))
+        error('parameters.needs may only contain ''zeeman_op'', ''iso_eq'', and ''aniso_eq'' in this context.');
+    end
     if ismember('iso_eq',parameters.needs)&&ismember('aniso_eq',parameters.needs)
         error('iso_eq and aniso_eq needs cannot be specified simultaneously.');
     end

--- a/kernel/contexts/powder.m
+++ b/kernel/contexts/powder.m
@@ -408,10 +408,10 @@ end
 
 % Additional needs
 if isfield(parameters,'needs')
-    if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+    if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs(:)))
         error('parameters.needs must be a cell array of character strings.');
     end
-    if any(~ismember(parameters.needs,{'zeeman_op','iso_eq','aniso_eq'}))
+    if any(~ismember(parameters.needs(:),{'zeeman_op','iso_eq','aniso_eq'}))
         error('parameters.needs may only contain ''zeeman_op'', ''iso_eq'', and ''aniso_eq'' in this context.');
     end
     if ismember('iso_eq',parameters.needs)&&ismember('aniso_eq',parameters.needs)

--- a/kernel/contexts/singlerot.m
+++ b/kernel/contexts/singlerot.m
@@ -500,6 +500,13 @@ for n=1:numel(parameters.rframes)
     end
 end
         
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
+    error('parameters.needs must be a cell array of character strings.');
+end
+if any(~ismember(parameters.needs,{'iso_eq'}))
+    error('parameters.needs may only contain ''iso_eq'' in this context.');
+end
+
 end
 
 % There are no set working hours, your contract requires you to work such

--- a/kernel/contexts/singlerot.m
+++ b/kernel/contexts/singlerot.m
@@ -400,6 +400,13 @@ end
 % Consistency enforcement
 function grumble(spin_system,pulse_sequence,parameters,assumptions)
 
+if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs(:)))
+    error('parameters.needs must be a cell array of character strings.');
+end
+if any(~ismember(parameters.needs(:),{'iso_eq'}))
+    error('parameters.needs may only contain ''iso_eq'' in this context.');
+end
+
 % Option combination restrictions
 if isfield(parameters,'rho0')&&isfield(parameters,'needs')&&...
    ismember('iso_eq',parameters.needs)
@@ -500,13 +507,6 @@ for n=1:numel(parameters.rframes)
     end
 end
         
-if (~iscell(parameters.needs))||any(~cellfun(@ischar,parameters.needs))
-    error('parameters.needs must be a cell array of character strings.');
-end
-if any(~ismember(parameters.needs,{'iso_eq'}))
-    error('parameters.needs may only contain ''iso_eq'' in this context.');
-end
-
 end
 
 % There are no set working hours, your contract requires you to work such


### PR DESCRIPTION
The seven context functions that read `parameters.needs` (`crystal`, `doublerot`, `floquet`, `gridfree`, `liquid`, `powder`, and `singlerot`) document the field as a cell array of character strings but never validate it.

With a bare character string `ismember` degenerates to character membership: every character of `iso_eq` occurs in `aniso_eq`, so `ismember('iso_eq','aniso_eq')` returns `[1 1 1 1 1 1]`, the `if` is true, the isotropic equilibrium branch fires, and the `elseif` for the anisotropic branch is unreachable. The user silently gets an orientation-independent thermal equilibrium state. An unrecognised or misspelled need was equally silent: it simply did nothing.

Each grumbler now enforces two conditions:

- `parameters.needs` must be a cell array of character strings, using the same test as `experiments/spin_chem/rydmr_exp.m`;
- it may only contain needs that the context actually implements: `zeeman_op` and `aniso_eq` in `crystal`, `iso_eq` in `doublerot`, `floquet`, `gridfree`, and `singlerot`, `rdc`, `zeeman_op`, and `rho_eq` in `liquid`, and `zeeman_op`, `iso_eq`, and `aniso_eq` in `powder`.

In `powder` both checks are placed inside the existing `if isfield(parameters,'needs')` block and before the `ismember(...)&&ismember(...)` exclusion test, which raises an uninformative `MATLAB:nonLogicalConditional` when the field is a bare string. Function bodies and APIs are unchanged.

Validation:

- A probe running all seven contexts with a bare string, an unrecognised need, and the correct cell array: 14 informative rejections and 7 runs that reach the pulse sequence. Against the unpatched tree the same 21 cases produced 20 runs that reached the pulse sequence and one `MATLAB:nonLogicalConditional`.
- Nine shipped examples that pass `needs` through the patched contexts run to completion: `cp_powder_static_nh`, `singlet_yield_anisotropy_1`, `crosspol_powder_static_1`, `cross_effect_freq_scan_1`, `rdc_twospin`, `tau_scan_si_sys_a`, `singlet_yield_4`, `cp_contact_mas_nh_fplanck`, and `cp_contact_mas_nh_floquet`.
- A scan of the whole tree found no call site that passes a need outside its context's implemented set, so nothing shipped changes behaviour.
- `checkcode` is empty on all seven files.