### PR TITLE
optimcon.m: reject non-finite power levels and NaN waveform bounds

### DIFF
--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -478,8 +478,9 @@ if isfield(control,'pwr_levels')
 
     % Input validation
     if (~isnumeric(control.pwr_levels))||(~isreal(control.pwr_levels))||...
-       (~isrow(control.pwr_levels))||any(control.pwr_levels(:)<=0)
-        error('control.pwr_levels must be a row vector of positive real numbers.');
+       (~isrow(control.pwr_levels))||any(~isfinite(control.pwr_levels(:)))||...
+       any(control.pwr_levels(:)<=0)
+        error('control.pwr_levels must be a row vector of finite positive real numbers.');
     end
 
     % Absorb power levels
@@ -1022,11 +1023,13 @@ if isfield(control,'u_bound')&&isfield(control,'l_bound')
     wf_dims=[spin_system.control.ncontrols spin_system.control.pulse_ntpts];
 
     % Input validation
-    if (~isnumeric(control.u_bound))||(~isreal(control.u_bound))
-        error('control.u_bound must be a real scalar or a real array.');
+    if (~isnumeric(control.u_bound))||(~isreal(control.u_bound))||...
+       any(isnan(control.u_bound(:)))
+        error('control.u_bound must be a real scalar or a real array, free of NaN.');
     end
-    if (~isnumeric(control.l_bound))||(~isreal(control.l_bound))
-        error('control.l_bound must be a real scalar or a real array.');
+    if (~isnumeric(control.l_bound))||(~isreal(control.l_bound))||...
+       any(isnan(control.l_bound(:)))
+        error('control.l_bound must be a real scalar or a real array, free of NaN.');
     end
     if (~isscalar(control.u_bound))&&(~isequal(size(control.u_bound),wf_dims))
         error(['control.u_bound must be a scalar or have dimensions ' int2str(wf_dims) '.']);


### PR DESCRIPTION
Audit item 17: `control.pwr_levels` was gated by `<=0`, which NaN and Inf both pass, and the `u_bound`/`l_bound` checks had no finiteness condition at all — NaN bounds also slip through the `u_bound-l_bound<0` ordering test because every comparison with NaN is false. Measured on stock: `pwr_levels=NaN`, `pwr_levels=[1 Inf]`, and NaN bounds were all absorbed. Power levels are now required finite and positive; bounds are required NaN-free. Infinite bounds remain legal — they mean an unclipped waveform and work correctly downstream, matching the finite defaults' semantics.

Validation: `NaN`, `[1 Inf]`, and `[1 NaN]` power levels rejected; NaN upper and lower bounds rejected; `u_bound=Inf, l_bound=-Inf` accepted; the valid finite template accepted through full `optimcon` construction; `checkcode` empty; house style adds no new violations (9 legacy hits, identical on stock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)