### PR TITLE
fix_path.m: anchor path setup at the function location

### DIFF
--- a/fix_path.m
+++ b/fix_path.m
@@ -21,6 +21,9 @@ end
 % Check consistency
 grumble(config_style);
 
+% Resolve the Spinach root directory
+spinach_root=fileparts(mfilename('fullpath'));
+
 % Run the configuration
 switch config_style
 
@@ -36,10 +39,10 @@ switch config_style
         disp('Updating Matlab path...');
 
         % Add Spinach directories to path
-        addpath(genpath('etc'),'-begin');
-        addpath(genpath('experiments'),'-begin');
-        addpath(genpath('interfaces'),'-begin');
-        addpath(genpath('kernel'),'-begin');
+        addpath(genpath(fullfile(spinach_root,'etc')),'-begin');
+        addpath(genpath(fullfile(spinach_root,'experiments')),'-begin');
+        addpath(genpath(fullfile(spinach_root,'interfaces')),'-begin');
+        addpath(genpath(fullfile(spinach_root,'kernel')),'-begin');
 
         % Run existential checks
         existentials();
@@ -53,10 +56,10 @@ switch config_style
         disp('Updating Matlab path...');
 
         % Keep revious path, add Spinach
-        addpath(genpath('etc'),'-begin');
-        addpath(genpath('experiments'),'-begin');
-        addpath(genpath('interfaces'),'-begin');
-        addpath(genpath('kernel'),'-begin');
+        addpath(genpath(fullfile(spinach_root,'etc')),'-begin');
+        addpath(genpath(fullfile(spinach_root,'experiments')),'-begin');
+        addpath(genpath(fullfile(spinach_root,'interfaces')),'-begin');
+        addpath(genpath(fullfile(spinach_root,'kernel')),'-begin');
 
         % Run existential checks
         existentials();
@@ -70,10 +73,10 @@ switch config_style
         disp('Updating Matlab path...');
 
         % Keep revious path, remove Spinach
-        rmpath(genpath('etc'));
-        rmpath(genpath('experiments'));
-        rmpath(genpath('interfaces'));
-        rmpath(genpath('kernel'));
+        rmpath(genpath(fullfile(spinach_root,'etc')));
+        rmpath(genpath(fullfile(spinach_root,'experiments')));
+        rmpath(genpath(fullfile(spinach_root,'interfaces')));
+        rmpath(genpath(fullfile(spinach_root,'kernel')));
 
         % Report to the console
         disp('Spinach folders have been removed from Matlab path.');


### PR DESCRIPTION
`fix_path` used `genpath` on relative directory names, so it only worked when the current directory happened to be the Spinach root: from anywhere else it added unrelated `etc`/`experiments`/`interfaces`/`kernel` folders from the caller's directory or nothing at all, and the remove mode had the symmetric failure, leaving Spinach folders on the path. All `addpath`/`rmpath` targets are now built from `fileparts(mfilename('fullpath'))`, so the function configures the Spinach tree it belongs to regardless of the caller's location.

Validation, MATLAB R2026a: from a foreign working directory, stock `fix_path('add')` added nothing and died with 'Unrecognized function or variable existentials'; patched it puts `kernel/evolution.m` of its own tree on the path and `fix_path('remove')` cleans it off again. From the Spinach root, add/remove cycles behave identically stock and patched. `checkcode` empty; house-style gate clean. (Audit item F033.)