### PR TITLE
lorentzcon.m: handle three identical zero offsets

### DIFF
--- a/kernel/line_shapes/lorentzcon.m
+++ b/kernel/line_shapes/lorentzcon.m
@@ -37,15 +37,18 @@ offs=sort(offs(:),1,'ascend');
 
 % Similarity tolerance
 sim_tol=sqrt(eps)*norm(offs,2);
+if sim_tol==0
+    sim_tol=eps;
+end
 
 % Single offset or three identical vertices
-if isscalar(offs)||(offs(3)-offs(1)<sim_tol)
+if isscalar(offs)||(offs(3)-offs(1)<=sim_tol)
     
     % Just a Lorentzian curve
     y=(ampl/(pi*gam))./(1+((x-mean(offs))/gam).^2);
     
 % Vertices 1 and 2 identical
-elseif (offs(2)-offs(1)<sim_tol)
+elseif (offs(2)-offs(1)<=sim_tol)
     
     % Update the offsets
     offs=[mean(offs(1:2)) offs(3)];
@@ -56,7 +59,7 @@ elseif (offs(2)-offs(1)<sim_tol)
       ((ampl*gam/pi)/((offs(1)-offs(2))*(offs(1)-offs(2))))*log(((offs(1)-x).^2+gam^2)./((offs(2)-x).^2+gam^2));
     
 % Vertices 2 and 3 identical
-elseif (offs(3)-offs(2)<sim_tol)
+elseif (offs(3)-offs(2)<=sim_tol)
     
     % Update the offsets
     offs=[offs(1) mean(offs(2:3))];

--- a/kernel/line_shapes/lorentzcon.m
+++ b/kernel/line_shapes/lorentzcon.m
@@ -37,9 +37,6 @@ offs=sort(offs(:),1,'ascend');
 
 % Similarity tolerance
 sim_tol=sqrt(eps)*norm(offs,2);
-if sim_tol==0
-    sim_tol=eps;
-end
 
 % Single offset or three identical vertices
 if isscalar(offs)||(offs(3)-offs(1)<=sim_tol)


### PR DESCRIPTION
For `offs=[0 0 0]` the similarity tolerance `sqrt(eps)*norm(offs,2)` is zero, and with strict `<` comparisons every degenerate-vertex branch is missed, so a valid request for a zero-centred Lorentzian falls into the general triangle formula and divides by zero. `gausscon.m` already guards this with a zero-tolerance fallback to `eps` and inclusive `<=` comparisons; the same pattern is applied here (the shipped MEX binaries shadow this file and are addressed separately).

Validation, MATLAB R2026a with the MEX shelved so the .m dispatches: stock `lorentzcon([0 0 0],1,0.1,x)` returns NaN; patched it equals the scalar-offset Lorentzian exactly (deviation 0). Anchors unchanged stock vs patched: `[2 2 2]` equals its scalar form to 0, `[0 0 1]` finite with sum 2.904789, general triangle `[0 0.5 1]` sum 2.786259336 identical to nine digits. `checkcode` empty; house-style gate clean. (Audit item F045.)