### PR TITLE
spf.m, amp_tanh.m, amp_root.m: reject non-finite distortion parameters

### DIFF
--- a/kernel/optimcon/distortions/amp_root.m
+++ b/kernel/optimcon/distortions/amp_root.m
@@ -130,8 +130,9 @@ if (~isnumeric(w))||(~isreal(w))||(mod(size(w,1),2)~=0)
     error('w must be an array of reals with an even number of rows.');
 end
 if (~isnumeric(sat_lvls))||(~isreal(sat_lvls))||...
-   (numel(sat_lvls)~=size(w,1)/2)||any(sat_lvls<=0,'all')
-    error('sat_lvls must be a real array with one element per XY channel pair.');
+   (numel(sat_lvls)~=size(w,1)/2)||any(~isfinite(sat_lvls),'all')||...
+   any(sat_lvls<=0,'all')
+    error('sat_lvls must be a finite positive real array with one element per XY channel pair.');
 end
 if (~isnumeric(s))||(~isreal(s))||(numel(s)~=size(w,1)/2)||...
    any(mod(s,1)~=0,'all')||any(s<1,'all')

--- a/kernel/optimcon/distortions/amp_tanh.m
+++ b/kernel/optimcon/distortions/amp_tanh.m
@@ -123,8 +123,9 @@ if (~isnumeric(w))||(~isreal(w))||(mod(size(w,1),2)~=0)
     error('w must be an array of reals with an even number of rows.');
 end
 if (~isnumeric(sat_lvls))||(~isreal(sat_lvls))||...
-   (numel(sat_lvls)~=size(w,1)/2)||any(sat_lvls<=0,'all')
-    error('sat_lvls must be a real array with one element per XY channel pair.');
+   (numel(sat_lvls)~=size(w,1)/2)||any(~isfinite(sat_lvls),'all')||...
+   any(sat_lvls<=0,'all')
+    error('sat_lvls must be a finite positive real array with one element per XY channel pair.');
 end
 end
 

--- a/kernel/optimcon/distortions/spf.m
+++ b/kernel/optimcon/distortions/spf.m
@@ -111,8 +111,8 @@ end
 if numel(p)~=size(w,1)/2
     error('p must have one element per X,Y control pair.');
 end
-if any(abs(p(:))>=1)
-    error('must have |p(k)|<1 for causal stability.');
+if any(~isfinite(p(:)))||any(abs(p(:))>=1)
+    error('p elements must be finite with |p(k)|<1 for causal stability.');
 end
 end
 


### PR DESCRIPTION
Audit item 19 (remainder — the `szf.m` z-validation is already on main): a NaN pole passed `spf`'s `|p|<1` check because `abs(NaN)>=1` is false, and NaN/Inf saturation levels passed the `<=0` test in `amp_tanh`/`amp_root` for the same reason. All three distortions then silently produced non-finite waveforms/Jacobians (measured: `allfinite=0` outputs on stock code). The grumbles now require finite parameters.

Validation: NaN and Inf parameters rejected with informative messages in all three functions; valid parameters (p=0.5, sat=300) still produce finite distorted waveforms; `checkcode` clean on all three; house style clean (0 violations, same as stock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)