### PR TITLE
s2m.m: reject a zero Zeeman frequency difference

### DIFF
--- a/experiments/singlets/s2m.m
+++ b/experiments/singlets/s2m.m
@@ -69,8 +69,9 @@ end
 if (~isnumeric(J))||(~isreal(J))||(~isscalar(J))
     error('J must be a real scalar.');
 end
-if (~isnumeric(delta_v))||(~isreal(delta_v))||(~isscalar(delta_v))
-    error('delta_v must be a real scalar.');
+if (~isnumeric(delta_v))||(~isreal(delta_v))||(~isscalar(delta_v))||...
+   (~isfinite(delta_v))||(delta_v==0)
+    error('delta_v must be a non-zero finite real scalar.');
 end
 end
 


### PR DESCRIPTION
The S2M repetition count is `m1=floor(pi*J/(2*delta_v))`, and the grumbler accepted `delta_v=0`: the count overflows to Inf, MATLAB caps the for loop at 9.2e18 iterations with a 'Too many FOR loop iterations' warning (measured at line 41), and the sequence then runs effectively forever (measured: no progress until the 90 s probe timeout). With `J=0` as well, the echo time `t=1/(4*sqrt(J^2+delta_v^2))` is additionally infinite. The grumbler now requires a non-zero finite real scalar.

Validation, MATLAB R2026a, on the shipped two-carbon example system: the valid call `s2m(...,55,6.0)` returns the identical finite state before and after the change (singlet projection 0.000000000 both sides, all state-vector entries finite); `delta_v=0` and `J=0,delta_v=0` hung stock and are rejected patched with 'delta_v must be a non-zero finite real scalar'. `checkcode` empty; house-style gate clean. Companion fix for the inverse sequence: m2s, PR #239. (Audit item F029.)