### PR TITLE
redfield_integral_serial.m: clean the integral fragment, not the accumulator

### DIFF
--- a/kernel/includes/redfield_integral_serial.m
+++ b/kernel/includes/redfield_integral_serial.m
@@ -87,9 +87,6 @@ for n=1:numel(Q)
     end
 end
     
-% Final clean-up
-R=clean_up(spin_system,R,1e-2*spin_system.tols.rlx_zero);
-
 % Deallocate variables
 clear('Q','L0','R_int','weights','rates','states');
 

--- a/kernel/includes/redfield_integral_serial.m
+++ b/kernel/includes/redfield_integral_serial.m
@@ -71,8 +71,8 @@ for n=1:numel(Q)
                                             
                                         % Compute the integral and clean up to the tolerance
                                         R_int=-weights{s}(j)*A*expmint(spin_system,B,C,D,upper_limit);
-                                        R=clean_up(spin_system,R,1e-2*spin_system.tols.rlx_zero);
-                                        
+                                        R_int=clean_up(spin_system,R_int,1e-2*spin_system.tols.rlx_zero);
+
                                         % Add to the total
                                         R=R+R_int;
                                             
@@ -87,6 +87,9 @@ for n=1:numel(Q)
     end
 end
     
+% Final clean-up
+R=clean_up(spin_system,R,1e-2*spin_system.tols.rlx_zero);
+
 % Deallocate variables
 clear('Q','L0','R_int','weights','rates','states');
 


### PR DESCRIPTION
The serial Redfield include computed each integral fragment `R_int` and then applied `clean_up` to the accumulated total `R` before the addition — so every new fragment entered uncleaned (the last one permanently), while the growing accumulator was rescanned on every term. The adjacent comment says the integral is what should be cleaned, and the asynchronous path does exactly that: `brw_compute_kernel` cleans each fragment before returning it. The include now mirrors that convention exactly — `R_int` is cleaned before accumulation, and nothing else is touched (the first version of this PR also added a whole-accumulator clean after the loop nest; the Codex review correctly pointed out that the asynchronous include has no such pass and that `R` can already carry other relaxation theories' contributions at that point, so it has been removed — the common cleanup at `relaxation.m:701` remains the only whole-R pass).

Consequence scope, measured honestly: the returned relaxation superoperator is unchanged — a two-spin dipolar+CSA probe returns bit-identical serial and asynchronous superoperators before and after the change at both the default and a deliberately coarsened threshold (relative deviation exactly zero, 29 non-zeroes). The fix repairs the intermediate-accumulation behaviour that densifies sparse storage in large systems, restores the documented intent, and makes the serial and parallel code paths structurally equivalent. `checkcode` empty; house-style gate: one pre-existing footer-quote violation, identical in stock, none added. (Audit item F043.)