### PR TITLE
ttclass/size: support the two-output call

### DIFF
--- a/kernel/overloads/@ttclass/size.m
+++ b/kernel/overloads/@ttclass/size.m
@@ -24,22 +24,25 @@
 function varargout=size(tt,dim)
 
 % Multiply up physical dimensions of all cores
-if nargin==1
-    m=prod(cellfun(@(x)size(x,2),tt.cores),1);
-    n=prod(cellfun(@(x)size(x,3),tt.cores),1);
-    varargout={[m(1) n(1)]};
-elseif dim==1
-    m=prod(cellfun(@(x)size(x,2),tt.cores),1);
-    varargout={m(1)};
-elseif dim==2
-    n=prod(cellfun(@(x)size(x,3),tt.cores),1);
-    varargout={n(1)};
+m=prod(cellfun(@(x)size(x,2),tt.cores),1);
+n=prod(cellfun(@(x)size(x,3),tt.cores),1);
+
+% Compose the answer
+if (nargin==1)&&(nargout<=1)
+    varargout{1}=[m(1) n(1)];
+elseif (nargin==1)&&(nargout==2)
+    varargout{1}=m(1);
+    varargout{2}=n(1);
+elseif (nargin==2)&&(dim==1)
+    varargout{1}=m(1);
+elseif (nargin==2)&&(dim==2)
+    varargout{1}=n(1);
 else
     error('incorrect call syntax.');
 end
 
 % Check for infinities
-if any(varargout{1}>intmax)
+if any(cellfun(@(x)any(x(:)>intmax),varargout))
     error('tensor train dimensions exceed Matlab''s intmax.');
 end
 


### PR DESCRIPTION
`size(tt)` assigned a single `varargout` cell regardless of `nargout`, so the header-advertised `[m,n]=size(tt)` call failed with 'Output argument "varargout{2}" not assigned'. MATLAB-compatible code paths that split dimensions this way could not use tensor trains.

Fix: branch on `nargout` as the `@opium` and `@polyadic` size overloads do; single-output and `dim`-argument calls are unchanged, and the intmax guard now covers every composed output.

Validation, MATLAB R2026a, on a 2 x 3 one-core train: stock `[m,n]=size(tt)` errors; patched returns m=2, n=3, while `size(tt)`=[2 3], `size(tt,1)`=2, `size(tt,2)`=3 are identical stock and patched. `checkcode` empty; house-style gate clean. (Audit item F055.)