### PR TITLE
g2spinach.m: import spin-rotation tensors from the field gparse writes

### DIFF
--- a/interfaces/g2spinach.m
+++ b/interfaces/g2spinach.m
@@ -202,10 +202,10 @@ switch ismember('E',[particles{:}])
         end
         
         % Absorb spin-rotation couplings
-        if isfield(props,'src')
-            inter.spinrot.matrix=cell(nspins);
+        if isfield(props,'srt')
+            inter.spinrot.matrix=cell(1,nspins);
             for n=1:nspins
-                inter.spinrot.matrix{n}=props.src{index(n)};
+                inter.spinrot.matrix{n}=props.srt{index(n)};
             end
         end
         


### PR DESCRIPTION
The NMR branch checked `isfield(props,'src')` and read `props.src`, but `gparse` documents and populates spin-rotation tensors as `props.srt` (header line 36, parser line 302). Gaussian spin-rotation data was therefore silently discarded on import. Because the branch had never executed, it also hid a preallocation bug on the same lines: `cell(nspins)` creates an nspins-by-nspins cell array; it is now `cell(1,nspins)`, matching `x2spinach` and the other interaction imports.

Validation, MATLAB R2026a: `gparse` of the shipped `glycine.log` with distinct synthetic `props.srt` tensors injected per atom, then proton NMR import — stock returns no `inter.spinrot` field at all; patched returns a 1 x 5 cell whose first tensor carries the value of the first hydrogen's atom index (5), confirming the `index(n)` mapping; `create()` accepts the resulting structure in both cases with 5 spins. `checkcode` empty; house-style gate clean. (Audit item F035.)