### PR TITLE
features_dt_opt.m: replace stray control character with microseconds

### DIFF
--- a/examples/optimal_control/features_dt_opt.m
+++ b/examples/optimal_control/features_dt_opt.m
@@ -104,7 +104,7 @@ subplot(1,2,2); plot_1d(spin_system,real(spectrum_new),parameters);
 ktitle('composite inversion, optimised');
 
 % Write the old and the new pulses to the console
-disp('Old and new durations (s):'); disp([dt_old dt_new]);
+disp('Old and new durations (microseconds):'); disp([dt_old dt_new]);
 
 end
 


### PR DESCRIPTION
Audit item 28: the duration display label contained a 0x1A (SUB) control character where the unit belonged — `durations (\x1as):`. The example works in units of `time_unit=1e-6`, so the label now reads `(microseconds)`. No µ glyphs exist anywhere in the repo, so the spelled-out unit follows repo prose convention.

Validation: file now contains zero control characters (grep -P class check); `checkcode` clean; house-style violation count unchanged versus stock (3 legacy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)