### PR TITLE
stack_2d.m: return after plotting a complex spectrum

### DIFF
--- a/kernel/plotting/stack_2d.m
+++ b/kernel/plotting/stack_2d.m
@@ -43,8 +43,8 @@ grumble(spectrum,parameters,stack_dim);
 
 % If a complex spectrum is received, plot both components
 if nnz(imag(spectrum))>0
-    stack_2d(spin_system,real(spectrum),parameters,stack_dim); hold on;
-    stack_2d(spin_system,imag(spectrum),parameters,stack_dim);
+    stack_2d(spin_system,real(spectrum),parameters,stack_dim,alpha_fun); hold on;
+    stack_2d(spin_system,imag(spectrum),parameters,stack_dim,alpha_fun); return;
 end
 
 % Inform the user


### PR DESCRIPTION
The complex-spectrum branch recursively plots the real and the imaginary stacks but, unlike `plot_1d` and `plot_2d`, did not return afterwards: execution fell through and drew a third stack directly from the complex matrix. The recursion also dropped the caller's `alpha_fun`, silently reverting the two component plots to the default opacity; both recursive calls now pass it through, and the branch returns.

Validation, MATLAB R2026a, headless, one-proton system, 64 x 16 complex Gaussian test surface: stock draws 192 patch objects for the complex input (real pass + imaginary pass + the spurious fall-through pass); patched draws 128; a real input draws 64 in both. `checkcode` empty; house-style gate clean. (Audit item F057.)