### PR TITLE
gridfree.m: validate the spinning axis when a spinning rate is given

### DIFF
--- a/kernel/contexts/gridfree.m
+++ b/kernel/contexts/gridfree.m
@@ -267,14 +267,18 @@ elseif (~isnumeric(parameters.max_rank))||(~isreal(parameters.max_rank))||...
 end
 
 % Spinning rate
-if isfield(parameters,'rate')&&((~isnumeric(parameters.rate))||(~isreal(parameters.rate)))
-    error('parameters.rate must be a real number.');
+if isfield(parameters,'rate')&&((~isnumeric(parameters.rate))||(~isreal(parameters.rate))||...
+                                (~isscalar(parameters.rate))||(~isfinite(parameters.rate)))
+    error('parameters.rate must be a finite real number.');
 end
 
 % Spinning axis
 if isfield(parameters,'axis')&&((~isnumeric(parameters.axis))||(~isreal(parameters.axis))||...
-                                (~isrow(parameters.axis))||(numel(parameters.axis)~=3))
-    error('parameters.axis must be a row vector of three real numbers.');
+                                (~isrow(parameters.axis))||(numel(parameters.axis)~=3)||...
+                                (~all(isfinite(parameters.axis)))||(norm(parameters.axis,2)==0))
+    error('parameters.axis must be a row vector of three finite real numbers with a non-zero norm.');
+elseif isfield(parameters,'rate')&&(abs(parameters.rate)>0)&&(~isfield(parameters,'axis'))
+    error('a non-zero parameters.rate requires parameters.axis to be specified.');
 end
 
 % Check rotational correlation time


### PR DESCRIPTION
A non-zero `parameters.rate` makes the context read and normalise `parameters.axis` unconditionally, but the grumbler only validated the axis when the field happened to be present, and accepted a zero vector. Measured on a reduced two-proton version of the shipped `mas_powder_csa_gridfree.m` example: stock, a missing axis dies late with 'Unrecognized field name "axis"' after the setup work, and `axis=[0 0 0]` produces NaN rotation terms that are only caught much deeper by the evolution guard ('evolution generator is not finite'); patched, both are rejected upfront with 'a non-zero parameters.rate requires parameters.axis to be specified.' and 'parameters.axis must be a row vector of three finite real numbers with a non-zero norm.' The valid spinning call returns the identical probe sum 1.405977358e+01.

The grumbler now also requires the rate to be a finite real scalar. Function body untouched. `checkcode` empty; house-style gate clean. (Audit item F038.)