### PR TITLE
dcm2euler.m: stop folding beta=pi to zero

### DIFF
--- a/kernel/conventions/transforms/dcm2euler.m
+++ b/kernel/conventions/transforms/dcm2euler.m
@@ -34,8 +34,8 @@ function [arg1,arg2,arg3]=dcm2euler(dcm)
 % Check consistency
 grumble(dcm);
 
-% Get the beta angle out and wrap it into [0,pi]
-beta=mod(acos(dcm(3,3)),pi);
+% Get the beta angle out, clamping the cosine into [-1,1]
+beta=acos(max(-1,min(1,dcm(3,3))));
 
 % Do a brute force surface scan with respect to alpha and gamma
 alphas=pi*linspace(0.05,1.95,20);


### PR DESCRIPTION
`acos` already returns beta in [0,pi]; the `mod(...,pi)` wrap only ever fires at exactly pi, mapping it to zero. Any valid ZYZ rotation with `dcm(3,3)=-1` — e.g. `euler2dcm(0,pi,0)` — therefore had beta pinned at zero, the alpha/gamma surface scan could not compensate, and the function reached its own 'DCM to Euler conversion failed' error. Round trips through the singular beta=pi branch were impossible.

Fix: clamp the cosine into [-1,1] and take `acos` directly. The clamp also protects `acos` from going complex on the slightly non-orthogonal matrices the grumbler deliberately admits below its 1e-2 hard error — stock, `dcm(3,3)=-1-1e-7` died inside `fminunc` with 'Argument must be real'.

Validation, MATLAB R2026a: `euler2dcm(0,pi,0)` and `euler2dcm(1.1,pi,0.4)` failed stock and reconstruct to 2.1e-17 and 3.7e-09 patched; 200 random rotations give an identical maximum reconstruction error of 2.5e-06 stock and patched (no regression); the beta=0 degenerate case is identical at 1.0e-08; the clamped near-singular input returns beta=pi to nine digits instead of erroring. `checkcode` empty; house-style gate clean. (Audit item F039.)