### PR TITLE
x2spinach.m: close the two-spin gap in the id sequence check

### DIFF
--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -115,11 +115,8 @@ sys.labels=sys.labels(index);
 inter.coordinates=inter.coordinates(index);
 
 % Check for missing spin ids
-if norm(diff(diff(spin_ids)),1)>1e-6
-    error('spin id numbers are not sequential integers.');
-end
-if min(spin_ids)~=1
-    error('spin id numbers must start from 1.');
+if ~isequal(spin_ids(:).',1:numel(spin_ids))
+    error('spin id numbers must be sequential integers starting from 1.');
 end
 
 % Preallocate interaction arrays


### PR DESCRIPTION
`norm(diff(diff(spin_ids)),1)` is empty for a two-element list, so a SpinXML file with spin ids [1 3] passed both the sequence check and the `min==1` check and loaded silently; interactions referencing the declared ids then index the compacted two-element arrays incorrectly or fail with confusing out-of-bounds errors. After the ascending sort the correct condition is a direct comparison against `1:numel(spin_ids)`, which also catches duplicates and subsumes the separate start-from-1 test.

Validation, MATLAB R2026a on synthetic SpinXML fixtures: a two-spin file with ids [1 3] loaded silently stock (2 isotopes returned) and is rejected patched; a three-spin file with ids [1 2 4] is rejected stock and patched; a valid [1 2] file loads identically in both, isotopes 1H and 13C. `checkcode` empty; house-style gate clean. (Audit item F036.)