### PR TITLE
bfgs.m, lbfgs.m: validate history row counts and finiteness

### DIFF
--- a/kernel/optimcon/bfgs.m
+++ b/kernel/optimcon/bfgs.m
@@ -111,8 +111,16 @@ function grumble(dx_hist,dg_hist,g_new)
 if (size(dx_hist,2)~=size(dg_hist,2))||(size(g_new,2)~=1)
     error('all vector inputs must be column vector arrays.');
 end
+if (~isempty(dx_hist))&&((size(dx_hist,1)~=size(g_new,1))||...
+                         (size(dg_hist,1)~=size(g_new,1)))
+    error('dx_hist and dg_hist must have the same number of rows as g_new.');
+end
 if (~isreal(dx_hist))||(~isreal(dg_hist))||(~isreal(g_new))
     error('all vector inputs must be real.');
+end
+if any(~isfinite(dx_hist(:)))||any(~isfinite(dg_hist(:)))||...
+   any(~isfinite(g_new(:)))
+    error('all vector inputs must be finite.');
 end
 end
 

--- a/kernel/optimcon/lbfgs.m
+++ b/kernel/optimcon/lbfgs.m
@@ -86,8 +86,16 @@ function grumble(dx_hist,dg_hist,g_new)
 if (size(dx_hist,2)~=size(dg_hist,2))||(size(g_new,2)~=1)
     error('all vector inputs must be column vector arrays.');
 end
+if (~isempty(dx_hist))&&((size(dx_hist,1)~=size(g_new,1))||...
+                         (size(dg_hist,1)~=size(g_new,1)))
+    error('dx_hist and dg_hist must have the same number of rows as g_new.');
+end
 if (~isreal(dx_hist))||(~isreal(dg_hist))||(~isreal(g_new))
     error('all vector inputs must be real.');
+end
+if any(~isfinite(dx_hist(:)))||any(~isfinite(dg_hist(:)))||...
+   any(~isfinite(g_new(:)))
+    error('all vector inputs must be finite.');
 end
 end
 


### PR DESCRIPTION
Audit item 25: both grumbles checked only that `dx_hist` and `dg_hist` have equal column counts. Mismatched row counts then died as raw `sizeDimensionsMustMatch` errors inside the update products, and NaN/Inf history entries were accepted silently — `lbfgs` even returned an all-finite direction from an all-NaN `dx_hist`, i.e. silently wrong search directions. Rows must now match `g_new` (empty first-iteration histories remain allowed) and all inputs must be finite.

Validation: mismatched rows and NaN/Inf inputs rejected with informative messages in both helpers; a consistent seeded history still yields a finite `lbfgs` direction and a finite symmetric `bfgs` pseudo-Hessian; `checkcode` clean on both; house-style violation count unchanged versus stock (2 legacy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)