### PR TITLE
ttclass/mtimes: keep tolerances non-negative under scalar multiplication

### DIFF
--- a/kernel/overloads/@ttclass/mtimes.m
+++ b/kernel/overloads/@ttclass/mtimes.m
@@ -23,7 +23,7 @@ function c=mtimes(a,b)
 if isa(a,'ttclass')&&isa(b,'double')&&isscalar(b)
     
     % Multiply tensor train by a scalar from the right
-    c=a; c.coeff=b*c.coeff; c.tolerance=b*c.tolerance;
+    c=a; c.coeff=b*c.coeff; c.tolerance=abs(b)*c.tolerance;
     
 elseif isa(a,'ttclass')&&isa(b,'double')&&numel(b)>1
     
@@ -70,7 +70,7 @@ elseif isa(a,'ttclass')&&isa(b,'double')&&numel(b)>1
 elseif isa(a,'double')&&isa(b,'ttclass')&&isscalar(a)
     
     % Multiply tensor train by a scalar from the left
-    c=b; c.coeff=a*c.coeff; c.tolerance=a*c.tolerance;
+    c=b; c.coeff=a*c.coeff; c.tolerance=abs(a)*c.tolerance;
     
 elseif isa(a,'ttclass')&&isa(b,'ttclass')
     


### PR DESCRIPTION
Both scalar branches of `ttclass/mtimes` scaled `c.tolerance` by the scalar itself, so multiplying a tensor train by a negative or complex scalar produced a negative or complex truncation tolerance, violating the invariant that later rank-truncation and error-control logic relies on.

Fix: scale by `abs(b)` in the right-scalar branch and `abs(a)` in the left-scalar branch.

Validation, MATLAB R2026a, `tt=ttclass(1,{sparse(magic(2))},0.1)`: `(tt*(-2)).tolerance` and `((-2)*tt).tolerance` were both -0.2 stock and are both 0.2 patched. `checkcode` empty; house-style gate clean. (Audit item F053.)