### PR TITLE
tgrape.m: correct dt_grid validation and its error message

### DIFF
--- a/kernel/optimcon/tgrape.m
+++ b/kernel/optimcon/tgrape.m
@@ -146,8 +146,9 @@ end
 if size(waveform,1)~=numel(controls)
     error('number of waveform rows must be equal to the number of controls.');
 end
-if (~isnumeric(dt_grid))||(~isreal(dt_grid))||(~iscolumn(dt_grid))
-    error('dt_grid must be a real row vector.');
+if (~isnumeric(dt_grid))||(~isreal(dt_grid))||(~iscolumn(dt_grid))||...
+   any(~isfinite(dt_grid))
+    error('dt_grid must be a finite real column vector.');
 end
 if (~isnumeric(time_unit))||(~isreal(time_unit))||(numel(time_unit)~=1)||...
    (~isfinite(time_unit))||(time_unit<=0)


### PR DESCRIPTION
Audit item 24: `tgrape` enforced `iscolumn(dt_grid)` while the error message said "must be a real row vector", and non-finite durations passed validation. The check now also rejects NaN/Inf and the message states the actual (column) requirement.

Validation: row input and NaN input both rejected with the corrected message; a valid column-grid call returns finite fidelity and gradient; `checkcode` clean; house-style violation count unchanged versus stock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)