### PR TITLE
Method of moving asymptotes as control.method='mma' in fmaxnewton

### DIFF
--- a/kernel/optimcon/fmaxnewton.m
+++ b/kernel/optimcon/fmaxnewton.m
@@ -1,5 +1,16 @@
-% Finds a local maximum of a function of several variables using Newton
-% and quasi-Newton algorithms. Syntax:
+% Finds a local maximum of a function of several variables using Newton,
+% quasi-Newton, and moving asymptote algorithms. The algorithm is chosen
+% by control.method in optimcon.m; 'lbfgs', 'rbfgs', 'newton', and 'good-
+% win' take a line search along a search direction, whereas 'mma' solves
+% a convex separable subproblem with poles at the moving asymptotes and
+% accepts its solution as the next iterate, as described in
+%
+%             https://doi.org/10.1002/nme.1620240207
+%
+% The amplitude bounds set in optimcon.m are hard box constraints in the
+% moving asymptote method, but only soft penalties in the other methods;
+% the penalties listed in control.penalties are folded into the objecti-
+% ve by objeval.m in all cases. Syntax:
 %
 %          [x,data]=fmaxnewton(spin_system,cost_function,guess)
 %
@@ -11,7 +22,9 @@
 %    cost_function - a function handle that takes the input
 %                    the size of guess
 %
-%    guess         - the initial point of the optimisation
+%    guess         - the initial point of the optimisation,
+%                    which must be within the amplitude bo-
+%                    unds when control.method is 'mma'
 %
 % Outputs:
 %
@@ -85,6 +98,11 @@ else
     frozen=false(size(x));
 
 end
+
+% Stretch the amplitude bounds and get their span
+lo_bound=spin_system.control.l_bound.*ones(data.x_shape); lo_bound=lo_bound(:);
+up_bound=spin_system.control.u_bound.*ones(data.x_shape); up_bound=up_bound(:);
+bnd_span=up_bound-lo_bound;
 
 % Print the header
 header(spin_system);
@@ -189,27 +207,89 @@ for n=1:spin_system.control.max_iter
             % Get the search direction
             dir=zeros(size(frozen));
             dir(~frozen)=H\g(~frozen);
-            
+
+        case 'mma'
+
+            % Get objective and gradient
+            [data,fx,g]=objeval(x,cost_function,data,spin_system);
+
+            % Tidy up the gradient
+            g=real(g);
+
+            % Switch to the minimisation convention of the method
+            grad=-g;
+
+            % Place the asymptotes symmetrically at the first two iterations
+            if n<3
+
+                lo_asym=x-0.05*bnd_span; up_asym=x+0.05*bnd_span;
+
+            else
+
+                % Contract the asymptotes on oscillation and relax them otherwise
+                adapt=ones(size(x)); osc=(x-x_prev).*(x_prev-x_prev2);
+                adapt(osc<0)=0.7; adapt(osc>0)=1.2;
+                lo_asym=x-adapt.*(x_prev-lo_asym);
+                up_asym=x+adapt.*(up_asym-x_prev);
+
+                % Keep the asymptote distances within the standard safeguards
+                lo_asym=max(min(lo_asym,x-0.01*bnd_span),x-10*bnd_span);
+                up_asym=min(max(up_asym,x+0.01*bnd_span),x+10*bnd_span);
+
+            end
+
+            % Set the move limits of the subproblem
+            mov_lo=max(lo_bound,lo_asym+0.1*(x-lo_asym));
+            mov_up=min(up_bound,up_asym-0.1*(up_asym-x));
+
+            % Build the convex separable approximation
+            grad_pos=max(grad,0); grad_neg=max(-grad,0);
+            p_term=((up_asym-x).^2).*(1.001*grad_pos+0.001*grad_neg+1e-5./bnd_span);
+            q_term=((x-lo_asym).^2).*(0.001*grad_pos+1.001*grad_neg+1e-5./bnd_span);
+
+            % Solve the subproblem in closed form and clip to the move limits
+            x_new=(sqrt(p_term).*lo_asym+sqrt(q_term).*up_asym)./...
+                  (sqrt(p_term)+sqrt(q_term));
+            x_new=min(max(x_new,mov_lo),mov_up);
+
+            % Shift the iterate history
+            if n>1, x_prev2=x_prev; end
+            x_prev=x;
+
+            % Get the search direction
+            dir=zeros(size(frozen));
+            dir(~frozen)=x_new(~frozen)-x(~frozen);
+
     end
 
     % Store the reference point
     g_ref=g(~frozen); dir_ref=dir(~frozen);
 
-    % If line search would be worthwhile, get a bracket [A B] of acceptable points
-    [A,B,alpha,fx_new,g_new,next_act,data]=bracketing(cost_function,1,dir,x,fx,...
-                                                      g.*(~frozen),data,spin_system);
+    % The moving asymptote subproblem already returns the step
+    if strcmp(spin_system.control.method,'mma')
 
-    % Run sectioning if necessary
-    if strcmp(next_act,'sectioning')
-    
-        % Find an acceptable point within the [A B] bracket    
-       [alpha,fx,g,exitflag,data]=sectioning(cost_function,A,B,x,fx,g.*(~frozen),...
-                                             dir,data,spin_system);
-                                 
+        % Accept the solution of the subproblem
+        alpha=1;
+
     else
 
-        % History update
-        fx=fx_new; g=g_new;
+        % If line search would be worthwhile, get a bracket [A B] of acceptable points
+        [A,B,alpha,fx_new,g_new,next_act,data]=bracketing(cost_function,1,dir,x,fx,...
+                                                          g.*(~frozen),data,spin_system);
+
+        % Run sectioning if necessary
+        if strcmp(next_act,'sectioning')
+
+            % Find an acceptable point within the [A B] bracket
+            [alpha,fx,g,exitflag,data]=sectioning(cost_function,A,B,x,fx,g.*(~frozen),...
+                                                  dir,data,spin_system);
+
+        else
+
+            % History update
+            fx=fx_new; g=g_new;
+
+        end
 
     end
 
@@ -287,6 +367,7 @@ switch(spin_system.control.method)
     case 'rbfgs',   data.algorithm='Regularised BFGS method';
     case 'newton',  data.algorithm='Regularised Newton-Raphson method';
     case 'goodwin', data.algorithm='Regularised Newton-Raphson method with Goodwin acceleration';
+    case 'mma',     data.algorithm='Method of moving asymptotes';
 end
 switch exitflag
     case  1, message='norm(gradient,2) < tol_gfx';
@@ -338,6 +419,18 @@ if ~isfield(spin_system,'control')
 end
 if (~isnumeric(guess))||(~isreal(guess))
     error('guess must be an array of real numbers.');
+end
+if strcmp(spin_system.control.method,'mma')
+    if ~isempty(spin_system.control.basis)
+        error('moving asymptote optimiser is not available with a waveform basis.');
+    end
+    if isfield(spin_system.control,'amplitudes')
+        error('moving asymptote optimiser is not available for phase-modulated optimisations.');
+    end
+    if any(guess>spin_system.control.u_bound,'all')||...
+       any(guess<spin_system.control.l_bound,'all')
+        error('guess must be within control.l_bound and control.u_bound.');
+    end
 end
 switch spin_system.control.integrator
     case 'rectangle'

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -115,8 +115,8 @@ if isfield(control,'method')
 
     % Input validation
     if (~ischar(control.method))||(~ismember(control.method,{'lbfgs','rbfgs',...
-                                                             'newton','goodwin'}))
-        error('control.method must be ''lbfgs'', ''rbfgs'', ''newton'', or ''goodwin''.');
+                                                             'newton','goodwin','mma'}))
+        error('control.method must be ''lbfgs'', ''rbfgs'', ''newton'', ''goodwin'', or ''mma''.');
     end
 
     % Absorb the method


### PR DESCRIPTION
Adds the method of moving asymptotes ([Svanberg, *Int. J. Numer. Meth. Engng* **24**, 359 (1987)](https://doi.org/10.1002/nme.1620240207)) to the existing optimiser as `control.method='mma'`. No new top-level function: the algorithm is a new branch of `fmaxnewton.m`, and `optimcon.m` accepts the new keyword.

**What it does.** At each iteration the objective is replaced by the separable convex surrogate with poles at the moving asymptotes, the coefficients being fixed by matching the true gradient at the current point. With only the amplitude box present the subproblem has a closed-form solution, so `control.l_bound` and `control.u_bound` are honoured exactly instead of being pushed by the spillout penalty. The asymptotes move by the standard sign heuristic (contract by 0.7 on oscillation, relax by 1.2 otherwise, distances kept between 0.01 and 10 amplitude ranges); the initial separation is 5% of the amplitude range rather than Svanberg's 50%, which was measured to stall waveform optimisations. Because the subproblem returns the next iterate directly, this branch takes no line search.

The implementation is clean-room from the 1987 paper. Svanberg's reference MATLAB implementation is GPLv3 and Spinach is MIT, so it cannot be bundled or wrapped.

**Scope guards.** The grumbler refuses `'mma'` when a waveform basis or a phase-modulated optimisation is in use (the amplitude box then does not describe the optimisation variables) and when the initial guess is outside the box.

**Regression.** All four existing methods were run on the same two-spin test problem before and after the patch: `lbfgs` 0.746925, `rbfgs` 0.746925, `newton` 0.779537, `goodwin` 0.779537 in both cases, with identical amplitude maxima and gradient counts. `checkcode` is clean on both touched files.

**Benchmark.** All seven shipped examples that use `'newton'` or `'goodwin'` and actually run an optimisation (`features_newton`, `features_freeze`, `state_transfer_wf`, `static_powder_control`, `rlc_response_2`, `transmon_frog`, `transmon_stirap`) were executed under `mma`, `lbfgs`, `rbfgs`, and their own method, from the same guess, at the shipped iteration cap, with plotting off, sequentially on one 24-core host, with the returned waveform re-evaluated once after the clock stopped. 31 runs.

- MMA uses exactly one gradient per iteration and no line search, against 51-113 gradients per 50-100 iterations for LBFGS/RBFGS and 74-266 gradients plus 26-100 Hessians for Newton/Goodwin.
- Against LBFGS that is worth between 28% less and 6% more wall clock; against Newton and Goodwin it is a factor of three to seventy.
- At equal iteration count MMA is behind on fidelity on all seven examples, by 0.03 to 0.43.
- MMA is the only method that returns a waveform inside the amplitude box; the others exceed it by up to 204%. Clipping the others into the box on `features_newton` (goodwin 0.997 -> 0.768, lbfgs 0.954 -> 0.923) still leaves them ahead of MMA (0.693), so the deficit is not the price of feasibility.
- The iterates are not monotonic: in five of seven examples the returned waveform is worse than the best point already evaluated, by up to 0.083.

The parallel ensemble reduction is not bit-reproducible, so repeated runs of the same configuration scatter: on `features_newton`, four MMA runs gave 0.637-0.807 and four LBFGS runs gave 0.935-0.976. Conclusions above are drawn only from gaps larger than that scatter.

**Caveats, stated in the header.** This is the m = 0 case of MMA: one objective, box constraints, closed-form subproblem. The formulation of He, Deng, Luy, and Korvink, *J. Chem. Phys.* **164**, 064114 (2026) needs the dual solve for m = 2N_ens and per-ensemble-member fidelities and gradients, which `ensemble.m` averages away before the optimiser sees them.
