### PR TITLE
fapt2sfo.m: refuse zero-frequency sequences without an explicit time grid

### DIFF
--- a/kernel/optimcon/fapt2sfo.m
+++ b/kernel/optimcon/fapt2sfo.m
@@ -44,6 +44,11 @@ if ~exist('time_grid','var')
     % Find the end time of the sequence
     end_time=max(cellfun(@(x)x(5),fapt));
 
+    % Refuse zero-frequency sequences without a grid
+    if max_freq==0
+        error('all frequencies in fapt are zero, an explicit time_grid must be supplied.');
+    end
+
     % Get the time grid with dt < half Nyquist
     dt_hN=1/(4*max_freq); npts=ceil(end_time/dt_hN)+1;
     time_grid=linspace(0,end_time,npts); dt=time_grid(2);

--- a/kernel/optimcon/fapt2sfo.m
+++ b/kernel/optimcon/fapt2sfo.m
@@ -33,7 +33,7 @@
 function [wave,dt,time_grid]=fapt2sfo(fapt,time_grid)
 
 % Check consistency
-grumble(fapt);
+grumble(fapt,exist('time_grid','var'));
 
 % Make time grid if not provided
 if ~exist('time_grid','var')
@@ -43,11 +43,6 @@ if ~exist('time_grid','var')
 
     % Find the end time of the sequence
     end_time=max(cellfun(@(x)x(5),fapt));
-
-    % Refuse zero-frequency sequences without a grid
-    if max_freq==0
-        error('all frequencies in fapt are zero, an explicit time_grid must be supplied.');
-    end
 
     % Get the time grid with dt < half Nyquist
     dt_hN=1/(4*max_freq); npts=ceil(end_time/dt_hN)+1;
@@ -89,7 +84,7 @@ end
 end
 
 % Consistency enforcement
-function grumble(fapt)
+function grumble(fapt,have_grid)
 if ~iscell(fapt)
     error('fapt must be a cell array of five-element vectors.');
 end
@@ -103,6 +98,9 @@ for n=1:numel(fapt)
     if fapt{n}(4)>=fapt{n}(5)
         error('end time precedes start time in fapt.');
     end
+end
+if (~have_grid)&&(max(abs(cellfun(@(x)x(1),fapt)))==0)
+    error('all frequencies in fapt are zero, an explicit time_grid must be supplied.');
 end
 end
 


### PR DESCRIPTION
When no `time_grid` is supplied, the grid step is derived from the highest frequency in the sequence. A valid purely on-resonance specification has `max_freq=0`, so `dt_hN` becomes Inf, the grid collapses to one point, and `time_grid(2)` dies with a raw indexing error. Measured: stock, the DC-only automatic-grid call fails with 'Index exceeds the number of array elements. Index must not exceed 1.'; patched, it is refused upfront with 'all frequencies in fapt are zero, an explicit time_grid must be supplied.' The mixed-frequency automatic-grid path and the DC-with-user-grid path return outputs identical to stock (probe sums 9.071024301e+00 and 2.849717011e+01).

Nyquist-based gridding is genuinely undefined at zero bandwidth, so the documented resolution is an explicit user grid rather than an arbitrary default rule. `checkcode` empty; house-style gate clean. (Audit item F046; also item 8 of the optimal-control audit list, claimed by this job in the cross-session dedup.)