### PR TITLE
grape_coop.m: keep impurity gradients out of penalty slices

### DIFF
--- a/kernel/optimcon/wrappers/grape_coop.m
+++ b/kernel/optimcon/wrappers/grape_coop.m
@@ -102,8 +102,9 @@ switch spin_system.bas.formalism
         fidelity(1)=fidelity(1)-mean(cellfun(@(x)norm(x,2)^2,dirt_sum));
 end
 
-% Assemble the gradient
-gradient=cat(1,gradient_a,gradient_b)/2-2*cat(1,gradient_c,gradient_d);
+% Assemble the gradient, impurity term only enters the fidelity slice
+gradient=cat(1,gradient_a,gradient_b)/2;
+gradient(:,:,1)=gradient(:,:,1)-2*cat(1,gradient_c(:,:,1),gradient_d(:,:,1));
 
 % Return both trajectories
 traj_data={traj_data_a,traj_data_b};


### PR DESCRIPTION
## Problem

`grape_coop` assembles its gradient as

```matlab
gradient=cat(1,gradient_a,gradient_b)/2-2*cat(1,gradient_c,gradient_d);
```

The wrapper gradients are sliced arrays (one slice per objective term: fidelity plus each penalty), and `gradient_c`/`gradient_d` come from `grape_phase` calls on the same profiles with the same penalty settings, so their penalty slices duplicate the penalty gradients of the main runs. The subtraction therefore corrupts every penalty slice: assembled penalty gradient `pen/2-2*pen=-1.5*pen` instead of the correct `(pen_a+pen_b)/2`, i.e. exactly **-3x** the true value, while the fidelity vector itself only puts the dirt penalty into `fidelity(1)`.

## Evidence

Reduced two-pulse cooperative problem (single 14N, 6 time steps, DNS penalty), central finite differences over all 12 phase variables at stock `f82fae6`:

- fidelity slice: relative error 9.6e-08 (correct before and after)
- penalty slice: analytic/FD ratio **-3.0000** on every variable (relative error 4.0)

## Fix

Subtract the doubled impurity-cancellation gradients from the fidelity slice only:

```matlab
gradient=cat(1,gradient_a,gradient_b)/2;
gradient(:,:,1)=gradient(:,:,1)-2*cat(1,gradient_c(:,:,1),gradient_d(:,:,1));
```

## Validation

- Penalty-slice relative error vs finite differences: 4.0 → **8.4e-11**; fidelity slice unchanged (9.6e-08)
- `checkcode`: clean; house-style gate: clean
- Regression tests pass: `optimcon/support_paths`, `optimcon/grape_one_spin`, `kernel/dynamic_optimcon_remaining`

Part of the optimal-control audit follow-up (item 1 of 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)