### PR TITLE
penalty.m: refuse DNS penalty on waveforms shorter than the stencil

### DIFF
--- a/kernel/optimcon/penalty.m
+++ b/kernel/optimcon/penalty.m
@@ -239,6 +239,9 @@ end
 if ~ischar(type)
     error('type must be a character string.');
 end
+if strcmp(type,'DNS')&&(size(wf,2)<5)
+    error('DNS penalty needs at least five waveform time points.');
+end
 if strcmp(type,'SNSA')&&((~isscalar(fb))||(~isscalar(cb)))
     error('SNSA bounds must be scalar.');
 end


### PR DESCRIPTION
Audit item 9: the DNS penalty differentiates the waveform with a five-point second-derivative matrix, `fdmat(size(wf,2),5,2,'wall')`, but the grumble never checked the waveform length. A three-point waveform died as a raw `MATLAB:innerdim` inside `penalty`, and a two-point waveform surfaced a confusing grumble from `fdmat` about stencil sizes. The grumble now refuses DNS for waveforms with fewer than five time points — the five-point stencil defines the bound.

Validation: two-, three-, and four-point DNS waveforms are rejected with `DNS penalty needs at least five waveform time points`; the five-point boundary case returns finite penalty, gradient, and Hessian; the eight-point DNS gradient matches central finite differences elementwise; the NS penalty still accepts short waveforms; `checkcode` empty; house style adds no new violations (the four flagged inline comments are pre-existing stock `case` labels outside this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)