### PR TITLE
rcv/times: accept both operand orders

### DIFF
--- a/kernel/overloads/@rcv/times.m
+++ b/kernel/overloads/@rcv/times.m
@@ -1,37 +1,51 @@
-% Multiplies an RCV sparse matrix by a numeric scalar. Syntax:
+% Multiplies an RCV sparse matrix by a numeric scalar,
+% in either operand order. Syntax:
 %
-%                         A=times(k,A)
+%                        C=times(A,B)
 %
 % Parameters:
 %
-%    k - numeric scalar
-%
-%    A - RCV sparse matrix
+%    A,B - an RCV sparse matrix and a numeric
+%          scalar, in either order
 %
 % Outputs:
 %
-%    A - RCV sparse matrix
+%    C - RCV sparse matrix
 %
 % m.keitel@soton.ac.uk
 %
 % <https://spindynamics.org/wiki/index.php?title=rcv/times.m>
 
-function A=times(k,A)
+function C=times(A,B)
 
 % Check consistency
-grumble(k,A);
+grumble(A,B);
 
-% Multiply values
-A.val=k*A.val;
+% RCV sparse by a scalar
+if isa(A,'rcv')
+
+    A.val=A.val*B; C=A;
+
+% Scalar by RCV sparse
+else
+
+    B.val=B.val*A; C=B;
+
+end
 
 end
 
 % Consistency enforcement
-function grumble(k,A)
-if ~isa(A,'rcv')
-    error('the second argument must be an RCV sparse matrix.');
+function grumble(A,B)
+if ~xor(isa(A,'rcv'),isa(B,'rcv'))
+    error('exactly one of the arguments must be an RCV sparse matrix.');
 end
-if (~isnumeric(k))||(~isscalar(k))
+if isa(A,'rcv')
+    scalar_arg=B;
+else
+    scalar_arg=A;
+end
+if (~isnumeric(scalar_arg))||(~isscalar(scalar_arg))
     error('multiplication is only defined by numeric scalars.');
 end
 end


### PR DESCRIPTION
`times` was implemented as `times(k,A)` with the grumbler requiring the second argument to be RCV, so `scalar.*rcv` worked while `rcv.*scalar` failed validation — a commutative scalar operation behaved differently depending on operand order. Both orders are now dispatched, matching the structure of `rcv/mtimes`.

The grumbler also now refuses two RCV operands explicitly: RCV overloads `isnumeric` to true, so `rcv.*rcv` previously slipped past the scalar check and failed deeper with a misleading message.

Validation, MATLAB R2026a, `A=rcv(sparse([1 0;0 2]))`: stock `A.*3` errors with 'the second argument must be an RCV sparse matrix' and `3.*A` works; patched both give Frobenius norm 6.7082 = sqrt(45); `A.*A` now errors cleanly with 'exactly one of the arguments must be an RCV sparse matrix'. `checkcode` empty; house-style gate clean. (Audit item F052.)