### PR TITLE
stoch_chop.m: unbiased stochastic compression of state vectors

### DIFF
--- a/kernel/utilities/stoch_chop.m
+++ b/kernel/utilities/stoch_chop.m
@@ -1,0 +1,109 @@
+% Unbiased stochastic compression of a state vector. Reduces the
+% number of non-zeroes to a user-specified target in such a way
+% that the expectation value of every element of the result is
+% exactly equal to the corresponding element of the input. Ele-
+% ments with magnitudes above a calibrated threshold are kept
+% exactly, and the remainder are retained with probabilities pro-
+% portional to their magnitudes using systematic resampling, the
+% survivors being rescaled by the reciprocal of their retention
+% probability. In contrast to the deterministic amplitude thres-
+% holding performed by clean_up.m, the error introduced here has
+% zero mean, and therefore averages out across an ensemble of in-
+% dependent trajectories, allowing the truncation error to be es-
+% timated from the scatter of the ensemble. Syntax:
+%
+%                   v=stoch_chop(v,nnz_target)
+%
+% Parameters:
+%
+%    v          - a state vector, a complex column vector
+%
+%    nnz_target - the number of non-zeroes to keep, a posi-
+%                 tive integer; an input having this many
+%                 non-zeroes or fewer is returned unchanged
+%
+% Outputs:
+%
+%    v          - a column vector of the same dimension and
+%                 storage class as the input, having at most
+%                 nnz_target non-zeroes
+%
+% Note: the threshold is the unique solution of the requirement
+%       that the retention probabilities of the sub-threshold
+%       elements must sum to the number of slots left over by
+%       the elements kept exactly, and must not exceed unity.
+%
+% Note: the random number stream is not reset, call rng() before
+%       this function when a reproducible sequence is required.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=stoch_chop.m>
+
+function v=stoch_chop(v,nnz_target)
+
+% Check consistency
+grumble(v,nnz_target);
+
+% Locate the non-zeroes
+nz_idx=find(v);
+
+% Bail out when the vector is already sparse enough
+if numel(nz_idx)<=nnz_target, return; end
+
+% Rank the non-zeroes by decreasing magnitude
+[mags,sort_idx]=sort(abs(nonzeros(v)),'descend');
+ranked_idx=nz_idx(sort_idx);
+
+% Sums of the magnitudes left over by each retention count
+tail_sums=sum(mags)-[0; cumsum(mags(1:(nnz_target-1)))];
+
+% Thresholds implied by each retention count
+thresholds=tail_sums./((nnz_target:-1:1)');
+
+% Smallest retention count at which no probability exceeds unity
+n_kept=find(mags(1:nnz_target)<=thresholds,1)-1;
+
+% Retention probabilities of the sub-threshold elements
+retn_prob=mags((n_kept+1):end)/thresholds(n_kept+1);
+
+% Cumulative probability axis, closed at the exact total
+bin_edges=[0; cumsum(retn_prob)];
+bin_edges(end)=nnz_target-n_kept;
+
+% Systematically placed sample points, one per available slot
+sample_pts=rand()+(0:(nnz_target-n_kept-1))';
+
+% Sub-threshold elements selected by the sample points
+picked=discretize(sample_pts,bin_edges);
+
+% Rescale the survivors to keep the expectation value exact
+v(ranked_idx(n_kept+picked))=v(ranked_idx(n_kept+picked))./retn_prob(picked);
+
+% Discard everything that was neither kept nor picked
+dropped=true(numel(nz_idx),1);
+dropped(1:n_kept)=false;
+dropped(n_kept+picked)=false;
+v(ranked_idx(dropped))=0;
+
+end
+
+% Consistency enforcement
+function grumble(v,nnz_target)
+if (~isnumeric(v))||(~ismatrix(v))||(size(v,2)~=1)
+    error('v must be a numeric column vector.');
+end
+if any(~isfinite(nonzeros(v)))
+    error('v must not have NaN or Inf elements.');
+end
+if (~isnumeric(nnz_target))||(~isreal(nnz_target))||(~isscalar(nnz_target))||...
+   (mod(nnz_target,1)~=0)||(nnz_target<1)
+    error('nnz_target must be a positive real integer.');
+end
+end
+
+% Anyone who considers arithmetical methods of producing random
+% digits is, of course, in a state of sin.
+%
+% John von Neumann
+


### PR DESCRIPTION
## What this adds

A single new kernel utility, `kernel/utilities/stoch_chop.m`, which reduces the
number of non-zeroes in a state vector to a user-specified target with an error
that has zero mean.

Spinach currently compresses state vectors deterministically: `clean_up.m` drops
every element whose magnitude falls below a tolerance. That is fast and simple,
but the error is systematic, so it does not average out, and its size cannot be
estimated from the calculation itself.

`stoch_chop.m` does the same job stochastically. It calibrates a threshold from
the requirement that the retention probabilities of the sub-threshold elements
sum to the number of slots left over by the elements kept exactly, and never
exceed unity. Elements above that threshold are kept exactly, and the rest are
selected by systematic resampling with probabilities proportional to their
magnitudes, each survivor being rescaled by the reciprocal of its retention
probability. The expectation value of every element of the output is then
exactly the corresponding element of the input, so the truncation error can be
estimated from the scatter across independent trajectories.

The function is standalone, calls nothing outside base MATLAB, and changes no
existing code.

## Validation

Headless probe, all invariants asserted, complete log clean, unique marker
reached. Test vector: 500 complex elements with heavy-tailed magnitudes
(`exp(3*randn)`), compressed to 50 non-zeroes.

```
PROBE: checkcode clean
PROBE: pass-through exact
PROBE: support, phase, and calibration invariants hold
PROBE: support containment holds
PROBE: 26 elements kept exactly, 26 kept in every trial
PROBE: max |z| over 322 sampled elements = 3.005
PROBE: overlap |z| = 0.240
PROBE: deterministic error 3.4153e-02, ensemble mean error 4.0273e-04
PROBE: median single-trajectory error 1.0576e-01
PROBE: sparse storage preserved
PROBE: real input stays real
PROBE: degenerate magnitudes handled
PROBE: dominant element kept exactly
PROBE: grumbler rejects malformed input
STOCH_CHOP_PROBE_OK
```

What the numbers mean:

- **Calibration.** In every one of 200 trials the output support is exactly the
  requested size, the surviving elements keep their phases, no survivor is
  scaled down, all resampled survivors share one common magnitude equal to the
  threshold, every exactly-kept element lies above that threshold, and every
  dropped element lies below it.
- **Unbiasedness, element by element.** Over 40000 independent compressions,
  the largest |z| deviation of the sample mean from the input, over the 322
  elements sampled often enough for a normal approximation, is 3.005. The
  expected maximum of 322 half-normal draws is about 3.2.
- **Unbiasedness, aggregate.** The overlap with a fixed random probe vector
  aggregates every element, including those sampled too rarely for an
  element-wise test. Its |z| is 0.240.
- **Bias removal.** Deterministic top-50 truncation of this vector has a 3.4e-2
  relative error that no amount of repetition removes. The mean of 40000
  stochastic compressions is 4.0e-4 from the input, consistent with pure Monte
  Carlo noise at that sample size.
- **The trade-off, stated honestly.** A single stochastic trajectory has a
  median relative error of 1.06e-1, about three times worse than deterministic
  thresholding at the same support size. The method buys an unbiased estimator
  and a computable error bar at the cost of per-trajectory noise; it is worth
  using when trajectories are averaged, not when one shot is all there is.
- **Storage and edge cases.** Sparse storage class is preserved, real input
  stays real, an input with fewer non-zeroes than the target is returned
  unchanged, uniform magnitudes are handled (all 200 elements sub-threshold,
  survivors correctly rescaled to 10), and a vector dominated by one element
  keeps that element exactly.
- **Style gates.** `check_house_style.py` reports 0 violations; MATLAB
  `checkcode` on the file is empty.