### PR TITLE
optimcon.m: fix integrator error message typo

### DIFF
--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -92,7 +92,7 @@ if isfield(control,'integrator')
         error('control.integrator must be a character string.');
     end
     if ~ismember(control.integrator,{'rectangle','trapezium'})
-        error('control.intgrator must be either ''rectangle'' or ''trapezium''.');
+        error('control.integrator must be either ''rectangle'' or ''trapezium''.');
     end
 
     % Absorb integrator type


### PR DESCRIPTION
Audit item 29: the invalid-integrator error message said `control.intgrator` where the field is `control.integrator`. One-character fix in the error string.

Validation: probe triggers the error path and shows the corrected message; a valid `control.integrator='rectangle'` setup still passes; `checkcode` clean; house-style violation count unchanged versus stock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)