### PR TITLE
kernel_from_antenna.m, kernel_from_transm.m: save kernels next to the scripts

### DIFF
--- a/examples/optimal_control/distortions/kernel_estimation/kernel_from_antenna.m
+++ b/examples/optimal_control/distortions/kernel_estimation/kernel_from_antenna.m
@@ -32,7 +32,10 @@ kylabel('a.u.'); ktitle('ideal waveform');
 x=real_ideal+1i*imag_ideal;
 y=real_part+1i*imag_part;
 h=kernelest(x,y,32,'tikh','causal',10);
-save('hiper_kernel_antenna.mat','h');
+
+% Save the kernel next to this script
+save(fullfile(fileparts(mfilename('fullpath')),...
+              'hiper_kernel_antenna.mat'),'h');
 
 % Compute and plot the convolution
 y=conv(x,h); y=y(1:numel(x));

--- a/examples/optimal_control/distortions/kernel_estimation/kernel_from_transm.m
+++ b/examples/optimal_control/distortions/kernel_estimation/kernel_from_transm.m
@@ -47,7 +47,10 @@ df=freq_axis_ghz(2)-freq_axis_ghz(1); zf=2*numel(amp);
 [~,t]=ifft_time_axis(numel(amp),df,zf);
 h_old=h(t<=16); t_old=t(t<=16); t=(0:31)'/2;
 h=interp1(t_old,h_old,t,'spline');
-save('hiper_kernel_trans.mat','h');
+
+% Save the kernel next to this script
+save(fullfile(fileparts(mfilename('fullpath')),...
+              'hiper_kernel_trans.mat'),'h');
 subplot(2,1,2); plot(t,[real(h) imag(h)]);
 kxlabel('time, ns'); kgrid; xlim tight; ylim padded;
 kylabel('filter ampl.'); klegend({'in-phase','quadrature'});


### PR DESCRIPTION
Audit item 27: both kernel estimation examples end with `save('hiper_kernel_*.mat','h')`, which writes into whatever directory the user happens to be in. The shipped kernels of the same names are git-tracked in the example directory and are what `kernel_application.m` picks up from the path — so running the examples from elsewhere silently produces a stray file that the rest of the pipeline never sees. The saves are now anchored to the script's own directory via `mfilename('fullpath')`: the examples deliberately regenerate the shipped kernels regardless of the caller's working directory, and never litter the current directory.

Validation: both examples run to completion from a scratch directory outside the repository; no kernel files appear in that directory; the regenerated kernels land next to the scripts, load back, and are finite 32-point vectors; `checkcode` empty on both files; house style adds no new violations (one legacy inline comment on a stock line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)