### PR TITLE
optimcon.m: require one penalty weight per penalty

### DIFF
--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -995,6 +995,9 @@ if isfield(control,'penalties')&&isfield(control,'p_weights')
        (~isrow(control.p_weights))||any(control.p_weights(:)<0)
             error('control.p_weights must be a row vector of non-negative real numbers.');
     end
+    if numel(control.p_weights)~=numel(control.penalties)
+        error('control.p_weights must have one weight per entry in control.penalties.');
+    end
     
     % Absorb penalties and their weights
     spin_system.control.penalties=control.penalties; control=rmfield(control,'penalties');


### PR DESCRIPTION
`control.p_weights` was validated as a non-negative row vector but never length-matched against `control.penalties`, although every downstream consumer indexes one weight per penalty. Measured on a minimal one-carbon GRAPE setup: stock, fewer weights than penalties dies in the post-absorption report loop with a raw 'Index exceeds the number of array elements.' and extra weights are silently accepted (two weights against one penalty), making the configured objective differ from the user input without any diagnostic; patched, both are rejected early with 'control.p_weights must have one weight per entry in control.penalties.' The matched case absorbs identically to stock.

Validation-only change inside the penalty-processing block; nothing else touched. `checkcode` empty; the house-style gate reports nine pre-existing inline-comment violations in the stock defaults block (verified identical count against f82fae6), none added by this change. (Audit item F047; also item 10 of the optimal-control audit list, claimed by this job in the cross-session dedup.)