### PR TITLE
optimcon.m: require offset, carrier, and drift generators to match control dimensions

### DIFF
--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -526,6 +526,9 @@ if isfield(control,'offsets')&&isfield(control,'off_ops')
            (size(control.off_ops{n},1)~=size(control.off_ops{n},2))
             error('elements of control.off_ops must be square matrices.');
         end
+        if size(control.off_ops{n},1)~=size(spin_system.control.operators{1},1)
+            error('control.off_ops must have the same dimension as the control operators.');
+        end
     end
 
     % Reject non-Hermitian offsets where unitarity is required
@@ -633,6 +636,9 @@ if isfield(control,'carrier_ops')
             size(control.carrier_ops{n},2))
             error('elements of control.carrier_ops must be square matrices.');
         end
+        if size(control.carrier_ops{n},1)~=size(spin_system.control.operators{1},1)
+            error('control.carrier_ops must have the same dimension as the control operators.');
+        end
     end
     if ~isfield(control,'carrier_frq')
         error('control.carrier_ops and control.carrier_frq are required simultaneously.');
@@ -695,6 +701,10 @@ if isfield(control,'drifts')
         if (numel(control.drifts{n})~=1)&&(numel(control.drifts{n})~=spin_system.control.pulse_ntpts)
             error(['need either 1 or ' int2str(spin_system.control.pulse_ntpts) ' elements in control.drift{' ...
                    int2str(n) '}, found ' int2str(numel(control.drifts{n})) ' elements.']);
+        end
+        if ~all(cellfun(@(m)isequal(size(m),size(spin_system.control.operators{1})),...
+                        control.drifts{n}(:)))
+            error('drift generators must have the same dimension as the control operators.');
         end
     end
     if ~all(cellfun(@numel,control.drifts(:))==numel(control.drifts{1}))


### PR DESCRIPTION
Audit item 18: `control.off_ops` and `control.carrier_ops` were checked for squareness, count, and Hermiticity only, and the drift blocks were checked for cell structure and slice counts only — nothing tied any of them to the dimension of the control operators they are summed with at propagation time. Measured on stock: a 3x3 offset operator was absorbed alongside 2x2 controls and drifts, leaving the failure to surface deep inside trajectory code. Each family is now required to match the control operator dimension at absorption, with the control operators (the first mandatory generator family processed) as the single reference.

Validation: 3x3 offset operator, 3x3 carrier operator, and 3x3 drift generator each rejected informatively against 2x2 controls; a matching offset operator and the plain template both accepted through full `optimcon` construction; `checkcode` empty; house style adds no new violations (9 legacy hits, identical on stock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)