### PR TITLE
fig2tiles: merge at a requested figure size, off the screen

### DIFF
--- a/kernel/plotting/fig2tiles.m
+++ b/kernel/plotting/fig2tiles.m
@@ -20,7 +20,8 @@
 %       ated, and so the figure must already have its final size at
 %       that point. Matlab shrinks a visible figure to fit the disp-
 %       lay; the merge therefore runs off the screen, and the figure
-%       is only shown at the end when the size requested does fit.
+%       is only shown at the end, at the visibility the caller has
+%       set as the figure default, when its outer extent fits.
 %       Figures bigger than the screen stay invisible and must be
 %       written out with exportgraphics.m or print.m; if they are
 %       reopened later with openfig.m, Matlab refits them to the
@@ -45,6 +46,9 @@ for n=1:numel(fig_files)
     [row_num,col_num]=ind2sub(size(fig_files),n);
     tile_nums(n)=(row_num-1)*tile_cols+col_num;
 end
+
+% Note the figure visibility the caller has set as the default
+def_visible=get(groot,'defaultFigureVisible');
 
 % Create the new figure off the screen at the size requested
 fig_obj=kfigure('Units','pixels','Position',[0 0 fig_size],...
@@ -313,8 +317,9 @@ for n=1:numel(fig_files)
 
     catch err
 
-        % Delete the invisible source figure
+        % Delete the source and the incomplete destination figure
         delete(src_fig);
+        delete(fig_obj);
 
         % Rethrow the error
         rethrow(err);
@@ -335,10 +340,16 @@ if panel_count>0
                             panel_objs(1:panel_count)};
 end
 
-% Show the figure when the size requested fits on the screen
+% Get the screen size in pixels whatever the root units are
+root_units=get(groot,'Units');
+set(groot,'Units','pixels');
 screen_size=get(groot,'ScreenSize');
-if all(fig_size<=screen_size(3:4))
-    set(fig_obj,'Visible','on');
+set(groot,'Units',root_units);
+
+% Show the figure at the caller's default when its outer extent fits
+outer_size=get(fig_obj,'OuterPosition');
+if all(outer_size(3:4)<=screen_size(3:4))
+    set(fig_obj,'Visible',def_visible);
 end
 
 end

--- a/kernel/plotting/fig2tiles.m
+++ b/kernel/plotting/fig2tiles.m
@@ -1,11 +1,14 @@
 % Combines Matlab figure files into a single tiled figure. Syntax:
 %
-%              [fig_obj,tile_obj]=fig2tiles(fig_files)
+%          [fig_obj,tile_obj]=fig2tiles(fig_files,fig_size)
 %
 % Parameters:
 %
 %    fig_files - cell array of character strings containing
 %                Matlab *.fig file names
+%
+%    fig_size  - width and height of the merged figure in scr-
+%                een pixels, a two-element row vector
 %
 % Outputs:
 %
@@ -13,14 +16,24 @@
 %
 %    tile_obj - handle of the tiled layout object
 %
+% Note: tile geometry is measured at the moment the layout is cre-
+%       ated, and so the figure must already have its final size at
+%       that point. Matlab shrinks a visible figure to fit the disp-
+%       lay; the merge therefore runs off the screen, and the figure
+%       is only shown at the end when the size requested does fit.
+%       Figures bigger than the screen stay invisible and must be
+%       written out with exportgraphics.m or print.m; if they are
+%       reopened later with openfig.m, Matlab refits them to the
+%       screen and the size requested here is lost.
+%
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=fig2tiles.m>
 
-function [fig_obj,tile_obj]=fig2tiles(fig_files)
+function [fig_obj,tile_obj]=fig2tiles(fig_files,fig_size)
 
 % Check consistency
-grumble(fig_files);
+grumble(fig_files,fig_size);
 
 % Get the tile grid size
 tile_rows=size(fig_files,1);
@@ -33,8 +46,9 @@ for n=1:numel(fig_files)
     tile_nums(n)=(row_num-1)*tile_cols+col_num;
 end
 
-% Create the new figure
-fig_obj=kfigure();
+% Create the new figure off the screen at the size requested
+fig_obj=kfigure('Units','pixels','Position',[0 0 fig_size],...
+                'Visible','off');
 
 % Create a loose tiled layout
 tile_obj=tiledlayout(fig_obj,tile_rows,tile_cols,'TileSpacing','loose',...
@@ -321,6 +335,12 @@ if panel_count>0
                             panel_objs(1:panel_count)};
 end
 
+% Show the figure when the size requested fits on the screen
+screen_size=get(groot,'ScreenSize');
+if all(fig_size<=screen_size(3:4))
+    set(fig_obj,'Visible','on');
+end
+
 end
 
 % Synchronises overlay panels with their tiled placeholders
@@ -333,7 +353,11 @@ end
 end
 
 % Consistency enforcement
-function grumble(fig_files)
+function grumble(fig_files,fig_size)
+if (~isnumeric(fig_size))||(~isreal(fig_size))||(~isrow(fig_size))||...
+   (numel(fig_size)~=2)||any(fig_size<1)||any(mod(fig_size,1)~=0)
+    error('fig_size must be a row vector of two positive whole numbers.');
+end
 if (~iscell(fig_files))||isempty(fig_files)||(~ismatrix(fig_files))
     error('fig_files must be a non-empty two-dimensional cell array of file names.');
 end

--- a/kernel/plotting/fig2tiles.m
+++ b/kernel/plotting/fig2tiles.m
@@ -350,6 +350,10 @@ set(groot,'Units',root_units);
 outer_size=get(fig_obj,'OuterPosition');
 if all(outer_size(3:4)<=screen_size(3:4))
     set(fig_obj,'Visible',def_visible);
+else
+    warning(['the merged figure is bigger than the screen, it stays '...
+             'off the screen and does not appear; use savefig.m to '...
+             'keep it and exportgraphics.m to write it out.']);
 end
 
 end


### PR DESCRIPTION
Merging panels into a figure that is taller than the screen was not possible: `fig2tiles` created the merged figure at the default size, and any later resize came too late, because the tile `OuterPosition` values are read at the `drawnow` immediately after the layout is created. Matlab also shrinks a *visible* figure to fit the display, so a tall merge was clamped by the monitor and `scale_figure` could not recover the aspect ratio.

The merged figure size is now an argument, the assembly runs off the screen, and the figure is only shown at the end when the size requested does fit on the screen.

```
[fig_obj,tile_obj]=fig2tiles(fig_files,fig_size)
```

Measured on MATLAB R2026a, Linux, merging the five panels of Figure S11 of the ststst GRAPE manuscript (each panel a 1500x420 pixel row):

- previously, and on the reporting user's machine, the merged figure came out 978x897 pt where the five panels need 978x1430 pt, and the y axis labels of adjacent rows collided;
- with `fig2tiles(fig_files,[1500 2100])` the merged figure holds `Position [0 0 1500 2100]` through the merge and the export, and the vector PDF comes out 978x1430 pt;
- reopening a saved oversized `.fig` with `openfig` refits it to the screen (1500x2100 comes back as 1500x1296 here), so the export has to happen in the same run; this is recorded in the function header.

No callers of `fig2tiles` exist in the repository, so no other file needed changing. The Wiki page for `fig2tiles.m` will need the new syntax.

Reported by Guinevere Mathies (Konstanz).