### PR TITLE
grape_xy.m: validate waveform columns against the basis or the time grid

### DIFF
--- a/kernel/optimcon/wrappers/grape_xy.m
+++ b/kernel/optimcon/wrappers/grape_xy.m
@@ -188,6 +188,15 @@ if ~isempty(spin_system.control.basis)
         error(['the number of columns in control.basis must be '...
                int2str(spin_system.control.pulse_ntpts)]);
     end
+    if size(waveform,2)~=size(spin_system.control.basis,1)
+        error(['waveform must have one column per basis function, i.e. '...
+               int2str(size(spin_system.control.basis,1)) ' columns.']);
+    end
+else
+    if size(waveform,2)~=spin_system.control.pulse_ntpts
+        error(['waveform must have ' ...
+               int2str(spin_system.control.pulse_ntpts) ' columns.']);
+    end
 end
 end
 


### PR DESCRIPTION
Audit item 22: the `grape_xy` grumble checked the waveform row count against the number of controls and the basis column count against the time grid, but never the waveform column count. Measured on stock: a 1x3 waveform against a two-row basis died as a raw `MATLAB:innerdim` at the `waveform*basis` translation. The grumble now requires one waveform column per basis function when a basis is active, and `pulse_ntpts` columns otherwise. Penalty weight indexing is untouched — that validation belongs to the whole-repo audit job's `optimcon`-level fix (its F047).

Validation: the 1x3-against-basis and 1x3-against-grid cases are both rejected informatively; matching shapes evaluate to finite fidelities through the full `ensemble` path in basis and plain modes; the `kernel/dynamic_optimcon_remaining` regression suite, which exercises `grape_xy`, `grape_phase`, `grape_coop`, and curvilinear wrappers, passes; `checkcode` empty; house style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)