### PR TITLE
mesh_vorn.m: refuse active vertices with unbounded Voronoi cells

### DIFF
--- a/interfaces/comsol/mesh_vorn.m
+++ b/interfaces/comsol/mesh_vorn.m
@@ -30,6 +30,13 @@ mesh.vor.cells=C;
 mesh.vor.cells=mesh.vor.cells(mesh.idx.active);
 mesh.vor.ncells=numel(mesh.vor.cells);
 
+% Refuse unbounded active cells
+unbounded=cellfun(@(x)any(x==1),mesh.vor.cells);
+if any(unbounded)
+    error(['vertices ' int2str(reshape(mesh.idx.active(unbounded),1,[])) ...
+           ' have unbounded Voronoi cells and must be inactivated.']);
+end
+
 % Voronoi cell area calculation
 vor_cell_areas=zeros(mesh.vor.ncells,1);
 for n=1:mesh.vor.ncells
@@ -48,8 +55,8 @@ end
 
 % Consistency enforcement
 function grumble(mesh)
-if ~isfield(mesh,'idx')
-    error('vertex index is missing from mesh structure.');
+if (~isfield(mesh,'idx'))||(~isfield(mesh.idx,'active'))
+    error('active vertex index is missing from mesh structure.');
 end
 end
 


### PR DESCRIPTION
The Voronoi weight calculation implicitly assumes every active vertex has a bounded cell: an active cell containing voronoin's point at infinity gives a NaN `polyarea`, which `flow_gen` later divides by, poisoning the flow generator with no diagnostic anywhere. Nothing enforced the assumption — `mesh_crop`'s first-guess active list is every vertex of every retained triangle, wall vertices included, and only the user's hand-picked `comsol.inactivate` list (chosen by eye via `show_mesh.m`) discharges it.

Measured on the shipped chip example: the blessed configuration is unchanged (2659 active cells, zero unbounded, zero NaN weights, identical before and after); the same pipeline with the inactivation step skipped silently stores 4 NaN weights out of 2693 on stock, and on the patched code is refused with 'vertices 10 14 3372 3386 have unbounded Voronoi cells and must be inactivated.' — those four are precisely members of the example's own inactivate list, so the error message tells the user exactly what to add. The grumbler now also requires `mesh.idx.active` to be present rather than failing later with a raw field reference.

Contract enforcement only; no geometry or weight computation changed. `checkcode` empty; house-style gate clean. (Audit item F034, added on Ilya's instruction after the design question was answered.)