### PR TITLE
average.m: reject a zero rotating-frame frequency

### DIFF
--- a/kernel/average.m
+++ b/kernel/average.m
@@ -190,8 +190,9 @@ end
 if any(size(Hp)~=size(H0))||any(size(H0)~=size(Hm))
     error('dimensions of the three Hamiltonian components must be the same.');
 end
-if (~isnumeric(omega))||(~isreal(omega))||(~isscalar(omega))
-    error('omega parameter must be a real number.');
+if (~isnumeric(omega))||(~isreal(omega))||(~isscalar(omega))||...
+   (~isfinite(omega))||(omega==0)
+    error('omega parameter must be a non-zero finite real number.');
 end
 if ~ischar(theory)
     error('theory parameter must be a character string.');


### PR DESCRIPTION
Every average-Hamiltonian branch divides by powers of `omega`, and the `matrix_log` branch builds its time grid from `2*pi/omega`, but the grumbler accepted `omega=0`. Measured on deterministic two-level matrices: stock, the `kb_second_order` branch returns a silently non-finite Hamiltonian (`finite=0`) that would contaminate every downstream propagator, and the `matrix_log` branch dies much deeper with the unhelpful 'timestep must be a finite scalar.'; patched, both calls are rejected at the grumbler with 'omega parameter must be a non-zero finite real number.' while the valid-frequency results are identical to stock through both branches (probe sums 2.000318209e+00 and 2.000954490e+00).

Grumbler-only change; function body untouched. `checkcode` empty; house-style gate clean. (Audit item F037.)