### PR TITLE
ipcs.m: handle the zero-density limit of the contrast functional

### DIFF
--- a/experiments/pseudocon/ipcs.m
+++ b/experiments/pseudocon/ipcs.m
@@ -221,6 +221,11 @@ else
        
 end
 
+% Refuse a zero starting density under the contrast term
+if (parameters.sharpen>0)&&(~any(guess))
+    error('the initial density is identically zero, the contrast functional is undefined there.');
+end
+
 % Generate Fourier derivative multipliers
 [X,Y,Z]=ndgrid(fftdiff(1,npoints,1),fftdiff(1,npoints,1),fftdiff(1,npoints,1));
 
@@ -289,7 +294,10 @@ end
         err=norm(theo_pcs-expt_pcs,2)^2; err_ls=err;
         
         % Compute contrast functional
-        if (parameters.sharpen>0)&&any(den)
+        if parameters.sharpen>0
+            if ~any(den)
+                error('density is identically zero, the contrast functional is undefined.');
+            end
             pivot=max(abs(den))/2; pden=den/pivot;
             reg_a=contrast_scaling*parameters.sharpen*...
                   sum((pden.^2).*exp(-pden.^2));
@@ -317,7 +325,10 @@ end
             grad_err=2*1e6*reshape(real(ifftn(S.*fftn_dx)),[npoints^3 1])/probdens_scaling;
             
             % Add contrast gradient (ugly interpolation over the singularity)
-            if (parameters.sharpen>0)&&any(den)
+            if parameters.sharpen>0
+                if ~any(den)
+                    error('density is identically zero, the contrast functional is undefined.');
+                end
                 [pivot,where]=max(abs(den)); pivot=pivot/2; pden=den/pivot;
                 grad_cont=2*contrast_scaling*parameters.sharpen*...
                             exp(-pden.^2).*pden.*(1-pden.^2)/pivot;
@@ -428,10 +439,19 @@ end
             
             % Add contrast Hessian (ugly interpolation over the singularity)
             if parameters.sharpen>0
+                if ~any(den_x)
+                    error('density is identically zero, the contrast functional is undefined.');
+                end
                 [pivot,where]=max(abs(den_x)); pivot=pivot/2; pden_x=den_x/pivot;
                 hess_cont=2*contrast_scaling*parameters.sharpen*(1/pivot^2)*...
                             exp(-pden_x.^2).*(1-5*pden_x.^2+2*pden_x.^4).*den_v;
-                hess_cont(where)=(hess_cont(where+1)+hess_cont(where-1))/2;
+                if where==1
+                    hess_cont(where)=hess_cont(where+1);
+                elseif where==numel(hess_cont)
+                    hess_cont(where)=hess_cont(where-1);
+                else
+                    hess_cont(where)=(hess_cont(where+1)+hess_cont(where-1))/2;
+                end
                 y(:,n)=y(:,n)+hess_cont;
             end
             

--- a/experiments/pseudocon/ipcs.m
+++ b/experiments/pseudocon/ipcs.m
@@ -289,10 +289,10 @@ end
         err=norm(theo_pcs-expt_pcs,2)^2; err_ls=err;
         
         % Compute contrast functional
-        if parameters.sharpen>0
-            pivot=max(abs(den))/2; pden=den/pivot; 
+        if (parameters.sharpen>0)&&any(den)
+            pivot=max(abs(den))/2; pden=den/pivot;
             reg_a=contrast_scaling*parameters.sharpen*...
-                  sum((pden.^2).*exp(-pden.^2)); 
+                  sum((pden.^2).*exp(-pden.^2));
             err=err+reg_a; clear('pden');
         else
             reg_a=0;
@@ -317,11 +317,17 @@ end
             grad_err=2*1e6*reshape(real(ifftn(S.*fftn_dx)),[npoints^3 1])/probdens_scaling;
             
             % Add contrast gradient (ugly interpolation over the singularity)
-            if parameters.sharpen>0
+            if (parameters.sharpen>0)&&any(den)
                 [pivot,where]=max(abs(den)); pivot=pivot/2; pden=den/pivot;
                 grad_cont=2*contrast_scaling*parameters.sharpen*...
                             exp(-pden.^2).*pden.*(1-pden.^2)/pivot;
-                grad_cont(where)=(grad_cont(where+1)+grad_cont(where-1))/2; 
+                if where==1
+                    grad_cont(where)=grad_cont(where+1);
+                elseif where==numel(grad_cont)
+                    grad_cont(where)=grad_cont(where-1);
+                else
+                    grad_cont(where)=(grad_cont(where+1)+grad_cont(where-1))/2;
+                end
                 grad_err=grad_err+grad_cont; clear('grad_cont','pden');
             end
             


### PR DESCRIPTION
The contrast-gradient interpolation `grad_cont(where)=(grad_cont(where+1)+grad_cont(where-1))/2` reads out of bounds when the density maximum sits at the first or last cube voxel. Reachability analysis: the cube corners lie outside the active region, so `where` can only reach a boundary when the density is identically zero — a state reachable in production because the Kuprov-equation branch clips negative user guesses to zero. At that point the contrast term itself is 0/0: the functional is zero-homogeneous (`pden=den/(max|den|/2)` is scale-invariant), so it has **no limit** at zero density and no value can be continuously assigned there.

The fix therefore refuses the undefined point instead of assigning one (the first version of this PR set the term to zero there; the Codex review correctly pointed out that this creates a jump discontinuity and a non-derivative gradient, and it has been replaced): `ipcs` refuses to start the optimisation from a clipped all-zero guess under `sharpen>0`, and the value, gradient, and Hessian paths all raise a clear error at an identically zero density. The pivot interpolations in both the gradient and the Hessian are now bounds-safe at the ends. Measured: stock, the zero-guess call dies with 'Array indices must be positive integers or logical values.'; patched, it is refused upfront with 'the initial density is identically zero, the contrast functional is undefined there.' Regression: 3000 consecutive fmincon iteration lines on a nonzero-density run are identical stock vs patched. `checkcode` empty; house-style gate clean. (Audit item F025.)