### PR TITLE
m2s.m: reject a zero Zeeman frequency difference

### DIFF
--- a/experiments/singlets/m2s.m
+++ b/experiments/singlets/m2s.m
@@ -69,8 +69,9 @@ end
 if (~isnumeric(J))||(~isreal(J))||(~isscalar(J))
     error('J must be a real scalar.');
 end
-if (~isnumeric(delta_v))||(~isreal(delta_v))||(~isscalar(delta_v))
-    error('delta_v must be a real scalar.');
+if (~isnumeric(delta_v))||(~isreal(delta_v))||(~isscalar(delta_v))||...
+   (~isfinite(delta_v))||(delta_v==0)
+    error('delta_v must be a non-zero finite real scalar.');
 end
 end
 


### PR DESCRIPTION
The M2S repetition count is `m1=floor(pi*J/(2*delta_v))`, and the grumbler accepted `delta_v=0`: the count overflows to Inf, MATLAB caps the for loop at 9.2e18 iterations with a 'Too many FOR loop iterations' warning, and the sequence then runs effectively forever (measured: warning at line 42, then no progress until the probe timeout). With `J=0` as well, the echo time `t=1/(4*sqrt(J^2+delta_v^2))` is additionally infinite. The grumbler now requires a non-zero finite real scalar.

Validation, MATLAB R2026a, on the shipped two-carbon example system: the valid call `m2s(...,55,6.0)` returns the identical singlet population -0.240750365 before and after the change; `delta_v=0` and `J=0,delta_v=0` hung stock and are rejected patched with 'delta_v must be a non-zero finite real scalar'. `checkcode` empty; house-style gate clean. Companion fix for the inverse sequence: s2m. (Audit item F028.)