### PR TITLE
pcs_combi_fit.m: support spin groups of any size

### DIFF
--- a/experiments/pseudocon/pcs_combi_fit.m
+++ b/experiments/pseudocon/pcs_combi_fit.m
@@ -100,8 +100,8 @@ parfor n=1:N*M %#ok<*PFBNS>
     pcs=paramag_shift_perms(p_index,:)-diamag_shift_perms(d_index,:); 
     
     % Build the input arrays
-    hfcs=cell(numel(cell2mat(parameters.spin_groups)),1); p=1;
-    pcs_expt=zeros(numel(cell2mat(parameters.spin_groups)),1); 
+    hfcs=cell(sum(cellfun(@numel,parameters.spin_groups)),1); p=1;
+    pcs_expt=zeros(sum(cellfun(@numel,parameters.spin_groups)),1); 
     for k=1:numel(parameters.spin_groups)
         for m=1:numel(parameters.spin_groups{k})
             hfcs{p}=parameters.hfcs{parameters.spin_groups{k}(m)};
@@ -122,8 +122,8 @@ p_shifts=paramag_shift_perms(p_index,:);
 disp(['Minimum score: ' num2str(min_score)]);
 
 % Build the input arrays
-hfcs=cell(numel(cell2mat(parameters.spin_groups)),1); p=1;
-pcs_expt=zeros(numel(cell2mat(parameters.spin_groups)),1);
+hfcs=cell(sum(cellfun(@numel,parameters.spin_groups)),1); p=1;
+pcs_expt=zeros(sum(cellfun(@numel,parameters.spin_groups)),1);
 for k=1:numel(parameters.spin_groups)
     for m=1:numel(parameters.spin_groups{k})
         hfcs{p}=parameters.hfcs{parameters.spin_groups{k}(m)};
@@ -141,7 +141,7 @@ for k=1:numel(hfcs)
 end
 
 % Compute the predicted total shifts
-total_theo=pcs_theo+kron(d_shifts',[1; 1; 1]);
+total_theo=pcs_theo+repelem(d_shifts(:),cellfun(@numel,parameters.spin_groups(:)));
 
 % Report to the user
 disp('Best permuted diamagnetic shifts:'); disp(d_shifts');

--- a/experiments/pseudocon/pcs_combi_fit.m
+++ b/experiments/pseudocon/pcs_combi_fit.m
@@ -100,8 +100,8 @@ parfor n=1:N*M %#ok<*PFBNS>
     pcs=paramag_shift_perms(p_index,:)-diamag_shift_perms(d_index,:); 
     
     % Build the input arrays
-    hfcs=cell(sum(cellfun(@numel,parameters.spin_groups)),1); p=1;
-    pcs_expt=zeros(sum(cellfun(@numel,parameters.spin_groups)),1); 
+    hfcs=cell(sum(cellfun(@numel,parameters.spin_groups(:))),1); p=1;
+    pcs_expt=zeros(sum(cellfun(@numel,parameters.spin_groups(:))),1); 
     for k=1:numel(parameters.spin_groups)
         for m=1:numel(parameters.spin_groups{k})
             hfcs{p}=parameters.hfcs{parameters.spin_groups{k}(m)};
@@ -122,8 +122,8 @@ p_shifts=paramag_shift_perms(p_index,:);
 disp(['Minimum score: ' num2str(min_score)]);
 
 % Build the input arrays
-hfcs=cell(sum(cellfun(@numel,parameters.spin_groups)),1); p=1;
-pcs_expt=zeros(sum(cellfun(@numel,parameters.spin_groups)),1);
+hfcs=cell(sum(cellfun(@numel,parameters.spin_groups(:))),1); p=1;
+pcs_expt=zeros(sum(cellfun(@numel,parameters.spin_groups(:))),1);
 for k=1:numel(parameters.spin_groups)
     for m=1:numel(parameters.spin_groups{k})
         hfcs{p}=parameters.hfcs{parameters.spin_groups{k}(m)};


### PR DESCRIPTION
The total-shift line `kron(d_shifts',[1; 1; 1])` hard-coded three members per chemical-shift group, and the member counting used `numel(cell2mat(parameters.spin_groups))`, which cannot even concatenate groups of unequal length — although the header documents `spin_groups` as arbitrary integer vectors. Measured on deterministic synthetic hyperfine tensors: stock, groups of 2+3 and 2+4 die at `cell2mat` with 'Dimensions of arrays being concatenated are not consistent.' and equal-size 2+2 groups die at the total-shift addition with 'Arrays have incompatible sizes'; patched, all three run, and the per-member diamagnetic assignment is exact — e.g. in the 2+4 case the first member of the second group carries precisely that group's shift (difference 2.000000000e+00), and in the 2+2 case precisely the permuted assignment the fit selected. The documented two-groups-of-three case returns sums identical to stock (7.060557767e-01).

Fix: member counting via `sum(cellfun(@numel,...))` at the four counting sites, and `repelem(d_shifts(:),cellfun(@numel,...))` for the total shifts. `checkcode` empty; house-style gate clean. (Audit item F026.)