### PR TITLE
fmaxnewton.m: accept valid starts with small initial fidelity

### DIFF
--- a/kernel/optimcon/fmaxnewton.m
+++ b/kernel/optimcon/fmaxnewton.m
@@ -123,9 +123,9 @@ for n=1:spin_system.control.max_iter
                 % Get objective and gradient
                 [data,fx,g]=objeval(x,cost_function,data,spin_system);
 
-                % Catch unreasonably small initial fidelities and gradients
-                if (abs(data.fx_sep_pen(1))<1e-6)||(norm(g(~frozen),2)<1e-6)
-                    error('fidelity or gradient too small at iter 1, find a better guess.');
+                % Stop if the initial point already meets the gradient tolerance
+                if norm(g(~frozen),2)<spin_system.control.tol_g
+                    exitflag=1; break;
                 end
                 
                 % Start history arrays

--- a/kernel/optimcon/fmaxnewton.m
+++ b/kernel/optimcon/fmaxnewton.m
@@ -123,8 +123,17 @@ for n=1:spin_system.control.max_iter
                 % Get objective and gradient
                 [data,fx,g]=objeval(x,cost_function,data,spin_system);
 
+                % Refuse non-finite objectives and gradients
+                if (~isfinite(fx))||(~all(isfinite(g(~frozen))))
+                    error('non-finite objective or gradient at the initial point.');
+                end
+
                 % Stop if the initial point already meets the gradient tolerance
-                if norm(g(~frozen),2)<spin_system.control.tol_g
+                grad_norm=norm(g(~frozen),2);
+                if (grad_norm==0)||(grad_norm<spin_system.control.tol_g)
+                    if strcmp(spin_system.control.fidelity,'square')&&(fx<sqrt(eps))
+                        error('square-fidelity start is numerically orthogonal to the target, choose a different initial guess.');
+                    end
                     exitflag=1; break;
                 end
                 


### PR DESCRIPTION
## Problem

The iteration-1 guard in the lbfgs/rbfgs branch of `fmaxnewton`

```matlab
if (abs(data.fx_sep_pen(1))<1e-6)||(norm(g(~frozen),2)<1e-6)
    error('fidelity or gradient too small at iter 1, find a better guess.');
end
```

rejects two classes of perfectly valid optimisation problems:

1. a start whose **current fidelity** happens to be below 1e-6 with a healthy gradient — the normal situation when a waveform guess begins near zero overlap with the target (reproduced live: a bounded one-control problem with fidelity 1e-8 and gradient norm 0.11 dies with the error above);
2. an **already-optimal initial guess**, which should report convergence, not demand "a better guess".

## Fix

The fidelity clause is removed, and the gradient clause becomes a proper convergence exit through the user's `control.tol_g` (default 1e-6, same threshold as before):

```matlab
% Stop if the initial point already meets the gradient tolerance
if norm(g(~frozen),2)<spin_system.control.tol_g
    exitflag=1; break;
end
```

This also keeps the conservative first-step normalisation `0.01*dir/max(abs(dir))` from dividing by zero when the initial gradient vanishes.

## Validation

- Small-fidelity healthy-gradient start now optimises (final fidelity improved over start)
- Already-optimal start converges cleanly with the guess returned unmoved
- `checkcode` clean; house-style gate: no new violations
- Regression tests pass: `optimcon/support_paths`, `optimcon/grape_one_spin`, `kernel/dynamic_optimcon_remaining`

Part of the optimal-control audit follow-up (item 4 of 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)