### PR TITLE
pulse_heterodyne.m: upsample twofold to satisfy the heterodyne sampling gate

### DIFF
--- a/examples/optimal_control/distortions/scope_readout/pulse_heterodyne.m
+++ b/examples/optimal_control/distortions/scope_readout/pulse_heterodyne.m
@@ -24,13 +24,16 @@ ktitle('wall clock'); kxlabel('time, s');
 % Carrier frequency and timing
 carrier_freq=500.1029395e6;
 dt=time_grid(2)-time_grid(1);
-                                  
+
+% Upsample twofold, the scope rate being under four samples per carrier period
+expt_data=resample(expt_data,2,1); dt=dt/2;
+
 % Apply heterodyne transformation wrt carrier frequency
 [real_bruk,imag_bruk]=heterodyne(dt,expt_data,carrier_freq);
 
 % Resample and convert to complex
-real_bruk=resample(real_bruk,1,10000);
-imag_bruk=resample(imag_bruk,1,10000);
+real_bruk=resample(real_bruk,1,20000);
+imag_bruk=resample(imag_bruk,1,20000);
 time_grid=linspace(time_grid(1),...
                    time_grid(end),...
                    numel(real_bruk))';


### PR DESCRIPTION
Audit item 20: the shipped `scope_readout` example dies in the `heterodyne` grumble with `the specified frequency is not sampled well enough`. Measured from `scope_readout.mat`: the scope trace is 1.25 GS/s (dt = 0.8 ns), so the 500.1029395 MHz carrier is sampled exactly 2.5 times per period — properly sampled (Nyquist is 625 MHz, no aliasing), but short of the four samples per period the gate requires. The example now upsamples the trace twofold before demodulation and doubles the final decimation factor, leaving the output grid unchanged. Demodulation stays at the true carrier; no other processing changes.

Validation: the example runs to completion; the demodulated amplitude profile correlates with the ideal optimal-control pulse at 0.979; the complex overlap with the ideal pulse sits within 2.3 degrees of zero phase, confirming the empirical phase constant in the example is untouched by the added resampling (MATLAB `resample` is delay-compensated); `checkcode` empty and house style clean on the touched file. The only log warning is this host's TITAN V compute-capability deprecation notice from the GPU path of `heterodyne`, present for any GPU use on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)