### PR TITLE
optimcon.m: refuse Goodwin's Hessian for non-Hermitian generators

### DIFF
--- a/kernel/optimcon/ctrl_trajan.m
+++ b/kernel/optimcon/ctrl_trajan.m
@@ -529,7 +529,8 @@ end
 if ismember('correlation_order',spin_system.control.plotting)
 
     % Disallow Zeeman formalisms
-    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv'})
+    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv',...
+                                           'zeeman-wavef'})
         error('trajectory analysis is not available in Zeeman formalisms, use sphten-liouv.');
     end
     
@@ -567,7 +568,8 @@ end
 if ismember('coherence_order',spin_system.control.plotting)
 
     % Disallow Zeeman formalisms
-    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv'})
+    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv',...
+                                           'zeeman-wavef'})
         error('trajectory analysis is not available in Zeeman formalisms, use sphten-liouv.');
     end
     
@@ -605,7 +607,8 @@ end
 if ismember('local_each_spin',spin_system.control.plotting)
 
     % Disallow Zeeman formalisms
-    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv'})
+    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv',...
+                                           'zeeman-wavef'})
         error('trajectory analysis is not available in Zeeman formalisms, use sphten-liouv.');
     end
     
@@ -643,7 +646,8 @@ end
 if ismember('total_each_spin',spin_system.control.plotting)
 
     % Disallow Zeeman formalisms
-    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv'})
+    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv',...
+                                           'zeeman-wavef'})
         error('trajectory analysis is not available in Zeeman formalisms, use sphten-liouv.');
     end
     
@@ -681,7 +685,8 @@ end
 if ismember('level_populations',spin_system.control.plotting)
 
     % Disallow Zeeman formalisms
-    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv'})
+    if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-liouv',...
+                                           'zeeman-wavef'})
         error('trajectory analysis is not available in Zeeman formalisms, use sphten-liouv.');
     end
     

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -153,8 +153,9 @@ if isfield(control,'operators')
         error('control.operators must be a cell array of matrices.');
     end
 
-    % In Hilbert space, disallow non-Hermitian controls
-    if strcmp('zeeman-hilb',spin_system.bas.formalism)
+    % Hilbert space and Goodwin's Hessian disallow non-Hermitian controls
+    if strcmp('zeeman-hilb',spin_system.bas.formalism)||...
+       strcmp('goodwin',spin_system.control.method)
 
         % Over controls
         for n=1:numel(control.operators)
@@ -166,7 +167,8 @@ if isfield(control,'operators')
 
             % Check the norms
             if norm_a>1e-10*norm_b
-                error('all control generators must be Hermitian in Hilbert space.');
+                error(['all control generators must be Hermitian in Hilbert '...
+                       'space and under control.method=''goodwin''.']);
             end
 
         end
@@ -706,9 +708,10 @@ if isfield(control,'drifts')
         error('all time-dependent drifts must have the same number of time slices.');
     end
 
-    % In Hilbert space, disallow non-Hermitian drifts
-    if strcmp('zeeman-hilb',spin_system.bas.formalism)
-        
+    % Hilbert space and Goodwin's Hessian disallow non-Hermitian drifts
+    if strcmp('zeeman-hilb',spin_system.bas.formalism)||...
+       strcmp('goodwin',spin_system.control.method)
+
         % Over drift ensemble
         for n=1:numel(control.drifts)
 
@@ -722,7 +725,8 @@ if isfield(control,'drifts')
 
                 % Check the norms
                 if norm_a>1e-10*norm_b
-                    error('all drift generators must be Hermitian in Hilbert space.');
+                    error(['all drift generators must be Hermitian in Hilbert '...
+                           'space and under control.method=''goodwin''.']);
                 end
 
             end

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -540,8 +540,29 @@ if isfield(control,'offsets')&&isfield(control,'off_ops')
         end
     end
 
+    % Goodwin's Hessian disallows non-Hermitian offset operators
+    if strcmp('goodwin',spin_system.control.method)
+
+        % Over offset channels
+        for n=1:numel(control.off_ops)
+
+            % Get pertinent norms
+            norm_a=cheap_norm(control.off_ops{n}-...
+                              control.off_ops{n}');
+            norm_b=cheap_norm(control.off_ops{n});
+
+            % Check the norms
+            if norm_a>1e-10*norm_b
+                error(['all offset operators must be Hermitian under '...
+                       'control.method=''goodwin''.']);
+            end
+
+        end
+
+    end
+
     % Absorb offset distributions
-    spin_system.control.offsets=control.offsets; 
+    spin_system.control.offsets=control.offsets;
     control=rmfield(control,'offsets');
 
     % Clean up and absorb offset operators

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -145,6 +145,11 @@ end
 % Inform the user
 report(spin_system,[pad('Optimisation method',60) spin_system.control.method]);
 
+% Hilbert space, wavefunctions, and Goodwin's Hessian need unitary propagation
+herm_gens=ismember(spin_system.bas.formalism,...
+                   {'zeeman-hilb','zeeman-wavef'})||...
+          strcmp(spin_system.control.method,'goodwin');
+
 % Process control operators
 if isfield(control,'operators')
 
@@ -153,26 +158,9 @@ if isfield(control,'operators')
         error('control.operators must be a cell array of matrices.');
     end
 
-    % Hilbert space and Goodwin's Hessian disallow non-Hermitian controls
-    if strcmp('zeeman-hilb',spin_system.bas.formalism)||...
-       strcmp('goodwin',spin_system.control.method)
-
-        % Over controls
-        for n=1:numel(control.operators)
-
-            % Get pertinent norms
-            norm_a=cheap_norm(control.operators{n}-...
-                              control.operators{n}');
-            norm_b=cheap_norm(control.operators{n});
-
-            % Check the norms
-            if norm_a>1e-10*norm_b
-                error(['all control generators must be Hermitian in Hilbert '...
-                       'space and under control.method=''goodwin''.']);
-            end
-
-        end
-
+    % Reject non-Hermitian controls where unitarity is required
+    if herm_gens
+        check_hermiticity(control.operators,'control generators');
     end
 
     % Control operator count
@@ -540,25 +528,9 @@ if isfield(control,'offsets')&&isfield(control,'off_ops')
         end
     end
 
-    % Goodwin's Hessian disallows non-Hermitian offset operators
-    if strcmp('goodwin',spin_system.control.method)
-
-        % Over offset channels
-        for n=1:numel(control.off_ops)
-
-            % Get pertinent norms
-            norm_a=cheap_norm(control.off_ops{n}-...
-                              control.off_ops{n}');
-            norm_b=cheap_norm(control.off_ops{n});
-
-            % Check the norms
-            if norm_a>1e-10*norm_b
-                error(['all offset operators must be Hermitian under '...
-                       'control.method=''goodwin''.']);
-            end
-
-        end
-
+    % Reject non-Hermitian offsets where unitarity is required
+    if herm_gens
+        check_hermiticity(control.off_ops,'offset operators');
     end
 
     % Absorb offset distributions
@@ -729,31 +701,11 @@ if isfield(control,'drifts')
         error('all time-dependent drifts must have the same number of time slices.');
     end
 
-    % Hilbert space and Goodwin's Hessian disallow non-Hermitian drifts
-    if strcmp('zeeman-hilb',spin_system.bas.formalism)||...
-       strcmp('goodwin',spin_system.control.method)
-
-        % Over drift ensemble
+    % Reject non-Hermitian drifts where unitarity is required
+    if herm_gens
         for n=1:numel(control.drifts)
-
-            % Over time slices
-            for k=1:numel(control.drifts{n})
-
-                % Get pertinent norms
-                norm_a=cheap_norm(control.drifts{n}{k}-...
-                                  control.drifts{n}{k}');
-                norm_b=cheap_norm(control.drifts{n}{k});
-
-                % Check the norms
-                if norm_a>1e-10*norm_b
-                    error(['all drift generators must be Hermitian in Hilbert '...
-                           'space and under control.method=''goodwin''.']);
-                end
-
-            end
-
+            check_hermiticity(control.drifts{n},'drift generators');
         end
-
     end
     
     % Inform the user
@@ -1359,6 +1311,27 @@ if ~isempty(unparsed)
         report(spin_system,['ERROR: unrecognised or mismatched option - ' unparsed{n}]);
     end
     error('there are problems with the control structure.');
+end
+
+end
+
+% Refuses a set of generators when any of them is not Hermitian
+function check_hermiticity(generators,generator_kind)
+
+% Over the supplied generators
+for n=1:numel(generators)
+
+    % Get pertinent norms
+    norm_a=cheap_norm(generators{n}-generators{n}');
+    norm_b=cheap_norm(generators{n});
+
+    % Check the norms
+    if norm_a>1e-10*norm_b
+        error(['all ' generator_kind ' must be Hermitian in zeeman-hilb '...
+               'and zeeman-wavef formalisms, and under '...
+               'control.method=''goodwin''.']);
+    end
+
 end
 
 end


### PR DESCRIPTION
Goodwin's Hessian route composes the propagator string between the two derivative insertions as `P_cum{n-1}*P_cum{m}'`, using the adjoint where the inverse belongs. That is the same operator only when the propagators are unitary. Under a non-Hermitian drift — a Liouvillian carrying relaxation, `H+1i*R` — or a non-Hermitian control operator, the Hessian error grows with the loss of unitarity over the pulse, and it does so silently: the shipped consistency test `dirdiff_5_rect.m` runs without relaxation, so it cannot see it. Measured previously on a three-spin `sphten-liouv` system, relative one-norm deviation of the Goodwin Hessian from a central finite difference of the analytical gradient: 4.7e-10 at zero relaxation, 5.2e-3, 5.1e-2, 3.8e-1 and 8.7e-1 as the relaxation superoperator is scaled by 1, 10, 100 and 1000, while the Newton route stays at 5e-11 throughout.

Rather than invert, refuse. The two Hermiticity checks that `optimcon.m` already applies to `control.drifts` and `control.operators` in Hilbert space are extended to `control.method='goodwin'` in every formalism, reusing the same `cheap_norm(A-A')>1e-10*cheap_norm(A)` test and the same loops. Four lines changed in each block, no new traversal code, no change to any other route.

Validation, MATLAB R2026a:

* All six shipped examples that select `control.method='goodwin'` — `static_powder_control`, `distortions/rlc_response_2`, `transmon_frog`, `transmon_stirap`, `features_freeze`, `state_transfer_wf` — still pass validation and reach their optimiser call. This covers lab-frame powder drift ensembles built by `drifts(...,'labframe')` with rotating-frame corrections, transmon quadrature control superoperators built from creation and annihilation operators, and the `zeeman-wavef`, `zeeman-liouv` and `sphten-liouv` formalisms. They were run with the optimiser call replaced by a sentinel error, so the generators are the examples' own and the validation is the real one.
* `examples/fundamentals/derivative_tests/dirdiff_5_rect.m` passes all six Newton-against-Goodwin checks in `sphten-liouv`, `zeeman-liouv` and `zeeman-hilb`.
* Refusals fire where they should and nowhere else: a `H+1i*R` drift is refused under `goodwin` and accepted under `newton` and `lbfgs`; a raising-operator control is refused under `goodwin` and accepted under `newton`; a Hermitian drift is accepted under `goodwin`.
* `checkcode` on the changed file is empty and it gains no house-style violations.

Supersedes #209, which corrected the route by inverting instead; that inverse was judged too dangerous to ship.

Review follow-up (`bab00db`): offset operators escaped the check. `ensemble.m` adds `control.offsets{k}*control.off_ops{k}` to the drift before propagation, so a non-Hermitian offset operator made the effective generator non-unitary while both the drifts and the controls passed. Measured on the three-spin system above with a Hermitian drift and Hermitian controls and one offset channel at 1 kHz: a `Lz` offset operator puts the Goodwin Hessian 9.8e-10 from Newton, a raising operator puts it 8.3e+02 away, and nothing warned. The same Hermiticity test now runs over `control.off_ops`. `static_powder_control` is the one shipped Goodwin example that uses offset operators, and its `Lz` operator still passes.

Second follow-up (`c67bc18`), on Ilya's instruction that Hilbert space must refuse non-Hermitian offsets too and that `zeeman-wavef` should carry the same refusals as `zeeman-hilb` across the optimal control module:

* The formalism condition and the method condition are folded into one flag computed once, `herm_gens`, and the three identical Hermiticity loops over drifts, controls and offset operators become a single `check_hermiticity` helper. `optimcon.m` ends up two lines shorter than stock despite gaining both the offset and the wavefunction cases.
* `zeeman-wavef` propagates as `exp(-1i*H*t)` exactly as `zeeman-hilb` does, so it now requires Hermitian generators on the same terms. It also joins `zeeman-hilb` and `zeeman-liouv` in the five `ctrl_trajan.m` refusals of trajectory analysis, which needs the spherical tensor basis; that list had omitted it.
* Survey of the rest of the module: the remaining `zeeman-hilb` branches in `optimcon.m` and `ensemble.m` are per-formalism dispatch with correct `zeeman-wavef` cases already present, `grape_hilb.m` requires a density matrix formalism and `grape_liouv.m` already lists `zeeman-wavef`, so no other refusal needed widening.

Re-validated: all six shipped Goodwin examples still pass, `dirdiff_5_rect.m` passes all six checks, and the refusals now fire in `zeeman-hilb` and `zeeman-wavef` for non-Hermitian drifts and offset operators under LBFGS while Hermitian generators are accepted in both. `ctrl_trajan` refuses `zeeman-wavef`, `zeeman-hilb` and `zeeman-liouv` for correlation order analysis and lets `sphten-liouv` through. `checkcode` is empty on both changed files and neither gains a house-style violation.
