### PR TITLE
chirp_pulse.m: preserve pi phase flips in the saltire amplitude-phase output

### DIFF
--- a/kernel/pulses/chirp_pulse.m
+++ b/kernel/pulses/chirp_pulse.m
@@ -83,7 +83,7 @@ if contains(type,'saltire')
     [Cx,Cy,durs,ints]=chirp_pulse(npts,dur,bwidth,smp,type);
 
     % Zero out Y component and update parameters
-    Cy=zeros(size(Cy)); amps=abs(Cx); phis=(pi/2)*sign(Cy); return;
+    Cy=zeros(size(Cy)); amps=abs(Cx); phis=pi*(Cx<0); return;
 
 end
 


### PR DESCRIPTION
Audit item 13. The saltire branch computed `phis=(pi/2)*sign(Cy)` on the same line that had just set `Cy` to zero, so `phis` was identically zero and every negative real lobe of the waveform became a positive amplitude with no compensating phase. The amplitude-phase pair therefore did not reconstruct the Cartesian waveform.

Fix: `phis=pi*(Cx<0)`, i.e. phase pi exactly where the real lobe is negative. `amps=abs(Cx)` is unchanged, and `Cx`, `Cy`, `durs`, `ints` are untouched, so all in-tree consumers (the SPEN experiments use only `Cx,Cy`) are unaffected.

Validation (MATLAB R2026a): focused probe on a 1000-point saltire — `amps.*exp(1i*phis)` reconstructs `Cx+1i*Cy` to 6.3e-13, phases are exactly {0,pi}, negative lobes present so the check is not vacuous, and all other outputs are bit-identical to stock main. Shipped `kernel/pulses_waveform_suite` regression test passes; `checkcode` and the house-style gate are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
