### PR TITLE
state.m: reject impossible projection quantum numbers in zeeman-wavef calls

### DIFF
--- a/kernel/state.m
+++ b/kernel/state.m
@@ -278,6 +278,12 @@ end
 if isnumeric(states)&&any(mod(states,0.5)~=0,'all')
     error('spin projection numbers must be integer or half-integer.');
 end
+if isnumeric(states)
+    spin_qn=(spin_system.comp.mults(:).'-1)/2;
+    if any(abs(states(:).')>spin_qn)||any(mod(states(:).'+spin_qn,1)~=0)
+        error('each projection quantum number must be an allowed level of its spin.');
+    end
+end
 if iscell(states)&&iscell(spins)&&(numel(states)~=numel(spins))
     error('spins and operators cell arrays should have the same number of elements.');
 end


### PR DESCRIPTION
Audit item 7. The `zeeman-wavef` branch built each one-hot factor by comparing the requested projection against the allowed levels, `levels==states(n)`. A projection outside the `-S:S` ladder of its spin, or one with the wrong integer/half-integer character (e.g. `m=0` for a spin-1/2), matched nothing, produced an all-zero factor, and the function silently returned a zero wavefunction instead of rejecting an impossible state.

Fix: `grumble` now checks every numeric projection against the multiplicity of its own spin — `abs(m)<=S` and `mod(m+S,1)==0` — and throws before any Kronecker product is built. No valid call changes behaviour.

Validation (MATLAB R2026a): stock main measured returning a zero-norm vector for `state(spin_system,[0 0])` on a `{'1H','14N'}` system; with the fix, valid projections `[1/2 0]` and `[-1/2 -1]` produce exactly the correct one-hot Kronecker vectors, and all four impossible specifications `[3/2 0]`, `[0 0]`, `[1/2 -2]`, `[1/2 1/2]` are rejected. Shipped `hilbert_state`, `state_projection`, and `multiprop_adaptive` regression tests pass; `checkcode` and the house-style gate are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
