### PR TITLE
spendosy.m: require the diffusion delay to cover Tau plus Te

### DIFF
--- a/experiments/spen/spendosy.m
+++ b/experiments/spen/spendosy.m
@@ -240,13 +240,15 @@ elseif numel(parameters.smfactor)~=1
 end
 if ~isfield(parameters,'Te')
     error('pulse duration should be specified in parameters.Te variable.');
-elseif numel(parameters.Te)~=1
-    error('parameters.Te array should have exactly one elements.');
+elseif (numel(parameters.Te)~=1)||(~isnumeric(parameters.Te))||...
+       (~isreal(parameters.Te))||(~isfinite(parameters.Te))||(parameters.Te<=0)
+    error('parameters.Te must be a positive finite real scalar.');
 end
 if ~isfield(parameters,'Tau')
     error('extra dephasing gradient duration should be specified in parameters.Tau variable.');
-elseif numel(parameters.Tau)~=1
-    error('parameters.Tau array should have exactly one elements.');
+elseif (numel(parameters.Tau)~=1)||(~isnumeric(parameters.Tau))||...
+       (~isreal(parameters.Tau))||(~isfinite(parameters.Tau))||(parameters.Tau<0)
+    error('parameters.Tau must be a non-negative finite real scalar.');
 end
 if ~isfield(parameters,'BW')
     error('pulse bandwidth should be specified in parameters.BW variable.');
@@ -265,8 +267,11 @@ elseif ~ischar(parameters.chirptype)
 end
 if ~isfield(parameters,'td')
     error('the diffusion delay should be specified in parameters.td variable.');
-elseif numel(parameters.td)~=1
-    error('parameters.td array should have exactly one elements.');
+elseif (numel(parameters.td)~=1)||(~isnumeric(parameters.td))||...
+       (~isreal(parameters.td))||(~isfinite(parameters.td))
+    error('parameters.td must be a finite real scalar.');
+elseif parameters.td<parameters.Tau+parameters.Te
+    error('parameters.td must not be smaller than parameters.Tau+parameters.Te.');
 end
 end
 

--- a/experiments/spen/spendosy.m
+++ b/experiments/spen/spendosy.m
@@ -38,7 +38,8 @@
 %
 % parameters.chirptype      can be 'wurst' or 'smoothed'
 %
-% parameters.td             diffusion delay
+% parameters.td             diffusion delay, at least
+%                           parameters.Tau+parameters.Te
 %
 % H                         Fokker-Planck Hamiltonian
 %
@@ -240,15 +241,15 @@ elseif numel(parameters.smfactor)~=1
 end
 if ~isfield(parameters,'Te')
     error('pulse duration should be specified in parameters.Te variable.');
-elseif (numel(parameters.Te)~=1)||(~isnumeric(parameters.Te))||...
+elseif (numel(parameters.Te)~=1)||(~isnumeric(parameters.Te))||(~isfloat(parameters.Te))||...
        (~isreal(parameters.Te))||(~isfinite(parameters.Te))||(parameters.Te<=0)
-    error('parameters.Te must be a positive finite real scalar.');
+    error('parameters.Te must be a positive finite real floating-point scalar.');
 end
 if ~isfield(parameters,'Tau')
     error('extra dephasing gradient duration should be specified in parameters.Tau variable.');
-elseif (numel(parameters.Tau)~=1)||(~isnumeric(parameters.Tau))||...
+elseif (numel(parameters.Tau)~=1)||(~isnumeric(parameters.Tau))||(~isfloat(parameters.Tau))||...
        (~isreal(parameters.Tau))||(~isfinite(parameters.Tau))||(parameters.Tau<0)
-    error('parameters.Tau must be a non-negative finite real scalar.');
+    error('parameters.Tau must be a non-negative finite real floating-point scalar.');
 end
 if ~isfield(parameters,'BW')
     error('pulse bandwidth should be specified in parameters.BW variable.');
@@ -267,10 +268,10 @@ elseif ~ischar(parameters.chirptype)
 end
 if ~isfield(parameters,'td')
     error('the diffusion delay should be specified in parameters.td variable.');
-elseif (numel(parameters.td)~=1)||(~isnumeric(parameters.td))||...
+elseif (numel(parameters.td)~=1)||(~isnumeric(parameters.td))||(~isfloat(parameters.td))||...
        (~isreal(parameters.td))||(~isfinite(parameters.td))
-    error('parameters.td must be a finite real scalar.');
-elseif parameters.td<parameters.Tau+parameters.Te
+    error('parameters.td must be a finite real floating-point scalar.');
+elseif parameters.td<parameters.Tau+parameters.Te-4*eps(parameters.Tau+parameters.Te)
     error('parameters.td must not be smaller than parameters.Tau+parameters.Te.');
 end
 end


### PR DESCRIPTION
The diffusion evolution step propagates for `parameters.td-parameters.Tau-parameters.Te`, and the grumbler only checked that the three timing fields have one element each: a parameter set with `td<Tau+Te` was accepted and quietly ran the diffusion delay backwards in time. Measured on a reduced one-proton version of the shipped `ufdosy_1spin.m` example: stock, `td=0.002` against `Tau+Te=0.0031` runs silently to a different answer (probe sums 1.073420351e+03 valid vs 1.090698095e+03 impossible); patched, the same call is rejected while the valid call returns the identical probe sum.

After the Codex review: the header documents the new constraint on `parameters.td`; the relationship comparison is round-off-aware (`td>=Tau+Te-4*eps(Tau+Te)`, so the decimal boundary `Te=0.0015, Tau=0.0016, td=0.0031` is accepted — measured, the zero-length diffusion interval runs to a finite fid); and the three timing fields must be floating-point classes, so saturating integer arithmetic cannot bypass the check (measured, `td=uint8(255)` is rejected). Function body untouched. `checkcode` empty; house-style gate clean. Sibling fix with identical hardening: PR #243. (Audit item F030.)