### PR TITLE
bracketing.m, cubic_interp.m: fail informatively on line search divergence

### DIFF
--- a/kernel/optimcon/bracketing.m
+++ b/kernel/optimcon/bracketing.m
@@ -121,6 +121,11 @@ while true
     br_end_pt_A=2*alpha_2-alpha_1;
     br_end_pt_B=alpha_2+spin_system.control.ls_tau1*(alpha_2-alpha_1);
 
+    % Stop if the expansion has escaped to non-finite values
+    if ~all(isfinite([br_end_pt_A br_end_pt_B fx_2 gfx_2'*dir]))
+        error('line search expansion diverged, objective appears unbounded above.');
+    end
+
     % Maximise the cubic model inside interpolation bounds
     alpha_new=cubic_interp(br_end_pt_A,br_end_pt_B,alpha_1,alpha_2,...
                            fx_1,gfx_1'*dir,fx_2,gfx_2'*dir);

--- a/kernel/optimcon/cubic_interp.m
+++ b/kernel/optimcon/cubic_interp.m
@@ -71,32 +71,32 @@ end
 
 % Consistency enforcement
 function grumble(end_a,end_b,alpha_a,alpha_b,f_a,dir_der_a,f_b,dir_der_b)
-if isempty(end_a)||(~isnumeric(end_a))||(~isreal(end_a))||(~isscalar(end_a))
-    error('end_A must be a real scalar.');
+if isempty(end_a)||(~isnumeric(end_a))||(~isreal(end_a))||(~isscalar(end_a))||(~isfinite(end_a))
+    error('end_A must be a finite real scalar.');
 end
-if isempty(end_b)||(~isnumeric(end_b))||(~isreal(end_b))||(~isscalar(end_b))
-    error('end_B must be a real scalar.');
+if isempty(end_b)||(~isnumeric(end_b))||(~isreal(end_b))||(~isscalar(end_b))||(~isfinite(end_b))
+    error('end_B must be a finite real scalar.');
 end
-if isempty(alpha_a)||(~isnumeric(alpha_a))||(~isreal(alpha_a))||(~isscalar(alpha_a))
-    error('alpha_A must be a real scalar.');
+if isempty(alpha_a)||(~isnumeric(alpha_a))||(~isreal(alpha_a))||(~isscalar(alpha_a))||(~isfinite(alpha_a))
+    error('alpha_A must be a finite real scalar.');
 end
-if isempty(alpha_b)||(~isnumeric(alpha_b))||(~isreal(alpha_b))||(~isscalar(alpha_b))
-    error('alpha_B must be a real scalar.');
+if isempty(alpha_b)||(~isnumeric(alpha_b))||(~isreal(alpha_b))||(~isscalar(alpha_b))||(~isfinite(alpha_b))
+    error('alpha_B must be a finite real scalar.');
 end
 if alpha_a==alpha_b
     error('alpha_A and alpha_B must be different.');
 end
-if isempty(f_a)||(~isnumeric(f_a))||(~isreal(f_a))||(~isscalar(f_a))
-    error('f_A must be a real scalar.');
+if isempty(f_a)||(~isnumeric(f_a))||(~isreal(f_a))||(~isscalar(f_a))||(~isfinite(f_a))
+    error('f_A must be a finite real scalar.');
 end
-if isempty(dir_der_a)||(~isnumeric(dir_der_a))||(~isreal(dir_der_a))||(~isscalar(dir_der_a))
-    error('dir_deriv_A must be a real scalar.');
+if isempty(dir_der_a)||(~isnumeric(dir_der_a))||(~isreal(dir_der_a))||(~isscalar(dir_der_a))||(~isfinite(dir_der_a))
+    error('dir_deriv_A must be a finite real scalar.');
 end
-if isempty(f_b)||(~isnumeric(f_b))||(~isreal(f_b))||(~isscalar(f_b))
-    error('f_B must be a real scalar.');
+if isempty(f_b)||(~isnumeric(f_b))||(~isreal(f_b))||(~isscalar(f_b))||(~isfinite(f_b))
+    error('f_B must be a finite real scalar.');
 end
-if isempty(dir_der_b)||(~isnumeric(dir_der_b))||(~isreal(dir_der_b))||(~isscalar(dir_der_b))
-    error('dir_deriv_B must be a real scalar.');
+if isempty(dir_der_b)||(~isnumeric(dir_der_b))||(~isreal(dir_der_b))||(~isscalar(dir_der_b))||(~isfinite(dir_der_b))
+    error('dir_deriv_B must be a finite real scalar.');
 end
 end
 


### PR DESCRIPTION
Audit item 6: the `bracketing` expansion loop had no divergence guard — on an objective that keeps rising along the search direction (measured with a linear objective probe), the step doubles until the interpolation end points and objective values overflow, and the failure surfaced as a raw `MATLAB:roots:NonFiniteInput` from inside `cubic_interp`. The expansion now stops with an informative error the moment any interpolation quantity goes non-finite, and the `cubic_interp` grumble refuses non-finite inputs outright, which `roots` cannot handle anyway. No iteration cap was added: divergence is detected from the data rather than from a magic number.

Validation: the linear-objective probe now fails with `line search expansion diverged, objective appears unbounded above` instead of the raw `roots` error; a NaN end point is refused by the `cubic_interp` grumble; a healthy bounded optimisation still improves its objective; `optimcon/support_paths`, `optimcon/grape_one_spin`, and `kernel/dynamic_optimcon_remaining` regression suites all pass; `checkcode` empty and house style clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)