### PR TITLE
optimcon.m: validate the ensemble budget against NaN and fractional counts

### DIFF
--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -1113,8 +1113,11 @@ if isfield(control,'budget')
 
     % Input validation
     if (~isnumeric(control.budget))||(~isreal(control.budget))||...
-       (~isscalar(control.budget))||(control.budget<=0)
+       (~isscalar(control.budget))||isnan(control.budget)||(control.budget<=0)
         error('control.budget must be a positive real scalar.');
+    end
+    if isfinite(control.budget)&&(control.budget>1)&&(mod(control.budget,1)~=0)
+        error('a control.budget above one must be an integer member count.');
     end
 
     % Absorb ensemble budget


### PR DESCRIPTION
Audit item 12: the `control.budget` check used `budget<=0`, which NaN passes, and accepted any real above one, which `randperm` later rejects for non-integers deep inside `ensemble` — measured on stock: `budget=NaN` was absorbed silently (downstream it disables the cap because every comparison with NaN is false), and `budget=2.5` died later as a raw `randperm` error. The grumble now rejects NaN outright and requires a budget above one to be an integer member count. Fractional budgets in (0,1], integer counts, and an explicit `Inf` (the documented no-cap default) all remain accepted.

Validation: `NaN`, `2.5`, `-1`, and `0` rejected with informative messages; `0.5`, `3`, `Inf`, and the no-field default all accepted through a full `optimcon` construction; `checkcode` empty; house style adds no new violations (the file's 9 flagged lines are identical on stock f82fae6, all outside this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)