### PR TITLE
fmaxnewton.m: guard the search direction before line search

### DIFF
--- a/kernel/optimcon/fmaxnewton.m
+++ b/kernel/optimcon/fmaxnewton.m
@@ -192,6 +192,16 @@ for n=1:spin_system.control.max_iter
             
     end
 
+    % Refuse a non-finite search direction
+    if any(~isfinite(dir))
+        error('search direction contains Inf or NaN, check gradients and Hessians.');
+    end
+
+    % Fall back to projected steepest ascent for non-ascent directions
+    if g(~frozen)'*dir(~frozen)<=0
+        dir=g.*(~frozen);
+    end
+
     % Store the reference point
     g_ref=g(~frozen); dir_ref=dir(~frozen);
 


### PR DESCRIPTION
## Problem

`fmaxnewton` sends every computed search direction straight into `bracketing` with no sanity check:

1. a **non-finite direction** (NaN gradient from the objective, or a singular Hessian surviving RFO regularisation) propagates into `cubic_interp` and dies with a raw `Input to ROOTS must not contain NaN or Inf` — far from the actual cause;
2. a **non-ascent direction** walks into sectioning and comes back as `exitflag=-2` ("line search failed"), misdiagnosing a direction problem as a line-search problem.

Both reproduced on stock `f82fae6` with direct probes.

## Fix

Two guards after direction assembly, before the line search:

```matlab
% Refuse a non-finite search direction
if any(~isfinite(dir))
    error('search direction contains Inf or NaN, check gradients and Hessians.');
end

% Fall back to projected steepest ascent for non-ascent directions
if g(~frozen)'*dir(~frozen)<=0
    dir=g.*(~frozen);
end
```

The steepest-ascent fallback is always a usable ascent direction for the Wolfe conditions when the gradient is nonzero; a zero gradient produces a zero step and exits through the existing `tol_x` test.

## Validation

- NaN gradient now raises the informative direction error instead of the raw `roots` crash
- A deliberately wrong-sign Hessian claim on a concave objective still converges to the maximum (final `|x|` ~ 8e-17)
- Healthy bounded optimisation unaffected (fidelity improves as before)
- `checkcode` clean; house-style gate: no new violations
- Regression tests pass: `optimcon/support_paths`, `optimcon/grape_one_spin`, `kernel/dynamic_optimcon_remaining`

Independent of #235 (different hunk of the same file); the two merge cleanly in either order.

Part of the optimal-control audit follow-up (item 5 of 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)