### PR TITLE
Correct the Goodwin Hessian route for dissipative dynamics

### DIFF
--- a/kernel/optimcon/grape_liouv.m
+++ b/kernel/optimcon/grape_liouv.m
@@ -278,8 +278,6 @@ switch spin_system.control.integrator
                 P_cum{n}=propagator(ss_parfor,L_forw{n},dt(n));
                 if n>1
                     P_cum{n}=P_cum{n}*P_cum{n-1};
-                    P_cum{n}=clean_up(spin_system,P_cum{n},...
-                                      spin_system.tols.prop_chop);
                 end
             end
 
@@ -640,9 +638,9 @@ if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
                 % Loop over controls
                 for k=1:nctrls
 
-                    % Propagate forward derivatives
+                    % Invert forward derivatives back
                     % to first time step
-                    fwd_dP{k,n}=P_cum{n}'*fwd_dP{k,n};
+                    fwd_dP{k,n}=P_cum{n}\fwd_dP{k,n};
 
                     % From second step
                     if n>1

--- a/kernel/optimcon/grape_liouv.m
+++ b/kernel/optimcon/grape_liouv.m
@@ -279,6 +279,10 @@ switch spin_system.control.integrator
                 if n>1
                     P_cum{n}=P_cum{n}*P_cum{n-1};
                 end
+                if issparse(P_cum{n})&&(nnz(P_cum{n})>...
+                   spin_system.tols.dense_matrix*numel(P_cum{n}))
+                    P_cum{n}=full(P_cum{n});
+                end
             end
 
             % Take a time step forwards and backwards
@@ -632,15 +636,21 @@ if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
             % derivative trajectory
             bwd_dP=fliplr(bwd_dP);
 
+            % Preallocate conditioning flags
+            ill_cond=false(1,nsteps);
+
             % Loop over timesteps
             parfor n=1:nsteps
+
+                % Factorise the cumulative propagator and flag conditioning
+                P_cum_fact=decomposition(P_cum{n});
+                ill_cond(n)=isIllConditioned(P_cum_fact);
 
                 % Loop over controls
                 for k=1:nctrls
 
-                    % Invert forward derivatives back
-                    % to first time step
-                    fwd_dP{k,n}=P_cum{n}\fwd_dP{k,n};
+                    % Invert forward derivatives back to first time step
+                    fwd_dP{k,n}=P_cum_fact\fwd_dP{k,n};
 
                     % From second step
                     if n>1
@@ -653,6 +663,14 @@ if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
 
                 end
 
+            end
+
+            % Ill-conditioned cumulative propagators cost Hessian accuracy
+            if any(ill_cond)
+                report(spin_system,['WARNING - ill-conditioned cumulative '...
+                                    'propagator at ' num2str(nnz(ill_cond))...
+                                    ' of ' num2str(nsteps) ' time steps, '...
+                                    'Hessian accuracy is reduced.']);
             end
 
             % Flip the backward trajectory


### PR DESCRIPTION
The `goodwin` branch of `grape_liouv.m` composed the propagator string required by Eq. (8) of Goodwin and Kuprov, *J. Chem. Phys.* **144**, 204107 (2016) as `P_cum{n-1}*P_cum{m}'`, using the adjoint where the inverse is needed. That is the same operator only for unitary propagators; under a dissipative drift the Hessian error grows with the loss of unitarity over the pulse, silently, because the shipped consistency test runs without relaxation.

Fix: `fwd_dP{k,n}=P_cum{n}\fwd_dP{k,n}` instead of `P_cum{n}'*fwd_dP{k,n}`. The backward side, `bwd_dP{k,n}'*P_cum{n-1}`, was already exact and is untouched — only the forward derivatives need un-propagating. The `clean_up` of the cumulative propagator at `tols.prop_chop` had to go with it: element dropping zeroes whole rows of a strongly decaying propagator, the chopped matrix becomes exactly singular, and the solve then returns NaN.

Accuracy, three-spin `sphten-liouv` system, two controls, 20 slices of 100 us, both Hessians against a central finite difference (step 1e-5) of the analytical gradient. Relative one-norm deviation, rate scale / Newton / Goodwin before / Goodwin after: 0 / 4.38e-11 / 4.73e-10 / 4.38e-11; 1 / 4.98e-11 / 5.21e-3 / 4.98e-11; 10 / 4.70e-11 / 5.05e-2 / 4.70e-11; 100 / 5.39e-11 / 3.82e-1 / 5.39e-11; 1000 / 1.18e-10 / 8.69e-1 / 1.18e-10. The route stays linear in the slice count: 0.176, 0.127, 0.219, 0.406 and 0.857 s at 10, 20, 40, 80 and 160 slices, against 6.475 s for Newton at 160.

Review follow-up (`ba7dcb0`), after the P2 comments below:

* The solve sat inside the control loop, so `mldivide` refactorised the same matrix once per control. It is now factorised once per time slice with `decomposition` and reused. Measured on a four-spin `sphten-liouv` space (dimension 256), 40 slices, eight controls: 4.995 s before, 4.402 s after; unchanged at two controls.
* Removing `clean_up` also removed the sparse-to-full switch at `tols.dense_matrix`, so cumulative products that fill in stayed in sparse storage. That conversion is restored explicitly, without chopping — `clean_up` cannot be reused for it, as it returns early at zero tolerance.
* `isIllConditioned` comes free with the factorisation and is now reported. The inverse-free alternative does not exist inside Goodwin's method: the common time origin is exactly what buys the linear scaling.

Validation, MATLAB R2026a: `examples/fundamentals/derivative_tests/dirdiff_5_rect.m` passes all six Newton-against-Goodwin checks in `sphten-liouv`, `zeeman-liouv` and `zeeman-hilb`; the dissipative accuracy scan above reproduces on the reviewed code, matching Newton at every rate scale, including 1000 with chopping left at its default, where the condition number of the cumulative propagator has already overflowed; forcing the storage conversion by lowering `tols.dense_matrix` to 0.05 leaves the Newton-against-Goodwin deviation at 4.6e-16, identical to the unconverted run; `checkcode` on the changed file is empty and it gains no house-style violations.
