### PR TITLE
optimcon.m: require one keyhole per pulse time point

### DIFF
--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -947,6 +947,10 @@ if isfield(control,'keyholes')
     if ~iscell(control.keyholes)
         error('control.keyholes must be a cell array.');
     end
+    if numel(control.keyholes)~=spin_system.control.pulse_ntpts
+        error(['control.keyholes must have ' ...
+               int2str(spin_system.control.pulse_ntpts) ' elements.']);
+    end
     for n=1:numel(control.keyholes)
         if (~isempty(control.keyholes{n}))&&(~isa(control.keyholes{n},'function_handle'))
             error('non-empty elements of control.keyholes must be function handles.');


### PR DESCRIPTION
Audit item 13: the keyhole schedule validation checked that entries are function handles, idempotent, and linear, but never that the schedule length matches the pulse grid — the no-keyholes default builds `cell(1,pulse_ntpts)`, which is what the propagation code indexes. Measured on stock: one keyhole and three keyholes were both absorbed for a two-point pulse, leaving out-of-range indexing to surface downstream. The grumble now requires exactly `pulse_ntpts` elements.

Validation: one and three keyholes for a two-point pulse are rejected with `control.keyholes must have 2 elements`; a matching all-empty schedule and a matching schedule containing an idempotent linear handle are both accepted through full `optimcon` construction; `checkcode` empty; house style adds no new violations (9 legacy hits, identical on stock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)