### PR TITLE
ocparse.m: keep the sign of the ORCA spin density

### DIFF
--- a/experiments/pseudocon/kpcs.m
+++ b/experiments/pseudocon/kpcs.m
@@ -5,7 +5,9 @@
 %
 % Parameters: 
 %
-%     probden - electron probability density cube.
+%     probden - electron spin density cube, signed, normalised
+%               to unit integral; negative spin-polarisation
+%               lobes are permitted.
 %
 %     chi     - electron magnetic susceptibility tensor in cubic Angstroms.
 %
@@ -106,7 +108,7 @@ if (~isnumeric(chi))||(size(chi,1)~=3)||(size(chi,2)~=3)||(~isreal(chi))
     error('chi parameter should be a real 3x3 matrix.');
 end
 if (~isnumeric(probden))||(ndims(probden)~=3)||(~isreal(probden))
-    error('probden parameter should be a real non-negative 3D array.');
+    error('probden parameter should be a real 3D array.');
 end
 if (~isnumeric(ranges))||(numel(ranges)~=6)||(~isreal(ranges))||...
    (ranges(1)>=ranges(2))||(ranges(3)>=ranges(4))||(ranges(5)>=ranges(6))

--- a/interfaces/orca/ocparse.m
+++ b/interfaces/orca/ocparse.m
@@ -1,6 +1,6 @@
-% ORCA cube file parser. Extracts the normalised probability density and
-% the associated metric information from ORCA spin density in "3D simple
-% format" (see ORCA manual). Syntax:
+% ORCA cube file parser. Extracts the signed spin density, normalised
+% to unit integral, and the associated metric information from an ORCA
+% spin density file in "3D simple format" (see ORCA manual). Syntax:
 %
 %            [density,ext,dx,dy,dz]=ocparse(filename,pad_factor)
 %
@@ -14,8 +14,8 @@
 %
 % Outputs:
 %
-%    density  - probability density cube with dimensions
-%               ordered as [X Y Z]
+%    density  - signed spin density cube, normalised to unit
+%               integral, with dimensions ordered as [X Y Z]
 %
 %    ext      - grid extents in Angstrom, ordered as
 %               [xmin xmax ymin ymax zmin zmax]
@@ -42,8 +42,8 @@ A=importdata(filename,' ',4);
 % Get the number of points along [x y z]
 npts=str2num(A.textdata{2}); %#ok<ST2NM>
 
-% Make the probability density cube
-density=reshape(abs(A.data),npts(2),npts(3),npts(1));
+% Make the spin density cube
+density=reshape(A.data,npts(2),npts(3),npts(1));
 density=permute(density,[3 2 1]);
 
 % Get the corner coordinates 
@@ -53,9 +53,9 @@ corner_xyz=str2num(A.textdata{3}); %#ok<ST2NM>
 dxdydz=str2num(A.textdata{4}); %#ok<ST2NM>
 dx=dxdydz(1); dy=dxdydz(2); dz=dxdydz(3);
 
-% Integrate and normalise probability density
-total_prob=trapz(trapz(trapz(density)))*dx*dy*dz;
-density=density/total_prob;
+% Normalise the spin density to unit integral
+total_spin=trapz(trapz(trapz(density)))*dx*dy*dz;
+density=density/total_spin;
 
 % Compute grid extents
 ext=[corner_xyz(1) (corner_xyz(1)+(npts(1)-1)*dx)...

--- a/interfaces/orca/ocparse.m
+++ b/interfaces/orca/ocparse.m
@@ -53,8 +53,14 @@ corner_xyz=str2num(A.textdata{3}); %#ok<ST2NM>
 dxdydz=str2num(A.textdata{4}); %#ok<ST2NM>
 dx=dxdydz(1); dy=dxdydz(2); dz=dxdydz(3);
 
-% Normalise the spin density to unit integral
+% Refuse densities with a negligible net spin
 total_spin=trapz(trapz(trapz(density)))*dx*dy*dz;
+total_abs=trapz(trapz(trapz(abs(density))))*dx*dy*dz;
+if abs(total_spin)<1e-3*total_abs
+    error('spin density integrates to zero, normalisation is not possible.');
+end
+
+% Normalise the spin density to unit integral
 density=density/total_spin;
 
 % Compute grid extents


### PR DESCRIPTION
Audit item 6. The parser stated that it consumes ORCA spin density, then built `density=reshape(abs(A.data),...)` and normalised the result as a probability density. Spin density is signed; `abs` destroys the cancellation between positive and negative spin-polarisation lobes, and inflates the normalisation integral, so everything downstream (the `kpcs` Kuprov-equation PCS solver in `porphyrin_example_3.m`) received a corrupted source term.

Fix: the sign is kept and the cube is normalised by its signed integral (the net spin), which is the quantity that the Kuprov-equation source term requires. The header and comments now say "signed spin density, normalised to unit integral" instead of the self-contradictory "probability density ... from ORCA spin density".

Validation (MATLAB R2026a), on the shipped `cu_porph_sd120.spindens.3d` through the full production `kpcs` path with the shipped padding: the signed density has genuine negative lobes (min -0.0099 against max 4.79); the twelve porphyrin proton PCS values move from stock `[-1.463 x8, -1.864 x4]` ppm to `[-1.489 x8, -1.820 x4]` ppm, against the hyperfine-route reference `[-1.532 x8, -1.898 x4]` ppm computed in the same example. Overall relative deviation from the hyperfine reference improves from 3.58 to 3.40 percent. The improvement is modest here because Cu(II) porphyrin has weak spin polarisation; the defect is larger for systems with significant negative spin density. `checkcode` and the house-style gate are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
