### PR TITLE
hessreg.m: warn when RFO regularisation fails to converge

### DIFF
--- a/kernel/optimcon/hessreg.m
+++ b/kernel/optimcon/hessreg.m
@@ -72,6 +72,11 @@ end
 % Clean up the result
 H=real(H+H')/2;
 
+% Warn if the target condition number was not reached
+if cond(H,2)>=max_cond
+    warning('RFO regularisation failed to reach the target condition number, increase control.reg_max_iter.');
+end
+
 end
 
 % Consistency enforcement


### PR DESCRIPTION
Audit item 14: when the RFO loop exhausts `control.reg_max_iter` without reaching `control.reg_max_cond`, `hessreg` silently returns whatever Hessian it last produced — measured on stock with a zero-gradient singular direction (`H=diag([0 -1])`, `g=[0;0]`, one iteration): the returned matrix has eigenvalues `[0 1]`, rank one, and the caller learns nothing. A warning is now raised whenever the returned Hessian still misses the target condition number. The returned value is unchanged — downstream Newton steps on a singular Hessian are separately guarded by the non-finite direction check of PR #238 — so converging optimisations are unaffected.

Validation: the exhaustion case returns the same `[0 1]` eigenvalues and now warns; a well-conditioned Hessian passes through bit-identical with no warning; a regularisable indefinite Hessian (`diag([-1 2])`) is fixed to positive definite (minimum eigenvalue 0.70, condition number 5.3) with no warning; `checkcode` empty; house style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)