### PR TITLE
rseq_compiler.m: cache composite-pulse propagators by phase-duration pair

### DIFF
--- a/kernel/pulses/rseq_compiler.m
+++ b/kernel/pulses/rseq_compiler.m
@@ -48,33 +48,40 @@ function [P,T]=rseq_compiler(spin_system,L,Sx,Sy,pulse_phi,...
 % Check consistency
 grumble(L,Sx,Sy,pulse_phi,pulse_amp,pulse_dur,element_type);
 
-% Find unique phases
-[phi,~,T]=unique(pulse_phi);
-
-% Preallocate propagators
-P=cell(numel(phi),1);
-
 % Compute propagators
 switch element_type
-    
+
     % Sequence of pi pulses
     case '180_pulse'
-        
+
+        % Find unique phases
+        [phi,~,T]=unique(pulse_phi);
+
+        % Preallocate propagators
+        P=cell(numel(phi),1);
+
         % Run matrix exponentials
         for n=1:numel(phi)
             LP=L+pulse_amp*(Sx*cos(phi(n))+Sy*sin(phi(n)));
             P{n}=propagator(spin_system,LP,pulse_dur);
         end
-    
+
     % Sequence of composite pulses
     case '90270_pulse'
-        
+
+        % Alternating segment durations
+        seg_durs=repmat([pulse_dur(1); pulse_dur(2)],numel(pulse_phi)/2,1);
+
+        % Find unique phase-duration pairs
+        [phi_dur,~,T]=unique([pulse_phi(:) seg_durs],'rows');
+
+        % Preallocate propagators
+        P=cell(size(phi_dur,1),1);
+
         % Run matrix exponentials
-        for n=1:2:numel(phi)
-            LP=L+pulse_amp*(Sx*cos(phi(n))+Sy*sin(phi(n)));
-            P{n}=propagator(spin_system,LP,pulse_dur(1));
-            LP=L+pulse_amp*(Sx*cos(phi(n+1))+Sy*sin(phi(n+1)));
-            P{n+1}=propagator(spin_system,LP,pulse_dur(2));
+        for n=1:size(phi_dur,1)
+            LP=L+pulse_amp*(Sx*cos(phi_dur(n,1))+Sy*sin(phi_dur(n,1)));
+            P{n}=propagator(spin_system,LP,phi_dur(n,2));
         end
         
     otherwise


### PR DESCRIPTION
Audit item 12. The `90270_pulse` branch cached propagators by unique phase only, then walked the sorted unique-phase list in odd/even pairs assigning `pulse_dur(1)` and `pulse_dur(2)` by list position. Phase identity does not identify a composite segment — duration is part of the propagator — and the sorted-unique list position carries no segment information. The canonical in-phase composite `90x270x` (`pulse_phi=[0;0]`) passes `grumble`, collapses to one unique phase, and crashes with an out-of-bounds index (measured on stock: "Index exceeds the number of array elements"); any composite whose segments share a phase would silently collapse to a single duration.

Fix: the composite branch now builds the alternating per-segment duration vector and caches by unique `(phase,duration)` rows; the index map `T` comes from the same `unique(...,'rows')` call. The `180_pulse` branch is byte-for-byte unchanged.

Validation (MATLAB R2026a): in-phase `[0;0]` composite now compiles with both propagators exact to machine precision against direct `expm`; a shared-phase sequence `[0;pi/2;pi/2;0]` resolves all four segments correctly by duration; the shipped test case `[0;pi/2]` produces identical `P` and `T` to stock; the `180_pulse` branch is regression-checked. Shipped `pulse_utilities_deep` and `pulses_propagation_suite` tests pass; `checkcode` and the house-style gate are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
