### PR TITLE
rlx_split.m: return pure blocks and a true remainder

### DIFF
--- a/kernel/utilities/rlx_split.m
+++ b/kernel/utilities/rlx_split.m
@@ -30,18 +30,17 @@ grumble(spin_system,R);
 % Interpret the basis
 [L,M]=lin2lm(spin_system.bas.basis);
 
-% Index single- and multi-spin orders (sso and mso)
+% Index single-spin orders
 sso_mask=(sum(logical(spin_system.bas.basis),2)==1);
-mso_mask=(sum(logical(spin_system.bas.basis),2)>1 );
 
-% Index longlitudinal and transverse states
+% Index longitudinal and transverse states
 long_sso_mask=any((L>0)&(M==0),2)&sso_mask;
 tran_sso_mask=any((L>0)&(M~=0),2)&sso_mask;
 
 % Split the relaxation superoperator
-R1=R; R1(~long_sso_mask,~long_sso_mask)=0;
-R2=R; R2(~tran_sso_mask,~tran_sso_mask)=0;
-Rm=R; Rm(~mso_mask,~mso_mask)=0;
+R1=0*R; R1(long_sso_mask,long_sso_mask)=R(long_sso_mask,long_sso_mask);
+R2=0*R; R2(tran_sso_mask,tran_sso_mask)=R(tran_sso_mask,tran_sso_mask);
+Rm=R-R1-R2;
 
 end
 


### PR DESCRIPTION
The split zeroed only the complement-complement block of each output, so couplings between selected and unselected states stayed in every component: cross-relaxation terms appeared in R1 and were duplicated into Rm, and R1+R2+Rm did not reconstruct R. Measured on a two-spin dipolar+CSA system with the Redfield kite retained: stock, four DD-CSA cross-term entries sit outside the longitudinal block of R1, the same four are duplicated in Rm, and the decomposition residual is 1.096e+00; patched, all components are pure (zero out-of-block entries, zero duplication) and R1+R2+Rm-R is exactly zero. The diagonal blocks themselves are identical to stock in both versions, so the correctly-assigned parts are unchanged.

R1 and R2 are now the pure longitudinal and transverse single-spin blocks, and Rm is computed as the literal remainder R-R1-R2, which matches the documented 'the rest of R' contract. The unused multi-spin mask fell away. No callers exist in the tree. `checkcode` empty; house-style gate clean. (Audit item F061.)