### PR TITLE
trapdiff.m: enforce drift pair, size agreement, and scalar edges

### DIFF
--- a/kernel/optimcon/trapdiff.m
+++ b/kernel/optimcon/trapdiff.m
@@ -68,9 +68,13 @@ end
 % Consistency enforcement
 function grumble(Hd,Hc,dt,cL,cR)
 if ~iscell(Hd), error('Hd must be a cell array of matrices.'); end
-for n=1:numel(Hd)     
-    if (~isnumeric(Hd{n}))||(size(Hd{n},1)~=size(Hd{n},2))
-        error('all elements of Hd cell array must be square matrices.');
+if numel(Hd)~=2
+    error('Hd must contain exactly two drift generators.');
+end
+for n=1:numel(Hd)
+    if (~isnumeric(Hd{n}))||(size(Hd{n},1)~=size(Hd{n},2))||...
+       (size(Hd{n},1)~=size(Hd{1},1))
+        error('all elements of Hd cell array must be square matrices of the same size.');
     end
 end
 if (~isnumeric(Hc))||(size(Hc,1)~=size(Hc,2))||(size(Hc,1)~=size(Hd{1},1))
@@ -80,7 +84,8 @@ end
 if (~isnumeric(dt))||(~isreal(dt))||(~isscalar(dt))||(dt<=0)
     error('dt must be a positive real scalar.');
 end
-if (~isnumeric(cL))||(~isreal(cL))||(~isnumeric(cR))||(~isreal(cR))
+if (~isnumeric(cL))||(~isreal(cL))||(~isscalar(cL))||...
+   (~isnumeric(cR))||(~isreal(cR))||(~isscalar(cR))
     error('cL and cR must be real scalars.');
 end
 end


### PR DESCRIPTION
Audit item 15: `trapdiff` uses `Hd{1}`/`Hd{2}` and scalar edge amplitudes, but the grumble validated none of that. A single drift died as raw `badsubscript`, a mismatched `Hd{2}` as raw `innerdim`, and a vector `cL` was ACCEPTED — implicit expansion produced a wrong-shaped generator that still returned a 2x2 result, i.e. silently wrong mathematics. The grumble now enforces exactly two same-size square drifts and scalar `cL`, `cR` (the error text already claimed scalars; the code now enforces it).

Validation: all three bad-input classes rejected with informative messages; a valid call still returns finite 2x2 directional derivatives; `checkcode` clean; house style clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)