### PR TITLE
fdvec.m: fix the sign of even-order derivatives at the right edge

### DIFF
--- a/kernel/derivatives/fdvec.m
+++ b/kernel/derivatives/fdvec.m
@@ -34,7 +34,7 @@ dx=zeros(size(x)); x=x(:);
 for n=1:(npoints-1)/2
     w=fdweights(n,1:npoints,order);
     dx(n)=w(end,:)*x(1:npoints);
-    dx(end-n+1)=-w(end,end:-1:1)*x((end-npoints+1):end);
+    dx(end-n+1)=((-1)^order)*w(end,end:-1:1)*x((end-npoints+1):end);
 end
 
 % Fill in the middle with centered schemes


### PR DESCRIPTION
The right-boundary sided stencils in `fdvec.m` were negated unconditionally: `dx(end-n+1)=-w(end,end:-1:1)*x(...)`. Reversing a finite-difference stencil flips its sign only for odd derivative orders; `fdmat.m` handles the same reflection with `((-1)^order)`. Even-order derivatives therefore came out with the wrong sign at the right edge; the affected callers are the curvatures in `lcurve.m` and `bloch_axis.m`.

Fix: the same parity factor as `fdmat.m` uses.

Validation, MATLAB R2026a, exp(x) on [0,3], 101 points, five-point stencil, `fdvec` against `fdmat(...,'wall')` applied to the same vector: orders 1 and 3 agree to 1.5e-13 and 6.4e-10 before and after the fix; order 2 disagreed by 4.0e+01 (= 2 exp(3), the two flipped edge rows) before and agrees to 7.7e-12 after; the patched right-edge second derivative lands 4.3e-04 from the analytic value, which is the stencil truncation level. `checkcode` empty; house-style gate clean. (Audit item F024-F061/F040.)