### PR TITLE
opium/full.m: keep the scalar coefficient in the dense conversion

### DIFF
--- a/kernel/overloads/@opium/full.m
+++ b/kernel/overloads/@opium/full.m
@@ -1,5 +1,5 @@
-% Converts an OPIUM object into a full
-% unit matrix. Syntax:
+% Converts an OPIUM object into the full scaled
+% unit matrix that it represents. Syntax:
 %
 %              M=full(M)
 %
@@ -9,8 +9,8 @@
 %
 % Outputs:
 %
-%     M - a full unit matrix of app-
-%         ropriate dimension
+%     M - a full scaled unit matrix
+%         of appropriate dimension
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -18,8 +18,8 @@
 
 function M=full(M)
     
-    % Make a unit matrix
-    M=eye(M.dim);
+    % Make a scaled unit matrix
+    M=M.coeff*eye(M.dim);
 
 end
 


### PR DESCRIPTION
`full()` of an OPIUM object returned `eye(M.dim)` regardless of `M.coeff`, while the constructor stores `opium(dim,coeff)` as coeff times the unit matrix and the multiplication paths honour that. Dense conversion of any scaled OPIUM therefore silently produced the unscaled identity.

Fix: `M=M.coeff*eye(M.dim)`, with the header wording updated to match.

Validation, MATLAB R2026a: `full(opium(4,3))` corner element was 1 stock and is 3 patched; `checkcode` empty; house-style gate reports only the pre-existing trailing-quote flag that stock carries. (Audit item F049.)