### PR TITLE
ttclass/rand: correct boundary ranks for one-core tensor trains

### DIFF
--- a/kernel/overloads/@ttclass/rand.m
+++ b/kernel/overloads/@ttclass/rand.m
@@ -31,11 +31,15 @@ grumble(tt,ttrank);
 tt.cores=cell(d,1);
 
 % Fill the cores with random elements
-tt.cores{1,1}=rand(1,sz(1,1),sz(1,2),ttrank);
-for k=2:d-1
-    tt.cores{k,1}=rand(ttrank,sz(k,1),sz(k,2),ttrank);
+if d==1
+    tt.cores{1,1}=rand(1,sz(1,1),sz(1,2),1);
+else
+    tt.cores{1,1}=rand(1,sz(1,1),sz(1,2),ttrank);
+    for k=2:d-1
+        tt.cores{k,1}=rand(ttrank,sz(k,1),sz(k,2),ttrank);
+    end
+    tt.cores{d,1}=rand(ttrank,sz(d,1),sz(d,2),1);
 end
-tt.cores{d,1}=rand(ttrank,sz(d,1),sz(d,2),1);
 
 % Unit coefficient and zero tolerance
 tt.coeff=1; tt.tolerance=0;


### PR DESCRIPTION
For a one-core tensor train, `rand(tt,ttrank)` first created the core as 1 x m x n x ttrank and then, because `d==1` makes the first and the last core the same cell, overwrote it with ttrank x m x n x 1 — an invalid left boundary rank whenever ttrank>1. A one-core train has no interior bonds, so ttrank does not apply and both boundary ranks must be 1.

Fix: an explicit `d==1` branch creating `rand(1,sz(1,1),sz(1,2),1)`; the `d>1` path is byte-identical logic.

Validation, MATLAB R2026a, `tr=rand(ttclass(1,{sparse(magic(3))},0),2)`: stock first core was 2 x 3 x 3 and `full(tr)` failed in reshape ('Number of elements must not change'); patched the core is 1 x 3 x 3 and `full(tr)` returns a 3 x 3 matrix. `checkcode` empty; house-style gate clean. (Audit item F054.)