### PR TITLE
polyadic/validate: check the core-facing end of the suffix chain

### DIFF
--- a/kernel/overloads/@polyadic/validate.m
+++ b/kernel/overloads/@polyadic/validate.m
@@ -67,7 +67,7 @@ end
 if (~isempty(p.prefix))&&(size(p.prefix{end},2)~=core_dims(1,1))
     error('inconsistent dimensions in prefix-core product.');
 end
-if (~isempty(p.suffix))&&(size(p.suffix{end},1)~=core_dims(1,2))
+if (~isempty(p.suffix))&&(size(p.suffix{1},1)~=core_dims(1,2))
     error('inconsistent dimensions in core-suffix product.');
 end
 if numel(p.prefix)>1


### PR DESCRIPTION
`polyadic/mtimes` applies suffixes in forward order (`B=A.suffix{n}*B` for `n=end:-1:1`), so the represented product is `prefix{1}...prefix{end} * core * suffix{1}...suffix{end}` and `suffix{1}` is what multiplies the core result directly. The core-suffix boundary check in `validate.m` compared the core column count against `size(p.suffix{end},1)`, i.e. the wrong end of the chain: valid multi-suffix chains were rejected, and a malformed core boundary with a dimensionally compatible tail could pass this particular check. The prefix side already checks its core-facing end (`prefix{end}`), and the suffix-sequence loop validates the chain interior — only the boundary comparison changes.

Validation, MATLAB R2026a: for a 3 x 3 core with suffixes 3 x 2 and 2 x 5 attached by two multiplications, `full(p)` matches the dense product to 0 and stock `validate(p)` throws 'inconsistent dimensions in core-suffix product' while patched `validate(p)` passes; a chain whose first suffix has the wrong row count remains rejected by the corrected comparison. `checkcode` empty; house-style gate clean. (Audit item F051.)