### PR TITLE
spendosycosy.m: require the diffusion delay to cover Tau plus Te

### DIFF
--- a/experiments/spen/spendosycosy.m
+++ b/experiments/spen/spendosycosy.m
@@ -272,13 +272,15 @@ elseif numel(parameters.smfactor)~=1
 end
 if ~isfield(parameters,'Te')
     error('pulse duration should be specified in parameters.Te variable.');
-elseif numel(parameters.Te)~=1
-    error('parameters.Te array should have exactly one elements.');
+elseif (numel(parameters.Te)~=1)||(~isnumeric(parameters.Te))||...
+       (~isreal(parameters.Te))||(~isfinite(parameters.Te))||(parameters.Te<=0)
+    error('parameters.Te must be a positive finite real scalar.');
 end
 if ~isfield(parameters,'Tau')
     error('extra dephasing gradient duration should be specified in parameters.Tau variable.');
-elseif numel(parameters.Tau)~=1
-    error('parameters.Tau array should have exactly one elements.');
+elseif (numel(parameters.Tau)~=1)||(~isnumeric(parameters.Tau))||...
+       (~isreal(parameters.Tau))||(~isfinite(parameters.Tau))||(parameters.Tau<0)
+    error('parameters.Tau must be a non-negative finite real scalar.');
 end
 if ~isfield(parameters,'td')
     error('the diffusion delay should be specified in parameters.td variable.');
@@ -299,6 +301,14 @@ if ~isfield(parameters,'chirptype')
     error('chirptype, smoothed or wurst, should be specified in parameters.chirptype variable.');
 elseif ~ischar(parameters.chirptype)
     error('parameters.chirptype must be a character string.');
+end
+if ~isfield(parameters,'td')
+    error('the diffusion delay should be specified in parameters.td variable.');
+elseif (numel(parameters.td)~=1)||(~isnumeric(parameters.td))||...
+       (~isreal(parameters.td))||(~isfinite(parameters.td))
+    error('parameters.td must be a finite real scalar.');
+elseif parameters.td<parameters.Tau+parameters.Te
+    error('parameters.td must not be smaller than parameters.Tau+parameters.Te.');
 end
 end
 

--- a/experiments/spen/spendosycosy.m
+++ b/experiments/spen/spendosycosy.m
@@ -26,6 +26,11 @@
 %
 % parameters.Te             duration of the pulse
 %
+% parameters.Tau            duration extra dephasing gradient
+%
+% parameters.td             diffusion delay, at least
+%                           parameters.Tau+parameters.Te
+%
 % parameters.BW             bandwidth of the pulse
 %
 % parameters.Ge             encoding gradient in T/m
@@ -272,20 +277,23 @@ elseif numel(parameters.smfactor)~=1
 end
 if ~isfield(parameters,'Te')
     error('pulse duration should be specified in parameters.Te variable.');
-elseif (numel(parameters.Te)~=1)||(~isnumeric(parameters.Te))||...
+elseif (numel(parameters.Te)~=1)||(~isnumeric(parameters.Te))||(~isfloat(parameters.Te))||...
        (~isreal(parameters.Te))||(~isfinite(parameters.Te))||(parameters.Te<=0)
-    error('parameters.Te must be a positive finite real scalar.');
+    error('parameters.Te must be a positive finite real floating-point scalar.');
 end
 if ~isfield(parameters,'Tau')
     error('extra dephasing gradient duration should be specified in parameters.Tau variable.');
-elseif (numel(parameters.Tau)~=1)||(~isnumeric(parameters.Tau))||...
+elseif (numel(parameters.Tau)~=1)||(~isnumeric(parameters.Tau))||(~isfloat(parameters.Tau))||...
        (~isreal(parameters.Tau))||(~isfinite(parameters.Tau))||(parameters.Tau<0)
-    error('parameters.Tau must be a non-negative finite real scalar.');
+    error('parameters.Tau must be a non-negative finite real floating-point scalar.');
 end
 if ~isfield(parameters,'td')
     error('the diffusion delay should be specified in parameters.td variable.');
-elseif numel(parameters.td)~=1
-    error('parameters.td array should have exactly one elements.');
+elseif (numel(parameters.td)~=1)||(~isnumeric(parameters.td))||(~isfloat(parameters.td))||...
+       (~isreal(parameters.td))||(~isfinite(parameters.td))
+    error('parameters.td must be a finite real floating-point scalar.');
+elseif parameters.td<parameters.Tau+parameters.Te-4*eps(parameters.Tau+parameters.Te)
+    error('parameters.td must not be smaller than parameters.Tau+parameters.Te.');
 end
 if ~isfield(parameters,'BW')
     error('pulse bandwidth should be specified in parameters.BW variable.');
@@ -301,14 +309,6 @@ if ~isfield(parameters,'chirptype')
     error('chirptype, smoothed or wurst, should be specified in parameters.chirptype variable.');
 elseif ~ischar(parameters.chirptype)
     error('parameters.chirptype must be a character string.');
-end
-if ~isfield(parameters,'td')
-    error('the diffusion delay should be specified in parameters.td variable.');
-elseif (numel(parameters.td)~=1)||(~isnumeric(parameters.td))||...
-       (~isreal(parameters.td))||(~isfinite(parameters.td))
-    error('parameters.td must be a finite real scalar.');
-elseif parameters.td<parameters.Tau+parameters.Te
-    error('parameters.td must not be smaller than parameters.Tau+parameters.Te.');
 end
 end
 


### PR DESCRIPTION
Same defect as spendosy.m (PR #241): the diffusion evolution propagates for `parameters.td-parameters.Tau-parameters.Te`, and the timing relationship was never enforced — a parameter set with `td<Tau+Te` ran the delay backwards in time silently. (The first version of this PR claimed td was not checked at all and appended a new block; the Codex review correctly pointed out an existing presence-and-scalar block, and the validation is now merged into it.)

The grumbler now requires `Te` a positive and `Tau` a non-negative finite real floating-point scalar (integer classes are rejected, so integer saturation cannot bypass the relationship check), `td` a finite real floating-point scalar, and `td>=Tau+Te` up to a 4*eps round-off guard — decimal-literal boundary timings such as `Te=0.0015, Tau=0.0016, td=0.0031` are accepted (measured: the boundary sequence runs to a finite fid, probe sum 4.309681175e+02). The header now documents `Tau` and `td`, which it had listed neither of. Measured on a reduced two-proton version of the shipped `ufdosycosy_2spin.m` example: stock, `td=0.002` against `Tau+Te=0.0031` completes silently with a different answer (probe sums 4.291731167e+02 valid vs 4.351594776e+02 impossible); patched, the impossible call is rejected and the valid call returns the identical probe sum. Function body untouched. `checkcode` empty; house-style gate clean. (Audit item F031.)