### PR TITLE
polar2cartesian.m: require positive amplitudes when derivatives are requested

### DIFF
--- a/kernel/pulses/polar2cartesian.m
+++ b/kernel/pulses/polar2cartesian.m
@@ -121,8 +121,8 @@ if nargin==2
         error('amplitude and phase vectors must have the same dimension.');
     end
 elseif nargin==4
-    if (~isnumeric(r))||(~isreal(r))||(~all(r>=0))
-        error('amplitude parameter must be a vector of non-negative real numbers.');
+    if (~isnumeric(r))||(~isreal(r))||(~all(r>0))
+        error('amplitude parameter must be a vector of positive real numbers when derivatives are requested.');
     end
     if (~isnumeric(p))||(~isreal(p))
         error('phase parameter must be a vector of real numbers.');
@@ -138,8 +138,8 @@ elseif nargin==4
         error('all input vectors must have the same dimension.');
     end
 elseif nargin==8
-    if (~isnumeric(r))||(~isreal(r))||(~all(r>=0))
-        error('amplitude parameter must be a vector of non-negative real numbers.');
+    if (~isnumeric(r))||(~isreal(r))||(~all(r>0))
+        error('amplitude parameter must be a vector of positive real numbers when derivatives are requested.');
     end
     if (~isnumeric(p))||(~isreal(p))
         error('phase parameter must be a vector of real numbers.');

--- a/kernel/pulses/polar2cartesian.m
+++ b/kernel/pulses/polar2cartesian.m
@@ -62,11 +62,11 @@ function [x,y,Dx,Dy,Dxx,Dxy,Dyx,Dyy]=polar2cartesian(r,p,Dr,Dp,Drr,Drp,Dpr,Dpp)
 
 % Check consistency
 if nargin==2
-    grumble(r,p);
+    grumble(nargout,r,p);
 elseif nargin==4
-    grumble(r,p,Dr,Dp);
+    grumble(nargout,r,p,Dr,Dp);
 elseif nargin==8
-    grumble(r,p,Dr,Dp,Drr,Drp,Dpr,Dpp);
+    grumble(nargout,r,p,Dr,Dp,Drr,Drp,Dpr,Dpp);
 else
     error('incorrect number of arguments.');
 end
@@ -109,8 +109,8 @@ end
 end
 
 % Consistency enforcement
-function grumble(r,p,df_dr,df_dp,d2f_dr2,d2f_drdp,d2f_dpdr,d2f_dp2)
-if nargin==2
+function grumble(nouts,r,p,df_dr,df_dp,d2f_dr2,d2f_drdp,d2f_dpdr,d2f_dp2)
+if nargin==3
     if (~isnumeric(r))||(~isreal(r))||(~all(r>=0))
         error('amplitude parameter must be a vector of non-negative real numbers.');
     end
@@ -120,8 +120,8 @@ if nargin==2
     if ~all(size(r)==size(p))
         error('amplitude and phase vectors must have the same dimension.');
     end
-elseif nargin==4
-    if (~isnumeric(r))||(~isreal(r))||(~all(r>0))
+elseif nargin==5
+    if (~isnumeric(r))||(~isreal(r))||(~all(r>=0))||((nouts>2)&&(~all(r>0)))
         error('amplitude parameter must be a vector of positive real numbers when derivatives are requested.');
     end
     if (~isnumeric(p))||(~isreal(p))
@@ -137,8 +137,8 @@ elseif nargin==4
        (~all(size(df_dr)==size(df_dp)))
         error('all input vectors must have the same dimension.');
     end
-elseif nargin==8
-    if (~isnumeric(r))||(~isreal(r))||(~all(r>0))
+elseif nargin==9
+    if (~isnumeric(r))||(~isreal(r))||(~all(r>=0))||((nouts>2)&&(~all(r>0)))
         error('amplitude parameter must be a vector of positive real numbers when derivatives are requested.');
     end
     if (~isnumeric(p))||(~isreal(p))


### PR DESCRIPTION
The derivative and Hessian transforms divide by `r` and `r.^2`, but the grumbler accepted `r>=0` in every branch. Measured: stock, a zero amplitude in the gradient or Hessian call returns silently non-finite output (`finite=0`) that poisons pulse optimisation; patched, both derivative branches reject it with 'amplitude parameter must be a vector of positive real numbers when derivatives are requested.' The value-only conversion still accepts zero amplitudes (unchanged, sum 4.024495537e+00), and positive-amplitude derivative output is identical to stock.

The only production caller that requests derivatives, the SNSA branch of `penalty.m`, cannot pass zeros: active samples exceed the ceiling bound and inactive ones are pinned to 1 by `amp_safe`, so this is a safety net for direct calls rather than a behaviour change for GRAPE. `checkcode` empty; house-style gate clean. (Audit item F059.)