### PR TITLE
evolution.m: recombine refocus subspaces at the true stack width

### DIFF
--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -496,10 +496,10 @@ switch spin_system.bas.formalism
                 % Recombine the subspaces
                 report(spin_system,'recombining subspaces...');
                 rows=cell2mat(rows); cols=cell2mat(cols); vals=cell2mat(vals);
-                answer=sparse(rows,cols,vals,size(rho,1),nsteps+1);
+                answer=sparse(rows,cols,vals,size(rho,1),size(rho,2));
                 answer=clean_up(spin_system,answer,spin_system.tols.zte_tol);
                 report(spin_system,'data retrieval finished.');
-                
+
             case 'observable'
                 
                 % Create arrays of projections


### PR DESCRIPTION
The multi-subspace Liouville `refocus` branch rebuilt its sparse answer with `nsteps+1` columns, although the propagated data comes from the input stack, whose width is `size(rho,2)`. Measured on a coupled two-spin system (three independent subspaces, verified against an independent direct `P^(k-1)` construction): stock, an eight-column stack against `nsteps=5` dies with 'Index exceeds array bounds.', and a four-column stack silently returns six columns with two phantom zero columns; patched, all widths return correctly (deviations from the direct construction at 5e-15), and the consistent case is numerically identical to stock.

One-token fix: `nsteps+1` becomes `size(rho,2)` in the recombination. `checkcode` empty; the house-style gate reports three pre-existing violations around the R2017b GPU workaround comment, identical in stock, none added. (Audit item F041.)