### PR TITLE
hess_reorder.m: validate Hessian shape and block dimensions

### DIFF
--- a/kernel/optimcon/hess_reorder.m
+++ b/kernel/optimcon/hess_reorder.m
@@ -50,8 +50,15 @@ end
 
 % Consistency enforcement
 function grumble(hess,dim1,dim2)
-if numel(hess)~=(dim1*dim2)^2
-    error('Hessian size should be (K*N)^2')
+if (~isnumeric(dim1))||(~isreal(dim1))||(~isscalar(dim1))||...
+   (dim1<1)||(mod(dim1,1)~=0)||...
+   (~isnumeric(dim2))||(~isreal(dim2))||(~isscalar(dim2))||...
+   (dim2<1)||(mod(dim2,1)~=0)
+    error('K and N must be positive integers.');
+end
+if (~isnumeric(hess))||(~ismatrix(hess))||...
+   (size(hess,1)~=dim1*dim2)||(size(hess,2)~=dim1*dim2)
+    error('hess must be a (K*N)x(K*N) matrix.');
 end
 end
 


### PR DESCRIPTION
Audit item 26: the grumble only compared `numel(hess)` with `(K*N)^2`, so a non-square array of matching element count (e.g. 2x8 with K=N=2) was silently reshaped into a nonsensical "reordered Hessian". The input must now be a square (K*N)x(K*N) matrix with positive-integer K and N.

Validation: 2x8 input and non-integer dimensions now rejected with informative messages; the valid path verified exactly against the explicit index permutation (hout==hin(perm,perm) for K=2, N=3); `checkcode` clean; house style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)