### PR TITLE
ttclass/subsref: validate element indices before mixed-radix conversion

### DIFF
--- a/kernel/overloads/@ttclass/subsref.m
+++ b/kernel/overloads/@ttclass/subsref.m
@@ -49,8 +49,17 @@ switch reference(1).type
             error('exactly two indices required to evaluate tt(j,k) element');
         elseif isscalar(reference(1).subs{1})&&isscalar(reference(1).subs{2})
             siz=sizes(ttrain);
-            ind=ttclass_ind2sub(siz(:,1),reference(1).subs{1});
-            jnd=ttclass_ind2sub(siz(:,2),reference(1).subs{2});
+            row_ind=reference(1).subs{1}; col_ind=reference(1).subs{2};
+            if (~isnumeric(row_ind))||(~isreal(row_ind))||(mod(row_ind,1)~=0)||...
+               (row_ind<1)||(row_ind>prod(siz(:,1)))
+                error('row index must be a positive integer within matrix dimensions.');
+            end
+            if (~isnumeric(col_ind))||(~isreal(col_ind))||(mod(col_ind,1)~=0)||...
+               (col_ind<1)||(col_ind>prod(siz(:,2)))
+                error('column index must be a positive integer within matrix dimensions.');
+            end
+            ind=ttclass_ind2sub(siz(:,1),row_ind);
+            jnd=ttclass_ind2sub(siz(:,2),col_ind);
         else
             error('advanced indexing is not implemented for tensor trains.');
         end

--- a/kernel/overloads/@ttclass/subsref.m
+++ b/kernel/overloads/@ttclass/subsref.m
@@ -50,14 +50,9 @@ switch reference(1).type
         elseif isscalar(reference(1).subs{1})&&isscalar(reference(1).subs{2})
             siz=sizes(ttrain);
             row_ind=reference(1).subs{1}; col_ind=reference(1).subs{2};
-            if (~isnumeric(row_ind))||(~isreal(row_ind))||(mod(row_ind,1)~=0)||...
-               (row_ind<1)||(row_ind>prod(siz(:,1)))
-                error('row index must be a positive integer within matrix dimensions.');
-            end
-            if (~isnumeric(col_ind))||(~isreal(col_ind))||(mod(col_ind,1)~=0)||...
-               (col_ind<1)||(col_ind>prod(siz(:,2)))
-                error('column index must be a positive integer within matrix dimensions.');
-            end
+            if islogical(row_ind), row_ind=double(row_ind); end
+            if islogical(col_ind), col_ind=double(col_ind); end
+            grumble(row_ind,col_ind,siz);
             ind=ttclass_ind2sub(siz(:,1),row_ind);
             jnd=ttclass_ind2sub(siz(:,2),col_ind);
         else
@@ -88,6 +83,32 @@ end
 
 end
 
+% Consistency enforcement
+function grumble(row_ind,col_ind,siz)
+if (~isnumeric(row_ind))||(~isreal(row_ind))||...
+   (mod(row_ind,1)~=0)||(row_ind<1)||(row_ind>flintmax)
+    error('row index must be a positive integer not exceeding flintmax.');
+end
+if (~isnumeric(col_ind))||(~isreal(col_ind))||...
+   (mod(col_ind,1)~=0)||(col_ind<1)||(col_ind>flintmax)
+    error('column index must be a positive integer not exceeding flintmax.');
+end
+leftover=row_ind-1;
+for n=1:size(siz,1)
+    leftover=floor(leftover/siz(n,1));
+end
+if leftover>0
+    error('row index must be a positive integer within matrix dimensions.');
+end
+leftover=col_ind-1;
+for n=1:size(siz,1)
+    leftover=floor(leftover/siz(n,2));
+end
+if leftover>0
+    error('column index must be a positive integer within matrix dimensions.');
+end
+end
+
 % Index to subscript transformation
 function ivec=ttclass_ind2sub(siz,ind)
 d=numel(siz); ind=ind-1; ivec=zeros(d,1);
@@ -102,5 +123,4 @@ end
 %
 % A Russian saying
 
-% #NGRUM
 


### PR DESCRIPTION
Scalar element indices went into `ttclass_ind2sub` unchecked, and the mixed-radix conversion wraps out-of-range values through `mod`, so an index beyond the matrix dimension silently returned an unrelated element instead of raising MATLAB's normal indexing error.

Fix: both indices must be real positive integers within `prod(siz(:,1))` and `prod(siz(:,2))` respectively, checked before conversion.

Validation, MATLAB R2026a, on the 4 x 4 train `ttclass(1,{sparse(magic(2));sparse([1 2;3 4])},0)`: in-range `tt(3,2)` returns 8, equal to the dense `kron` element, stock and patched; out-of-range `tt(5,1)` silently returned 1 stock and now errors with 'row index must be a positive integer within matrix dimensions'. `checkcode` empty; house-style gate shows only the file's pre-existing three-line-comment flag, unchanged. (Audit item F056.)