### PR TITLE
relaxation.m: firmly gate Redfield relaxation theory to sphten-liouv

### DIFF
--- a/interfaces/skills/spinach-simulations/references/pitfalls.md
+++ b/interfaces/skills/spinach-simulations/references/pitfalls.md
@@ -106,7 +106,7 @@ picking `zeeman-hilb` or `zeeman-wavef` for convenience and then asking for
 relaxation is a frequent dead end:
 
 ```
-Redfield relaxation theory is only available in Liouville space.
+Redfield relaxation theory is only available for sphten-liouv formalism.
 extended T1,T2 relaxation theory is only available for sphten-liouv formalism.
 analytical decoupling is only available for sphten-liouv formalism.
 chemical reaction modelling is only available for sphten-liouv formalism.
@@ -114,8 +114,8 @@ bas.projections option is only available for sphten-liouv formalism.
 ```
 
 (Lindblad, Nottingham, Weizmann, SRFK, SRSK relaxation and IME thermalisation
-carry the same Liouville-space restriction with parallel wording; the `kite`
-and `secular` values of `inter.rlx_keep` are also `sphten-liouv` only.) The
+are refused outside Liouville space with parallel wording; the `kite` and
+`secular` values of `inter.rlx_keep` are also `sphten-liouv` only.) The
 fix is to move to `sphten-liouv`, which is the correct default anyway.
 
 ### Relaxation setup

--- a/interfaces/skills/spinach-simulations/references/relaxation.md
+++ b/interfaces/skills/spinach-simulations/references/relaxation.md
@@ -39,9 +39,9 @@ inter.rlx_keep='kite';       % which terms of R survive
 inter.equilibrium='zero';    % where relaxation drives the system
 ```
 
-Formalism restrictions are enforced. `t1_t2` is `sphten-liouv` only.
-`redfield`, `lindblad`, `nottingham`, `weizmann`, `SRFK`, `SRSK`, and IME
-thermalisation all require Liouville space (`sphten-liouv` or
+Formalism restrictions are enforced. `t1_t2` and `redfield` are
+`sphten-liouv` only. `lindblad`, `nottingham`, `weizmann`, `SRFK`, `SRSK`,
+and IME thermalisation all require Liouville space (`sphten-liouv` or
 `zeeman-liouv`). Only `damp` works in `zeeman-hilb`.
 
 Terms accumulate in a fixed order: `t1_t2`, `redfield`, `lindblad`,

--- a/kernel/relaxation.m
+++ b/kernel/relaxation.m
@@ -748,8 +748,8 @@ if ( ismember('t1_t2',spin_system.rlx.theories))&&...
     error('extended T1,T2 relaxation theory is only available for sphten-liouv formalism.');
 end
 if ( ismember('redfield',spin_system.rlx.theories))&&...
-   (~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'}))
-    error('Redfield relaxation theory is only available in Liouville space.');
+   (~ismember(spin_system.bas.formalism,{'sphten-liouv'}))
+    error('Redfield relaxation theory is only available for sphten-liouv formalism.');
 end
 if ( ismember('lindblad',spin_system.rlx.theories))&&...
    (~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'}))


### PR DESCRIPTION
Per Ilya's decision in #talos-dev (2026-08-21): multi-species support is the stronger priority and Redfield is not to be extended to zeeman-liouv; the advertisement of that combination is to be deleted instead.

## What

The relaxation.m grumble admitted `{'sphten-liouv','zeeman-liouv'}` for the redfield theory with the message "only available in Liouville space". The combination has never worked: on this exact base commit (b2ac471), zeeman-liouv with anisotropic interactions runs the full lab-frame setup and five-index loop and then dies inside the corrfun grumble, and purely isotropic zeeman-liouv silently returns an all-zero relaxation superoperator (both re-measured today). The reason is structural: corrfun's species-state map (corrfun.m:66) is built from IST basis descriptors, and the per-species tau_c masking has no pointwise Zeeman-basis equivalent.

The gate now admits sphten-liouv only, with the same message corrfun already uses, so the refusal is upfront and states the strongest condition actually enforced. One statement changed, +2/-2; corrfun's own grumble remains as the backstop. A repository sweep found no other statement advertising Redfield outside sphten-liouv: ngce.m and rlx_scalar.m are formalism-free matrix machinery, all other mentions are formalism-neutral, and no shipped example combines zeeman-liouv with redfield.

## Validation

- sphten-liouv Redfield superoperator on a two-spin dipolar test system: stock vs patched difference norm exactly 0.
- zeeman-liouv anisotropic, zeeman-liouv isotropic, and zeeman-hilb all refused upfront with the new message (previously: late corrfun death, silent zero R, and a "Liouville space" refusal respectively).
- checkcode empty; house style checker 0 violations stock and patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Bot review round

Codex flagged (P2, accepted) that the spinach-simulations skill references still carried the old claim: `relaxation.md` advertised redfield in both Liouville formalisms and `pitfalls.md` quoted the deleted error string. Both updated in 4ecb24b; the original sweep was `*.m`-only, and a follow-up all-file-type sweep found no other stale statement in the repository.