### PR TITLE
st_ideal.m: forbid a diffusion delay shorter than the gradient duration

### DIFF
--- a/experiments/spen/st_ideal.m
+++ b/experiments/spen/st_ideal.m
@@ -98,17 +98,17 @@ end
 if ~isfield(parameters,'delta_sml')
     error('the gradient duration should be specified in parameters.delta_sml variable.');
 elseif (numel(parameters.delta_sml)~=1)||(~isnumeric(parameters.delta_sml))||...
-       (~isreal(parameters.delta_sml))||(~isfinite(parameters.delta_sml))||...
-       (parameters.delta_sml<=0)
-    error('parameters.delta_sml must be a positive finite real scalar.');
+       (~isfloat(parameters.delta_sml))||(~isreal(parameters.delta_sml))||...
+       (~isfinite(parameters.delta_sml))||(parameters.delta_sml<=0)
+    error('parameters.delta_sml must be a positive finite real floating-point scalar.');
 end
 if ~isfield(parameters,'delta_big')
     error('the diffusion delay should be specified in parameters.delta_big variable.');
 elseif (numel(parameters.delta_big)~=1)||(~isnumeric(parameters.delta_big))||...
-       (~isreal(parameters.delta_big))||(~isfinite(parameters.delta_big))||...
-       (parameters.delta_big<=0)
-    error('parameters.delta_big must be a positive finite real scalar.');
-elseif parameters.delta_big<parameters.delta_sml
+       (~isfloat(parameters.delta_big))||(~isreal(parameters.delta_big))||...
+       (~isfinite(parameters.delta_big))||(parameters.delta_big<=0)
+    error('parameters.delta_big must be a positive finite real floating-point scalar.');
+elseif parameters.delta_big<parameters.delta_sml-4*eps(parameters.delta_sml)
     error('parameters.delta_big must not be smaller than parameters.delta_sml.');
 end
 if ~isfield(parameters,'spins')

--- a/experiments/spen/st_ideal.m
+++ b/experiments/spen/st_ideal.m
@@ -97,13 +97,19 @@ elseif numel(parameters.g_amp)~=1
 end
 if ~isfield(parameters,'delta_sml')
     error('the gradient duration should be specified in parameters.delta_sml variable.');
-elseif numel(parameters.delta_sml)~=1
-    error('parameters.delta_sml array should have exactly one element.');
+elseif (numel(parameters.delta_sml)~=1)||(~isnumeric(parameters.delta_sml))||...
+       (~isreal(parameters.delta_sml))||(~isfinite(parameters.delta_sml))||...
+       (parameters.delta_sml<=0)
+    error('parameters.delta_sml must be a positive finite real scalar.');
 end
 if ~isfield(parameters,'delta_big')
     error('the diffusion delay should be specified in parameters.delta_big variable.');
-elseif numel(parameters.delta_big)~=1
-    error('parameters.delta_big array should have exactly one element.');
+elseif (numel(parameters.delta_big)~=1)||(~isnumeric(parameters.delta_big))||...
+       (~isreal(parameters.delta_big))||(~isfinite(parameters.delta_big))||...
+       (parameters.delta_big<=0)
+    error('parameters.delta_big must be a positive finite real scalar.');
+elseif parameters.delta_big<parameters.delta_sml
+    error('parameters.delta_big must not be smaller than parameters.delta_sml.');
 end
 if ~isfield(parameters,'spins')
     error('working spins should be specified in parameters.spins variable.');


### PR DESCRIPTION
The two free-evolution periods run for `(parameters.delta_big-parameters.delta_sml)/2`, and the grumbler only checked that both timing fields have one element: `delta_big<delta_sml` was accepted and silently propagated backwards in time between the gradient pulses. Measured on a reduced one-proton version of the shipped `conv_test.m` example: stock, `delta_big=0.001` against `delta_sml=0.002` completes silently with a different answer (probe sums 4.392350450e+00 valid vs 4.406350106e+00 impossible); patched, the impossible call is rejected and the valid call returns the identical probe sum.

During the all-PR review sweep this grumbler was brought level with its siblings (PRs #241, #243): both deltas must be positive finite real floating-point scalars (integer classes rejected, so saturating integer arithmetic cannot bypass the ordering check), and the ordering comparison carries a 4*eps round-off guard so exact decimal boundaries are accepted. Function body untouched. `checkcode` empty; house-style gate clean. (Audit item F032.)