### PR TITLE
ctrl_trajan.m: extend even-channel checks to phase and amplitude plots

### DIFF
--- a/kernel/optimcon/ctrl_trajan.m
+++ b/kernel/optimcon/ctrl_trajan.m
@@ -772,6 +772,16 @@ if ismember('frq_controls',spin_system.control.plotting)
         error('instantaneous frequency plots require an even number of control channels.');
     end
 end
+if ismember('phi_controls',spin_system.control.plotting)
+    if ~(mod(size(waveform,1),2)==0)
+        error('phase plots require an even number of control channels.');
+    end
+end
+if ismember('amp_controls',spin_system.control.plotting)
+    if ~(mod(size(waveform,1),2)==0)
+        error('amplitude plots require an even number of control channels.');
+    end
+end
 end
 
 % If you can't explain it simply, you don't


### PR DESCRIPTION
Audit item 21: `ctrl_trajan` converts control channel pairs to polar coordinates for the `phi_controls` and `amp_controls` plotting modes, but only the `spectrogram` and `frq_controls` modes had even-channel-count checks in the grumble. Measured on stock: a three-channel optimisation with `phi_controls` plotting died mid-run as a raw `sizeDimensionsMustMatch` inside the pairing loop. The grumble now applies the same even-channel requirement to the two missing pairwise modes, with mode-specific messages matching the existing pair.

Validation: odd-channel waveforms are rejected informatively for all four pairwise modes; an even-channel waveform passes the channel grumble (the mock then stops only on unrelated absent mock fields, as intended); the `kernel/dynamic_optimcon_remaining` regression suite, which exercises real `ctrl_trajan` plotting offscreen, passes; `checkcode` empty; house style adds no new violations (3 legacy hits, identical on stock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)