### PR TITLE
opium/nnz: recognise a zero-coefficient OPIUM as zero

### DIFF
--- a/kernel/overloads/@opium/opium.m
+++ b/kernel/overloads/@opium/opium.m
@@ -39,9 +39,13 @@ classdef (InferiorClasses={?gpuArray}) opium
         end
         
         % Number of non-zeroes
-        function n=nnz(op) %#ok<MANU>
+        function n=nnz(op)
             
-            n=1; % Always
+            if op.coeff==0
+                n=0;
+            else
+                n=1;
+            end
             
         end
         

--- a/kernel/overloads/@opium/opium.m
+++ b/kernel/overloads/@opium/opium.m
@@ -41,6 +41,7 @@ classdef (InferiorClasses={?gpuArray}) opium
         % Number of non-zeroes
         function n=nnz(op)
             
+            % Distinguish zero and scaled unit objects
             if op.coeff==0
                 n=0;
             else


### PR DESCRIPTION
`nnz()` of an OPIUM object returned 1 unconditionally, so a zero-coefficient OPIUM was never recognised as exactly zero. `polyadic/simplify.m` collapses zero cores through `nnz()==0`, so zero terms stayed buffered instead of taking the zero-matrix shortcut.

Fix: return 0 when `op.coeff==0`. The non-zero branch deliberately keeps the structural count of 1: the shipped overload predicate test (`tests/kernel/test_dynamic_overload_sparse_polyadic_suite.m`) asserts `nnz(opium(3,2))==1`, so the placeholder semantics for non-zero coefficients are upstream intent and are preserved.

Validation, MATLAB R2026a: `nnz(opium(4,0))` was 1 stock, 0 patched; `nnz(opium(4,2))` stays 1; `simplify(polyadic({{opium(3,0),speye(2)}}))` stays class `opium` stock and collapses to a sparse zero `double` patched; the shipped sparse_polyadic overload suite passes on the branch. `checkcode` empty; the file loses one of its four pre-existing inline-comment style flags and gains none. (Audit item F050.)