### PR TITLE
deut_pair.m: dephasing filter must not keep single-spin coherences

### DIFF
--- a/kernel/states/deut_pair.m
+++ b/kernel/states/deut_pair.m
@@ -10,8 +10,10 @@
 %   spin_b  - the number of the second spin 
 %
 %   options.dephasing - set to 1 to eliminate the states that are
-%                       not stationary under Az+Bz Hamiltonian, 
-%                       the default is to keep everything
+%                       not stationary under the Zeeman Hamilto-
+%                       nian of two inequivalent spins, i.e. to
+%                       keep only zero-projection products; the
+%                       default is to keep everything
 %
 % Outputs:
 %
@@ -73,7 +75,7 @@ for n=1:numel(IST)
         [L1,M1]=lin2lm(n-1); [L2,M2]=lin2lm(k-1);
 
         % Skip non-stationary states on user request
-        if (M1~=0)&&(M2~=0)&&(options.dephasing==1), continue; end
+        if ((M1~=0)||(M2~=0))&&(options.dephasing==1), continue; end
 
         % Build Spinach state descriptor
         descr_a=['T' int2str(L1) ',' int2str(M1)];


### PR DESCRIPTION
Audit item 8. The documentation said `options.dephasing` eliminates states not stationary under the `Az+Bz` Hamiltonian, but the implemented mask skipped a product component only when **both** projection indices were nonzero. That keeps single-spin coherences (`M1=0, M2~=0` and vice versa), which are not stationary under any Zeeman Hamiltonian — code and header disagreed under every reading.

The audit suggested a total-coherence test (`M1+M2=0`, stationarity for **equivalent** spins). I implemented the strict per-spin filter instead — keep only `M1=M2=0` — because the only in-tree consumer of the dephasing option, `examples/parahydrogen/ortho_deuterium.m` (Bargon's continuous-deuteration Figure 1), has **inequivalent** deuterons (1.2 vs 2.3 ppm), where zero-quantum flip-flop terms precess at the shift difference and dephase during bubbling as well. The dephased outputs are then exactly the diagonal parts of the undephased states, i.e. the classic PASADENA-style time average. The header now states this. If the equal-frequency (`M1+M2`) reading is the intended one, say so and I will change the mask and the header accordingly.

Measured consequences (MATLAB R2026a):
- The `ortho_deuterium.m` fid is **bit-identical** before and after the fix (relative change 0): for the population outputs `S`, `T`, `Q` the old and new masks coincide, because single-M product components have zero coefficients in populations. No shipped result changes.
- The behaviour change is confined to the `Tc`/`Qc` coherence outputs under dephasing, which no in-tree code requests: stock kept components with a commutator norm of 171.9 against an unequal-weight Zeeman Hamiltonian; fixed outputs commute to below 1e-12.
- Fixed dephased `S`, `T`, `Q` equal `diag(diag(.))` of the undephased ones to 1e-12; undephased outputs are bit-identical to stock.
- Shipped `state_projection` and `state_constructor` suites pass; `checkcode` and the house-style gate are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
