### PR TITLE
Formalism extensions: zeeman-liouv coherence machinery, decoupling, gates; zeeman-wavef propagation core; zeeman-hilb admission; doublerot rotor stacks

### DIFF
--- a/experiments/esr_dipolar/deer_3p_soft_deer.m
+++ b/experiments/esr_dipolar/deer_3p_soft_deer.m
@@ -75,36 +75,7 @@
 function echo_stack=deer_3p_soft_deer(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_dipolar/deer_3p_soft_deer.m
+++ b/experiments/esr_dipolar/deer_3p_soft_deer.m
@@ -95,6 +95,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_dipolar/deer_3p_soft_deer.m
+++ b/experiments/esr_dipolar/deer_3p_soft_deer.m
@@ -74,6 +74,32 @@
 
 function echo_stack=deer_3p_soft_deer(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/esr_dipolar/deer_3p_soft_hole.m
+++ b/experiments/esr_dipolar/deer_3p_soft_hole.m
@@ -67,36 +67,7 @@
 function fids=deer_3p_soft_hole(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_dipolar/deer_3p_soft_hole.m
+++ b/experiments/esr_dipolar/deer_3p_soft_hole.m
@@ -87,6 +87,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_dipolar/deer_3p_soft_hole.m
+++ b/experiments/esr_dipolar/deer_3p_soft_hole.m
@@ -66,6 +66,32 @@
 
 function fids=deer_3p_soft_hole(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/esr_dipolar/deer_4p_soft_deer.m
+++ b/experiments/esr_dipolar/deer_4p_soft_deer.m
@@ -101,6 +101,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_dipolar/deer_4p_soft_deer.m
+++ b/experiments/esr_dipolar/deer_4p_soft_deer.m
@@ -80,6 +80,32 @@
 
 function echo_stack=deer_4p_soft_deer(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/esr_dipolar/deer_4p_soft_deer.m
+++ b/experiments/esr_dipolar/deer_4p_soft_deer.m
@@ -81,36 +81,7 @@
 function echo_stack=deer_4p_soft_deer(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_dipolar/deer_4p_soft_hole.m
+++ b/experiments/esr_dipolar/deer_4p_soft_hole.m
@@ -66,6 +66,32 @@
 
 function fids=deer_4p_soft_hole(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/esr_dipolar/deer_4p_soft_hole.m
+++ b/experiments/esr_dipolar/deer_4p_soft_hole.m
@@ -87,6 +87,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_dipolar/deer_4p_soft_hole.m
+++ b/experiments/esr_dipolar/deer_4p_soft_hole.m
@@ -67,36 +67,7 @@
 function fids=deer_4p_soft_hole(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_dipolar/eseem.m
+++ b/experiments/esr_dipolar/eseem.m
@@ -36,6 +36,42 @@
 
 function fid=eseem(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Stretch the screen state
+    if isfield(parameters,'screen')
+        parameters.screen=reshape(parameters.screen,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Project the pulse operator
+    if isfield(parameters,'pulse_op')
+        parameters.pulse_op=hilb2liouv(parameters.pulse_op,'comm');
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K)
 

--- a/experiments/esr_dipolar/eseem.m
+++ b/experiments/esr_dipolar/eseem.m
@@ -37,46 +37,7 @@
 function fid=eseem(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Stretch the screen state
-    if isfield(parameters,'screen')
-        parameters.screen=reshape(parameters.screen,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Project the pulse operator
-    if isfield(parameters,'pulse_op')
-        parameters.pulse_op=hilb2liouv(parameters.pulse_op,'comm');
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K)

--- a/experiments/esr_dipolar/eseem.m
+++ b/experiments/esr_dipolar/eseem.m
@@ -67,6 +67,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_dipolar/oopeseem.m
+++ b/experiments/esr_dipolar/oopeseem.m
@@ -73,6 +73,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_dipolar/oopeseem.m
+++ b/experiments/esr_dipolar/oopeseem.m
@@ -42,6 +42,42 @@
 
 function fid=oopeseem(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Stretch the screen state
+    if isfield(parameters,'screen')
+        parameters.screen=reshape(parameters.screen,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Project the pulse operator
+    if isfield(parameters,'pulse_op')
+        parameters.pulse_op=hilb2liouv(parameters.pulse_op,'comm');
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K)
 

--- a/experiments/esr_dipolar/oopeseem.m
+++ b/experiments/esr_dipolar/oopeseem.m
@@ -43,46 +43,7 @@
 function fid=oopeseem(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Stretch the screen state
-    if isfield(parameters,'screen')
-        parameters.screen=reshape(parameters.screen,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Project the pulse operator
-    if isfield(parameters,'pulse_op')
-        parameters.pulse_op=hilb2liouv(parameters.pulse_op,'comm');
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K)

--- a/experiments/esr_hyperfine/endor_cw.m
+++ b/experiments/esr_hyperfine/endor_cw.m
@@ -28,36 +28,7 @@
 function fid=endor_cw(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Consistency check
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_hyperfine/endor_cw.m
+++ b/experiments/esr_hyperfine/endor_cw.m
@@ -27,6 +27,32 @@
 
 function fid=endor_cw(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Consistency check
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/esr_hyperfine/endor_cw.m
+++ b/experiments/esr_hyperfine/endor_cw.m
@@ -48,6 +48,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_hyperfine/endor_davies.m
+++ b/experiments/esr_hyperfine/endor_davies.m
@@ -92,6 +92,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_hyperfine/endor_davies.m
+++ b/experiments/esr_hyperfine/endor_davies.m
@@ -71,6 +71,32 @@
 
 function answer=endor_davies(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/esr_hyperfine/endor_davies.m
+++ b/experiments/esr_hyperfine/endor_davies.m
@@ -72,36 +72,7 @@
 function answer=endor_davies(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_hyperfine/endor_mims.m
+++ b/experiments/esr_hyperfine/endor_mims.m
@@ -27,6 +27,32 @@
 
 function fid=endor_mims(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Consistency check
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/esr_hyperfine/endor_mims.m
+++ b/experiments/esr_hyperfine/endor_mims.m
@@ -48,6 +48,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_hyperfine/endor_mims.m
+++ b/experiments/esr_hyperfine/endor_mims.m
@@ -28,36 +28,7 @@
 function fid=endor_mims(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Consistency check
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_hyperfine/endor_mims_echo.m
+++ b/experiments/esr_hyperfine/endor_mims_echo.m
@@ -47,6 +47,32 @@
 
 function stim_echo=endor_mims_echo(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/esr_hyperfine/endor_mims_echo.m
+++ b/experiments/esr_hyperfine/endor_mims_echo.m
@@ -48,36 +48,7 @@
 function stim_echo=endor_mims_echo(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_hyperfine/endor_mims_echo.m
+++ b/experiments/esr_hyperfine/endor_mims_echo.m
@@ -68,6 +68,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_hyperfine/endor_mims_ideal.m
+++ b/experiments/esr_hyperfine/endor_mims_ideal.m
@@ -72,6 +72,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/esr_hyperfine/endor_mims_ideal.m
+++ b/experiments/esr_hyperfine/endor_mims_ideal.m
@@ -52,36 +52,7 @@
 function endor_spec=endor_mims_ideal(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/esr_hyperfine/endor_mims_ideal.m
+++ b/experiments/esr_hyperfine/endor_mims_ideal.m
@@ -51,6 +51,32 @@
 
 function endor_spec=endor_mims_ideal(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/holeburn.m
+++ b/experiments/holeburn.m
@@ -59,6 +59,32 @@
 
 function fid=holeburn(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/experiments/holeburn.m
+++ b/experiments/holeburn.m
@@ -80,6 +80,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/holeburn.m
+++ b/experiments/holeburn.m
@@ -60,36 +60,7 @@
 function fid=holeburn(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/hyperpol/dnp_field_scan.m
+++ b/experiments/hyperpol/dnp_field_scan.m
@@ -58,8 +58,22 @@ function dnp=dnp_field_scan(spin_system,parameters,H,R,K)
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 
-% Damp unit state and check
-R(1,1)=-mean(abs(diag(R))); Rc=condest(R);
+% Damp the trace direction and check
+switch spin_system.bas.formalism
+
+    case 'sphten-liouv'
+
+        % Unit state carries the trace
+        R(1,1)=-mean(abs(diag(R)));
+
+    case 'zeeman-liouv'
+
+        % Trace direction is the stretched unit matrix
+        dim=sqrt(size(R,1)); u0=speye(dim); u0=u0(:);
+        R=R-(mean(abs(diag(R)))/dim)*(u0*u0');
+
+end
+Rc=condest(R);
 if Rc>1e9, error('R must be non-singular.'); end
 if any(ismember({'redfield','naka-zwan'},spin_system.rlx.theories))&&...
            (Rc>1/spin_system.tols.rlx_integration)
@@ -120,8 +134,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K)
-if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
-    error('this function is only available for sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available for sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||(~ismatrix(H))||(~ismatrix(R))||(~ismatrix(K))
     error('H, R and K arguments must be matrices.');

--- a/experiments/hyperpol/dnp_freq_scan.m
+++ b/experiments/hyperpol/dnp_freq_scan.m
@@ -58,8 +58,22 @@ function dnp=dnp_freq_scan(spin_system,parameters,H,R,K)
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 
-% Damp unit state and check
-R(1,1)=-mean(abs(diag(R))); Rc=condest(R);
+% Damp the trace direction and check
+switch spin_system.bas.formalism
+
+    case 'sphten-liouv'
+
+        % Unit state carries the trace
+        R(1,1)=-mean(abs(diag(R)));
+
+    case 'zeeman-liouv'
+
+        % Trace direction is the stretched unit matrix
+        dim=sqrt(size(R,1)); u0=speye(dim); u0=u0(:);
+        R=R-(mean(abs(diag(R)))/dim)*(u0*u0');
+
+end
+Rc=condest(R);
 if Rc>1e9, error('R must be non-singular.'); end
 if any(ismember({'redfield','naka-zwan'},spin_system.rlx.theories))&&...
            (Rc>1/spin_system.tols.rlx_integration)
@@ -199,8 +213,8 @@ end
 
 % Consistency checking
 function grumble(spin_system,parameters,H,R,K)
-if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
-    error('this function is only available for sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available for sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~ismatrix(H))||(~ismatrix(R))||(~ismatrix(K))

--- a/experiments/hyperpol/dnp_time_dep.m
+++ b/experiments/hyperpol/dnp_time_dep.m
@@ -43,44 +43,7 @@
 function answer=dnp_time_dep(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Project the microwave and electron Zeeman operators
-    if isfield(parameters,'mw_oper')
-        parameters.mw_oper=hilb2liouv(parameters.mw_oper,'comm');
-    end
-    if isfield(parameters,'ez_oper')
-        parameters.ez_oper=hilb2liouv(parameters.ez_oper,'comm');
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters)

--- a/experiments/hyperpol/dnp_time_dep.m
+++ b/experiments/hyperpol/dnp_time_dep.m
@@ -42,6 +42,40 @@
 
 function answer=dnp_time_dep(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Project the microwave and electron Zeeman operators
+    if isfield(parameters,'mw_oper')
+        parameters.mw_oper=hilb2liouv(parameters.mw_oper,'comm');
+    end
+    if isfield(parameters,'ez_oper')
+        parameters.ez_oper=hilb2liouv(parameters.ez_oper,'comm');
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters)
 

--- a/experiments/hyperpol/dnp_time_dep.m
+++ b/experiments/hyperpol/dnp_time_dep.m
@@ -71,6 +71,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/imaging/basic_1d_hard.m
+++ b/experiments/imaging/basic_1d_hard.m
@@ -59,8 +59,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/cpmg_dec.m
+++ b/experiments/imaging/cpmg_dec.m
@@ -79,8 +79,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/epi_2d.m
+++ b/experiments/imaging/epi_2d.m
@@ -115,8 +115,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/epi_3d.m
+++ b/experiments/imaging/epi_3d.m
@@ -181,8 +181,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/fse.m
+++ b/experiments/imaging/fse.m
@@ -91,8 +91,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/grad_echo.m
+++ b/experiments/imaging/grad_echo.m
@@ -50,8 +50,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/phase_enc_2d.m
+++ b/experiments/imaging/phase_enc_2d.m
@@ -117,8 +117,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/phase_enc_3d.m
+++ b/experiments/imaging/phase_enc_3d.m
@@ -125,8 +125,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/press_1d.m
+++ b/experiments/imaging/press_1d.m
@@ -62,8 +62,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/press_2d.m
+++ b/experiments/imaging/press_2d.m
@@ -81,8 +81,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/press_voxel_1d.m
+++ b/experiments/imaging/press_voxel_1d.m
@@ -68,8 +68,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/press_voxel_2d.m
+++ b/experiments/imaging/press_voxel_2d.m
@@ -87,8 +87,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/press_voxel_3d.m
+++ b/experiments/imaging/press_voxel_3d.m
@@ -102,8 +102,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F) 
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/spin_echo.m
+++ b/experiments/imaging/spin_echo.m
@@ -51,8 +51,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/spiral.m
+++ b/experiments/imaging/spiral.m
@@ -115,8 +115,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/imaging/udd_dec.m
+++ b/experiments/imaging/udd_dec.m
@@ -73,8 +73,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,parameters,H,R,K,G,F)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('this function is only available in sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('this function is only available in sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))||...
    (~isnumeric(F))||(~ismatrix(H))||(~ismatrix(R))||...

--- a/experiments/relaxan.m
+++ b/experiments/relaxan.m
@@ -44,6 +44,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/relaxan.m
+++ b/experiments/relaxan.m
@@ -34,6 +34,21 @@
 
 function [r1,r2,t1,t2,R]=relaxan(spin_system,euler_angles)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 if nargin==2
     grumble(spin_system,euler_angles);

--- a/experiments/relaxan.m
+++ b/experiments/relaxan.m
@@ -35,25 +35,7 @@
 function [r1,r2,t1,t2,R]=relaxan(spin_system,euler_angles)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+spin_system=sim2liouv(spin_system,struct(),[],[],[]);
 
 % Check consistency
 if nargin==2

--- a/experiments/slowpass.m
+++ b/experiments/slowpass.m
@@ -53,19 +53,7 @@ freq_grid=2*pi*linspace(parameters.sweep(1),...
 spectrum=zeros(size(freq_grid),'like',1i);
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-    
-    % Inform the user 
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-    
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-    parameters.rho0=parameters.rho0(:); parameters.coil=parameters.coil(:);
-    
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-    
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Compose the Liouvillian
 L=H+1i*R+1i*K;

--- a/experiments/sp_acquire.m
+++ b/experiments/sp_acquire.m
@@ -72,6 +72,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     zbas=spin_system.bas.basis; hdim=size(zbas,1);
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
     % Update the formalism setting
     spin_system.bas.formalism='zeeman-liouv';
 

--- a/experiments/sp_acquire.m
+++ b/experiments/sp_acquire.m
@@ -52,36 +52,7 @@
 function fid=sp_acquire(spin_system,parameters,H,R,K)
 
 % Move into adjoint representation if needed
-if strcmp(spin_system.bas.formalism,'zeeman-hilb')
-
-    % Inform the user
-    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
-
-    % Project into Liouville space
-    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
-
-    % Stretch the state parameters
-    if isfield(parameters,'rho0')
-        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
-    end
-    if isfield(parameters,'coil')
-        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
-    end
-
-    % Rebuild the basis index table for the Liouville space
-    zbas=spin_system.bas.basis; hdim=size(zbas,1);
-    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
-
-    % Discard Hilbert space symmetry data
-    if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
-    end
-
-    % Update the formalism setting
-    spin_system.bas.formalism='zeeman-liouv';
-
-end
+[spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K);
 
 % Check consistency
 grumble(spin_system,parameters,H,R,K);

--- a/experiments/sp_acquire.m
+++ b/experiments/sp_acquire.m
@@ -51,6 +51,32 @@
 
 function fid=sp_acquire(spin_system,parameters,H,R,K)
 
+% Move into adjoint representation if needed
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Stretch the state parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,size(spin_system.bas.basis,1)^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,size(spin_system.bas.basis,1)^2,[]);
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
 % Check consistency
 grumble(spin_system,parameters,H,R,K);
 

--- a/kernel/basis.m
+++ b/kernel/basis.m
@@ -534,10 +534,39 @@ if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-wavef'})
     
     % Report to the user
     report(spin_system,['matrix dimension for all operators and states: ' num2str(prod(spin_system.comp.mults))]);
-    
+
     % Run the symmetry treatment
     spin_system=symmetry(spin_system,bas);
-    
+
+end
+
+% Process Liouville space Zeeman basis
+if strcmp(spin_system.bas.formalism,'zeeman-liouv')
+
+    % Build the Hilbert space Zeeman index table
+    dim=prod(spin_system.comp.mults);
+    zbas=zeros(dim,spin_system.comp.nspins);
+    for n=1:spin_system.comp.nspins
+        current_column=1;
+        for k=1:spin_system.comp.nspins
+            if n==k
+                current_column=kron(current_column,(1:spin_system.comp.mults(k))');
+            else
+                current_column=kron(current_column,ones(spin_system.comp.mults(k),1));
+            end
+        end
+        zbas(:,n)=current_column;
+    end
+
+    % Ket and bra index tables in the vectorisation order
+    spin_system.bas.basis=[repmat(zbas,[dim 1]) kron(zbas,ones(dim,1))];
+
+    % Report to the user
+    report(spin_system,['matrix dimension for all superoperators and state vectors: ' num2str(dim^2)]);
+
+    % Run the symmetry treatment
+    spin_system=symmetry(spin_system,bas);
+
 end
 
 % Preload Lie algebra structure tables

--- a/kernel/coherence.m
+++ b/kernel/coherence.m
@@ -6,7 +6,9 @@
 %
 % Arguments:
 %
-%     rho    -  a state vector or a horizontal stack thereof
+%     rho    -  a state vector or a horizontal stack thereof;
+%               in zeeman-hilb, a density matrix or a horizon-
+%               tal stack thereof
 %
 %     spec   -  a cell array containing the specification of
 %               which coherences to keep on which spins. For
@@ -25,8 +27,11 @@
 %   rho     - the state vector with the undesired orders of
 %             spin correlations zeroed out
 %
-% Note: this function requires sphten-liouv or zeeman-liouv formalism
-%       and supports Fokker-Planck direct products.
+% Note: this function requires sphten-liouv, zeeman-liouv, or zeeman-
+%       hilb formalism; Fokker-Planck direct products are supported
+%       in the Liouville space formalisms. In zeeman-hilb, the densi-
+%       ty matrices are stretched into Liouville space, filtered the-
+%       re, and folded back.
 %
 % ilya.kuprov@weizmann.ac.il
 % ledwards@cbs.mpg.de
@@ -40,6 +45,9 @@ grumble(spin_system,rho,spec);
 
 % Store dimension statistics
 spn_dim=size(spin_system.bas.basis,1);
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+    spn_dim=spn_dim^2;
+end
 spc_dim=numel(rho)/spn_dim;
 problem_dims=size(rho);
 
@@ -64,6 +72,16 @@ switch spin_system.bas.formalism
 
         % Coherence orders of stretched density matrix elements
         M=M_ket-M_bra;
+
+    case 'zeeman-hilb'
+
+        % Projection quantum numbers of the Zeeman basis
+        hdim=size(spin_system.bas.basis,1);
+        spns=(spin_system.comp.mults-1)/2;
+        M_lvl=spns-spin_system.bas.basis+1;
+
+        % Coherence orders of stretched density matrix elements
+        M=repmat(M_lvl,[hdim 1])-kron(M_lvl,ones(hdim,1));
 
 end
 
@@ -120,8 +138,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,rho,spec)
-if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
-    error('analytical coherence order selection is only available for sphten-liouv and zeeman-liouv formalisms.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv','zeeman-hilb'})
+    error('analytical coherence order selection is only available for sphten-liouv, zeeman-liouv, and zeeman-hilb formalisms.');
 end
 if ~isnumeric(rho)
     error('the state vector(s) must be numeric.');

--- a/kernel/coherence.m
+++ b/kernel/coherence.m
@@ -25,8 +25,8 @@
 %   rho     - the state vector with the undesired orders of
 %             spin correlations zeroed out
 %
-% Note: this function requires sphten-liouv formalism and supports Fok-
-%       ker-Planck direct products.
+% Note: this function requires sphten-liouv or zeeman-liouv formalism
+%       and supports Fokker-Planck direct products.
 %
 % ilya.kuprov@weizmann.ac.il
 % ledwards@cbs.mpg.de
@@ -39,15 +39,44 @@ function rho=coherence(spin_system,rho,spec)
 grumble(spin_system,rho,spec);
 
 % Store dimension statistics
-spn_dim=size(spin_system.bas.basis,1);
+switch spin_system.bas.formalism
+    case 'sphten-liouv'
+        spn_dim=size(spin_system.bas.basis,1);
+    case 'zeeman-liouv'
+        spn_dim=prod(spin_system.comp.mults)^2;
+end
 spc_dim=numel(rho)/spn_dim;
 problem_dims=size(rho);
 
 % Fold indirect dimensions
 rho=reshape(rho,[spn_dim spc_dim]);
 
-% Compute projection quantum numbers of basis states
-[~,M]=lin2lm(spin_system.bas.basis);
+% Compute coherence order bookkeeping array
+switch spin_system.bas.formalism
+
+    case 'sphten-liouv'
+
+        % Projection quantum numbers of basis states
+        [~,M]=lin2lm(spin_system.bas.basis);
+
+    case 'zeeman-liouv'
+
+        % Hilbert space dimension and multiplicities
+        dim=prod(spin_system.comp.mults);
+        mults=spin_system.comp.mults;
+
+        % Zeeman projection quantum numbers of Hilbert space states
+        Mh=zeros(dim,numel(mults));
+        for n=1:numel(mults)
+            Mh(:,n)=kron(kron(ones(prod(mults(1:(n-1))),1),...
+                              ((mults(n)-1)/2:-1:-(mults(n)-1)/2)'),...
+                         ones(prod(mults((n+1):end)),1));
+        end
+
+        % Coherence orders of stretched density matrix elements
+        M=kron(ones(dim,1),Mh)-kron(Mh,ones(dim,1));
+
+end
 
 % Preallocate state mask array
 state_mask=false(spn_dim,numel(spec));
@@ -102,13 +131,18 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,rho,spec)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('analytical coherence order selection is only available for sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('analytical coherence order selection is only available for sphten-liouv and zeeman-liouv formalisms.');
 end
 if ~isnumeric(rho)
     error('the state vector(s) must be numeric.');
 end
-if mod(numel(rho),size(spin_system.bas.basis,1))~=0
+if strcmp(spin_system.bas.formalism,'sphten-liouv')
+    spn_dim=size(spin_system.bas.basis,1);
+else
+    spn_dim=prod(spin_system.comp.mults)^2;
+end
+if mod(numel(rho),spn_dim)~=0
     error('the number of elements in rho must be a multiple of the dimension of the spin state space.');
 end
 if ~iscell(spec)

--- a/kernel/coherence.m
+++ b/kernel/coherence.m
@@ -39,12 +39,7 @@ function rho=coherence(spin_system,rho,spec)
 grumble(spin_system,rho,spec);
 
 % Store dimension statistics
-switch spin_system.bas.formalism
-    case 'sphten-liouv'
-        spn_dim=size(spin_system.bas.basis,1);
-    case 'zeeman-liouv'
-        spn_dim=prod(spin_system.comp.mults)^2;
-end
+spn_dim=size(spin_system.bas.basis,1);
 spc_dim=numel(rho)/spn_dim;
 problem_dims=size(rho);
 
@@ -61,20 +56,14 @@ switch spin_system.bas.formalism
 
     case 'zeeman-liouv'
 
-        % Hilbert space dimension and multiplicities
-        dim=prod(spin_system.comp.mults);
-        mults=spin_system.comp.mults;
-
-        % Zeeman projection quantum numbers of Hilbert space states
-        Mh=zeros(dim,numel(mults));
-        for n=1:numel(mults)
-            Mh(:,n)=kron(kron(ones(prod(mults(1:(n-1))),1),...
-                              ((mults(n)-1)/2:-1:-(mults(n)-1)/2)'),...
-                         ones(prod(mults((n+1):end)),1));
-        end
+        % Projection quantum numbers of ket and bra indices
+        nspins=spin_system.comp.nspins;
+        spns=(spin_system.comp.mults-1)/2;
+        M_ket=spns-spin_system.bas.basis(:,1:nspins)+1;
+        M_bra=spns-spin_system.bas.basis(:,(nspins+1):end)+1;
 
         % Coherence orders of stretched density matrix elements
-        M=kron(ones(dim,1),Mh)-kron(Mh,ones(dim,1));
+        M=M_ket-M_bra;
 
 end
 
@@ -137,12 +126,7 @@ end
 if ~isnumeric(rho)
     error('the state vector(s) must be numeric.');
 end
-if strcmp(spin_system.bas.formalism,'sphten-liouv')
-    spn_dim=size(spin_system.bas.basis,1);
-else
-    spn_dim=prod(spin_system.comp.mults)^2;
-end
-if mod(numel(rho),spn_dim)~=0
+if mod(numel(rho),size(spin_system.bas.basis,1))~=0
     error('the number of elements in rho must be a multiple of the dimension of the spin state space.');
 end
 if ~iscell(spec)

--- a/kernel/contexts/doublerot.m
+++ b/kernel/contexts/doublerot.m
@@ -1,6 +1,9 @@
-% Fokker-Planck double angle spinning context. Generates a Liouvillian
-% superoperator and passes it on to the pulse sequence function, which
-% should be supplied as a handle. Syntax:
+% Double angle spinning context. In Liouville space, this wrapper builds
+% the Fokker-Planck evolution generator and passes it on to the pulse se-
+% quence function, which should be supplied as a handle. In Hilbert space,
+% this wrapper builds the stack of spin Hamiltonians, one for each pair of
+% rotor phases on the two-rotor phase grid, and hands that stack to the
+% pulse sequence. Syntax:
 %
 %      [answer,sph_grid]=doublerot(spin_system,pulse_sequence,...
 %                                  parameters,assumptions)
@@ -47,7 +50,10 @@
 %                         laboratory frame.
 %
 %   parameters.grid     - spherical grid file name. See grids
-%                         directory in the kernel.
+%                         directory in the kernel. Two-angle
+%                         grids should be used in Liouville
+%                         space and three-angle grids in Hil-
+%                         bert space.
 %
 %   parameters.needs    - a cell array of character strings spe-
 %                         cifying additional requirements that
@@ -112,7 +118,7 @@ parameters=defaults(spin_system,parameters);
 grumble(spin_system,pulse_sequence,parameters,assumptions);
 
 % Report to the user
-report(spin_system,'building the Liouvillian...');
+report(spin_system,'building the evolution generator...');
 
 % Set the assumptions
 spin_system=assume(spin_system,assumptions);
@@ -141,7 +147,6 @@ npoints_total=npoints_outer*npoints_inner;
 spc_dim=npoints_total; spn_dim=size(H,1);
 report(spin_system,['lab space problem dimension     ' num2str(spc_dim)]);
 report(spin_system,['spin space problem dimension    ' num2str(spn_dim)]);
-report(spin_system,['Fokker-Planck problem dimension ' num2str(spc_dim*spn_dim)]);
 parameters.spc_dim=spc_dim; parameters.spn_dim=spn_dim;
 
 % Compute spectral derivative operators
@@ -152,9 +157,31 @@ parameters.spc_dim=spc_dim; parameters.spn_dim=spn_dim;
 phases_outer=kron(traj_outer,ones(npoints_inner,1));
 phases_inner=kron(ones(npoints_outer,1),traj_inner);
 
-% Compute double spinning operator
-M=2*pi*kron((parameters.rate_outer*kron(d_dphi_outer,speye(size(d_dphi_inner)))+...
-             parameters.rate_inner*kron(speye(size(d_dphi_outer)),d_dphi_inner)),speye(size(H)));
+% Formalism-dependent stage
+switch spin_system.bas.formalism
+
+    % Liouville space
+    case {'sphten-liouv','zeeman-liouv'}
+
+        % Report the composite dimension of the Fokker-Planck problem
+        report(spin_system,['Fokker-Planck problem dimension ' num2str(spc_dim*spn_dim)]);
+
+        % Compute double spinning operator
+        M=2*pi*kron((parameters.rate_outer*kron(d_dphi_outer,speye(size(d_dphi_inner)))+...
+                     parameters.rate_inner*kron(speye(size(d_dphi_outer)),d_dphi_inner)),speye(size(H)));
+
+    % Hilbert space
+    case {'zeeman-hilb','zeeman-wavef'}
+
+        % No spinning operator in the rotor stack route
+        M=[];
+
+    otherwise
+
+        % Complain and bomb out
+        error('unknown formalism specification.');
+
+end
 
 % Get rotor axis orientations
 [phi_inner,theta_inner,~]=cart2sph(parameters.axis_inner(1),...
@@ -182,30 +209,35 @@ sph_grid=load([spin_system.sys.root_dir filesep 'kernel' filesep 'grids' ...
 alphas=sph_grid.alphas; betas=sph_grid.betas; 
 gammas=sph_grid.gammas; weights=sph_grid.weights;
 
-% Project relaxation and kinetics
-R=kron(speye(spc_dim),R); K=kron(speye(spc_dim),K);
+% Project into the Fokker-Planck space in Liouville formalisms
+if ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
 
-% Project the initial state
-if isfield(parameters,'rho0')&&strcmp(parameters.grid,'single_crystal')
-    
-    % Single crystal simulations start at 12 o'clock
-    space_part=zeros(parameters.spc_dim,1); space_part(1)=1;
-    parameters.rho0=kron(space_part,parameters.rho0);
-    report(spin_system,'single crystal simulation, rotor phase averaging switched off.');
-    
-elseif isfield(parameters,'rho0')
-    
-    % Powder simulations start equally distributed
-    space_part=ones(parameters.spc_dim,1)/parameters.spc_dim;
-    parameters.rho0=kron(space_part,parameters.rho0);
-    report(spin_system,'powder simulation, rotor phase averaging switched on.');
-    
-end
+    % Project relaxation and kinetics
+    R=kron(speye(spc_dim),R); K=kron(speye(spc_dim),K);
 
-% Project the coil state: same coil everywhere
-if isfield(parameters,'coil')
-    space_part=ones(parameters.spc_dim,1);
-    parameters.coil=kron(space_part,parameters.coil);
+    % Project the initial state
+    if isfield(parameters,'rho0')&&strcmp(parameters.grid,'single_crystal')
+
+        % Single crystal simulations start at 12 o'clock
+        space_part=zeros(parameters.spc_dim,1); space_part(1)=1;
+        parameters.rho0=kron(space_part,parameters.rho0);
+        report(spin_system,'single crystal simulation, rotor phase averaging switched off.');
+
+    elseif isfield(parameters,'rho0')
+
+        % Powder simulations start equally distributed
+        space_part=ones(parameters.spc_dim,1)/parameters.spc_dim;
+        parameters.rho0=kron(space_part,parameters.rho0);
+        report(spin_system,'powder simulation, rotor phase averaging switched on.');
+
+    end
+
+    % Project the coil state: same coil everywhere
+    if isfield(parameters,'coil')
+        space_part=ones(parameters.spc_dim,1);
+        parameters.coil=kron(space_part,parameters.coil);
+    end
+
 end
 
 % Preallocate answer array
@@ -290,14 +322,39 @@ parfor (q=1:numel(weights),nworkers) %#ok<*PFBNS>
         
     end
     
-    % Assemble the liouvillian
-    L=clean_up(spin_system,cell2mat(L),spin_system.tols.liouv_zero);
-    
     % Report to the user
     report(spin_system,'running the pulse sequence...');
-    
-    % Run the pulse sequence
-    ans_array{q}=pulse_sequence(spin_system,parameters,L+1i*M,R,K);
+
+    % Formalism-dependent stage
+    switch spin_system.bas.formalism
+
+        % Liouville space
+        case {'sphten-liouv','zeeman-liouv'}
+
+            % Assemble the Liouvillian
+            L=clean_up(spin_system,cell2mat(L),spin_system.tols.liouv_zero);
+
+            % Run the pulse sequence
+            ans_array{q}=pulse_sequence(spin_system,parameters,L+1i*M,R,K);
+
+        % Hilbert space
+        case {'zeeman-hilb','zeeman-wavef'}
+
+            % Extract the Hamiltonian rotor stack
+            ham_stack=cell(npoints_total,1);
+            for n=1:npoints_total
+                ham_stack{n}=sparse(L{n,n});
+            end
+
+            % Run the pulse sequence with a Hamiltonian stack
+            ans_array{q}=pulse_sequence(spin_system,parameters,ham_stack,R,K);
+
+        otherwise
+
+            % Complain and bomb out
+            error('unknown formalism specification.');
+
+    end
     
 end
 
@@ -360,9 +417,10 @@ end
 % Consistency enforcement
 function grumble(spin_system,pulse_sequence,parameters,assumptions)
 
-% Formalism 
-if ~ismember(spin_system.bas.formalism,{'zeeman-liouv','sphten-liouv'})
-    error('this function is only available in Liouville space.');
+% Wavefunctions cannot represent thermal equilibria
+if strcmp(spin_system.bas.formalism,'zeeman-wavef')&&isfield(parameters,'needs')&&...
+   ismember('iso_eq',parameters.needs)
+    error('thermal equilibrium state cannot be represented by a wavefunction.');
 end
 
 % Rotor ranks

--- a/kernel/contexts/doublerot.m
+++ b/kernel/contexts/doublerot.m
@@ -206,8 +206,14 @@ sph_grid=load([spin_system.sys.root_dir filesep 'kernel' filesep 'grids' ...
                                         filesep parameters.grid '.mat']);
 
 % Assign local variables
-alphas=sph_grid.alphas; betas=sph_grid.betas; 
+alphas=sph_grid.alphas; betas=sph_grid.betas;
 gammas=sph_grid.gammas; weights=sph_grid.weights;
+
+% Reject two-angle powder grids in the Hilbert space route
+if ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-wavef'})&&...
+   (numel(weights)>1)&&all(alphas(:)==0)
+    error('Hilbert space rotor stacks require a three-angle spherical grid.');
+end
 
 % Project into the Fokker-Planck space in Liouville formalisms
 if ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})

--- a/kernel/correlation.m
+++ b/kernel/correlation.m
@@ -6,7 +6,9 @@
 %
 % Parameters:
 %
-%   rho     -  a state vector or a horizontal stack thereof
+%   rho     -  a state vector or a horizontal stack thereof;
+%              in zeeman-hilb, a density matrix or a horizon-
+%              tal stack thereof
 %
 %   correlation_orders  -  a row vector of correlation
 %                          orders to keep
@@ -19,11 +21,13 @@
 %   rho     - the state vector with the undesired orders of
 %             spin correlations zeroed out
 %
-% Note: this function requires sphten-liouv or zeeman-liouv formalism
-%       and supports Fokker-Planck direct products. In zeeman-liouv the
+% Note: this function requires sphten-liouv, zeeman-liouv, or zeeman-
+%       hilb formalism; Fokker-Planck direct products are supported in
+%       the Liouville space formalisms. In the Zeeman formalisms the
 %       selection is an exact projection built from per-spin identity
-%       component channels because correlation order is not diagonal in
-%       the Zeeman basis of Liouville space.
+%       component channels because correlation order is not diagonal
+%       in the Zeeman basis; zeeman-hilb density matrices are stretch-
+%       ed into Liouville space, filtered there, and folded back.
 %
 % ilya.kuprov@weizmann.ac.il
 % ledwards@cbs.mpg.de
@@ -40,6 +44,9 @@ grumble(spin_system,rho,orders,spins)
 
 % Store dimension statistics
 spn_dim=size(spin_system.bas.basis,1);
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+    spn_dim=spn_dim^2;
+end
 spc_dim=numel(rho)/spn_dim;
 problem_dims=size(rho);
 
@@ -72,7 +79,7 @@ switch spin_system.bas.formalism
         % Apply the mask
         rho(~state_mask,:)=0;
 
-    case 'zeeman-liouv'
+    case {'zeeman-liouv','zeeman-hilb'}
 
         % Hilbert space dimension and multiplicities
         dim=prod(spin_system.comp.mults);
@@ -128,8 +135,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,rho,correlation_orders,spins)
-if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
-    error('analytical correlation order selection is only available for sphten-liouv and zeeman-liouv formalisms.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv','zeeman-hilb'})
+    error('analytical correlation order selection is only available for sphten-liouv, zeeman-liouv, and zeeman-hilb formalisms.');
 end
 if ~isnumeric(rho)
     error('the state vector(s) must be numeric.');

--- a/kernel/correlation.m
+++ b/kernel/correlation.m
@@ -92,28 +92,26 @@ switch spin_system.bas.formalism
             end
         end
 
-        % Generating function samples over the selected spins
+        % Generating function samples on the roots of unity
         nsel=numel(spins); gsam=cell(1,nsel+1);
-        for x=0:nsel
-            gs=rho;
+        for j=0:nsel
+            gs=rho; x=exp(2i*pi*j/(nsel+1));
             for n=1:nsel
                 gs=idch{n}*gs+x*(gs-idch{n}*gs);
             end
-            gsam{x+1}=gs;
+            gsam{j+1}=gs;
         end
 
-        % Cardinal weights of the correlation orders to keep
-        vmat=zeros(nsel+1); ind=zeros(nsel+1,1);
-        for c=0:nsel
-            vmat(c+1,:)=(0:nsel).^c;
-            ind(c+1)=double(ismember(c,orders));
+        % Discrete Fourier weights of the correlation orders to keep
+        wts=zeros(nsel+1,1); okords=orders(ismember(orders,0:nsel));
+        for j=0:nsel
+            wts(j+1)=sum(exp(-2i*pi*okords(:)*j/(nsel+1)))/(nsel+1);
         end
-        wts=vmat\ind;
 
         % Assemble the projected state
         rho=wts(1)*gsam{1};
-        for x=1:nsel
-            rho=rho+wts(x+1)*gsam{x+1};
+        for j=1:nsel
+            rho=rho+wts(j+1)*gsam{j+1};
         end
 
 end

--- a/kernel/correlation.m
+++ b/kernel/correlation.m
@@ -39,12 +39,7 @@ if ~exist('spins','var'), spins='all'; end
 grumble(spin_system,rho,orders,spins)
 
 % Store dimension statistics
-switch spin_system.bas.formalism
-    case 'sphten-liouv'
-        spn_dim=size(spin_system.bas.basis,1);
-    case 'zeeman-liouv'
-        spn_dim=prod(spin_system.comp.mults)^2;
-end
+spn_dim=size(spin_system.bas.basis,1);
 spc_dim=numel(rho)/spn_dim;
 problem_dims=size(rho);
 

--- a/kernel/correlation.m
+++ b/kernel/correlation.m
@@ -19,8 +19,11 @@
 %   rho     - the state vector with the undesired orders of
 %             spin correlations zeroed out
 %
-% Note: this function requires sphten-liouv formalism and supports Fok-
-%       ker-Planck direct products.
+% Note: this function requires sphten-liouv or zeeman-liouv formalism
+%       and supports Fokker-Planck direct products. In zeeman-liouv the
+%       selection is an exact projection built from per-spin identity
+%       component channels because correlation order is not diagonal in
+%       the Zeeman basis of Liouville space.
 %
 % ilya.kuprov@weizmann.ac.il
 % ledwards@cbs.mpg.de
@@ -36,7 +39,12 @@ if ~exist('spins','var'), spins='all'; end
 grumble(spin_system,rho,orders,spins)
 
 % Store dimension statistics
-spn_dim=size(spin_system.bas.basis,1);
+switch spin_system.bas.formalism
+    case 'sphten-liouv'
+        spn_dim=size(spin_system.bas.basis,1);
+    case 'zeeman-liouv'
+        spn_dim=prod(spin_system.comp.mults)^2;
+end
 spc_dim=numel(rho)/spn_dim;
 problem_dims=size(rho);
 
@@ -52,17 +60,68 @@ if ~isnumeric(spins)
     end
 end
 
-% Compute the order of correlation for each basis state
-orders_present=sum(logical(spin_system.bas.basis(:,spins)),2);
+% Decide how to proceed
+switch spin_system.bas.formalism
 
-% Wipe all correlation orders except those specified by the user
-state_mask=false(size(spin_system.bas.basis,1),1);
-for n=orders
-    state_mask=state_mask|(orders_present==n);
+    case 'sphten-liouv'
+
+        % Compute the order of correlation for each basis state
+        orders_present=sum(logical(spin_system.bas.basis(:,spins)),2);
+
+        % Wipe all correlation orders except those specified by the user
+        state_mask=false(size(spin_system.bas.basis,1),1);
+        for n=orders
+            state_mask=state_mask|(orders_present==n);
+        end
+
+        % Apply the mask
+        rho(~state_mask,:)=0;
+
+    case 'zeeman-liouv'
+
+        % Hilbert space dimension and multiplicities
+        dim=prod(spin_system.comp.mults);
+        mults=spin_system.comp.mults;
+
+        % Identity component channels of the selected spins
+        idch=cell(1,numel(spins));
+        for n=1:numel(spins)
+            idch{n}=sparse(dim^2,dim^2);
+            for p=1:mults(spins(n))
+                for q=1:mults(spins(n))
+                    A=kron(kron(speye(prod(mults(1:(spins(n)-1)))),...
+                                sparse(p,q,1,mults(spins(n)),mults(spins(n)))),...
+                           speye(prod(mults((spins(n)+1):end))));
+                    idch{n}=idch{n}+kron(conj(A),A)/mults(spins(n));
+                end
+            end
+        end
+
+        % Generating function samples over the selected spins
+        nsel=numel(spins); gsam=cell(1,nsel+1);
+        for x=0:nsel
+            gs=rho;
+            for n=1:nsel
+                gs=idch{n}*gs+x*(gs-idch{n}*gs);
+            end
+            gsam{x+1}=gs;
+        end
+
+        % Cardinal weights of the correlation orders to keep
+        vmat=zeros(nsel+1); ind=zeros(nsel+1,1);
+        for c=0:nsel
+            vmat(c+1,:)=(0:nsel).^c;
+            ind(c+1)=double(ismember(c,orders));
+        end
+        wts=vmat\ind;
+
+        % Assemble the projected state
+        rho=wts(1)*gsam{1};
+        for x=1:nsel
+            rho=rho+wts(x+1)*gsam{x+1};
+        end
+
 end
-    
-% Apply the mask
-rho(~state_mask,:)=0;
 
 % Unfold indirect dimensions
 rho=reshape(rho,problem_dims);
@@ -76,8 +135,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,rho,correlation_orders,spins)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('analytical correlation order selection is only available for sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('analytical correlation order selection is only available for sphten-liouv and zeeman-liouv formalisms.');
 end
 if ~isnumeric(rho)
     error('the state vector(s) must be numeric.');

--- a/kernel/decouple.m
+++ b/kernel/decouple.m
@@ -61,6 +61,9 @@ end
 % Inform the user
 report(spin_system,[num2str(nnz(dec_mask)) ' spins to be frozen and depopulated.']);
 
+% Get the spin space dimension
+spn_dim=size(spin_system.bas.basis,1);
+
 % Build the wipeout machinery
 switch spin_system.bas.formalism
 
@@ -68,9 +71,6 @@ switch spin_system.bas.formalism
 
         % Get the list of states to be wiped
         zero_mask=(sum(spin_system.bas.basis(:,dec_mask),2)~=0);
-
-        % Get the spin space dimension
-        spn_dim=size(spin_system.bas.basis,1);
 
     case 'zeeman-liouv'
 
@@ -92,9 +92,6 @@ switch spin_system.bas.formalism
             end
             P=P*idch;
         end
-
-        % Get the spin space dimension
-        spn_dim=dim^2;
 
 end
 

--- a/kernel/decouple.m
+++ b/kernel/decouple.m
@@ -26,8 +26,12 @@
 % Note: this function is an analytical equivalent of a perfect decoup-
 %       ling pulse sequence on the specified spins.
 %
-% Note: this function requires sphten-liouv formalism and supports Fok-
-%       ker-Planck direct products.
+% Note: this function requires sphten-liouv or zeeman-liouv formalism
+%       and supports Fokker-Planck direct products. In zeeman-liouv the
+%       operation is an exact projection onto the subspace where the
+%       decoupled spins carry only their identity component, because
+%       spin involvement is not diagonal in the Zeeman basis of the
+%       Liouville space.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -43,42 +47,92 @@ grumble(spin_system,L,rho,spins);
 
 % Find the spins to be decoupled
 if isnumeric(spins)
-    
+
     % Find spins by numbers
     dec_mask=false(1,spin_system.comp.nspins); dec_mask(spins)=true;
-    
+
 else
-    
+
     % Find spins by name
     dec_mask=ismember(spin_system.comp.isotopes,spins);
-    
+
 end
 
 % Inform the user
 report(spin_system,[num2str(nnz(dec_mask)) ' spins to be frozen and depopulated.']);
-                
-% Get the list of states to be wiped
-zero_mask=(sum(spin_system.bas.basis(:,dec_mask),2)~=0);
+
+% Build the wipeout machinery
+switch spin_system.bas.formalism
+
+    case 'sphten-liouv'
+
+        % Get the list of states to be wiped
+        zero_mask=(sum(spin_system.bas.basis(:,dec_mask),2)~=0);
+
+        % Get the spin space dimension
+        spn_dim=size(spin_system.bas.basis,1);
+
+    case 'zeeman-liouv'
+
+        % Hilbert space dimension and multiplicities
+        dim=prod(spin_system.comp.mults);
+        mults=spin_system.comp.mults;
+
+        % Identity component projector of the decoupled spins
+        P=speye(dim^2);
+        for n=find(dec_mask)
+            idch=sparse(dim^2,dim^2);
+            for p=1:mults(n)
+                for q=1:mults(n)
+                    A=kron(kron(speye(prod(mults(1:(n-1)))),...
+                                sparse(p,q,1,mults(n),mults(n))),...
+                           speye(prod(mults((n+1):end))));
+                    idch=idch+kron(conj(A),A)/mults(n);
+                end
+            end
+            P=P*idch;
+        end
+
+        % Get the spin space dimension
+        spn_dim=dim^2;
+
+end
 
 % Process the Liouvillian
 if (nargout>0)&&(~isempty(L))
-    
+
     % Get dimension statistics
-    spn_dim=size(spin_system.bas.basis,1); 
     spc_dim=size(L,1)/spn_dim;
-    
-    % Kron the list into the Fokker-Planck space
-    fp_zero_mask=logical(kron(ones(spc_dim,1),zero_mask));
 
     % Inform the user
     report(spin_system,['space sub-problem dimension: ' num2str(spc_dim)]);
     report(spin_system,['spin sub-problem dimension:  ' num2str(spn_dim)]);
-    report(spin_system,['zeroing ' num2str(nnz(fp_zero_mask))...
-                        ' rows and columns in the Liouvillian.']);
 
-    % Apply the zero mask
-    L(fp_zero_mask,:)=0; L(:,fp_zero_mask)=0;
-    
+    % Apply the wipeout machinery
+    switch spin_system.bas.formalism
+
+        case 'sphten-liouv'
+
+            % Kron the list into the Fokker-Planck space
+            fp_zero_mask=logical(kron(ones(spc_dim,1),zero_mask));
+
+            % Inform the user
+            report(spin_system,['zeroing ' num2str(nnz(fp_zero_mask))...
+                                ' rows and columns in the Liouvillian.']);
+
+            % Apply the zero mask
+            L(fp_zero_mask,:)=0; L(:,fp_zero_mask)=0;
+
+        case 'zeeman-liouv'
+
+            % Kron the projector into the Fokker-Planck space
+            fp_proj=kron(speye(spc_dim),P);
+
+            % Apply the projector from both sides
+            L=fp_proj*L*fp_proj;
+
+    end
+
     % Re-evaluate sparsity
     L=clean_up(spin_system,L,spin_system.tols.liouv_zero);
 
@@ -86,31 +140,47 @@ end
 
 % Process state vector stack
 if (nargout>1)&&(~isempty(rho))
-    
+
     % Get dimension statistics
-    spn_dim=size(spin_system.bas.basis,1); 
     spc_dim=size(rho,1)/spn_dim;
 
-    % Kron the list into the Fokker-Planck space
-    fp_zero_mask=logical(kron(ones(spc_dim,1),zero_mask));
-    
     % Inform the user
     report(spin_system,['space sub-problem dimension: ' num2str(spc_dim)]);
     report(spin_system,['spin sub-problem dimension:  ' num2str(spn_dim)]);
-    report(spin_system,['zeroing ' num2str(nnz(fp_zero_mask))...
-                        ' rows in the state vector.']);
-                    
-    % Apply the zero mask
-    rho(fp_zero_mask,:)=0;
-    
+
+    % Apply the wipeout machinery
+    switch spin_system.bas.formalism
+
+        case 'sphten-liouv'
+
+            % Kron the list into the Fokker-Planck space
+            fp_zero_mask=logical(kron(ones(spc_dim,1),zero_mask));
+
+            % Inform the user
+            report(spin_system,['zeroing ' num2str(nnz(fp_zero_mask))...
+                                ' rows in the state vector.']);
+
+            % Apply the zero mask
+            rho(fp_zero_mask,:)=0;
+
+        case 'zeeman-liouv'
+
+            % Kron the projector into the Fokker-Planck space
+            fp_proj=kron(speye(spc_dim),P);
+
+            % Apply the projector
+            rho=fp_proj*rho;
+
+    end
+
 end
 
 end
 
 % Consistency enforcement
 function grumble(spin_system,L,rho,spins)
-if ~ismember(spin_system.bas.formalism,{'sphten-liouv'})
-    error('analytical decoupling is only available for sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('analytical decoupling is only available for sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isempty(rho))&&(~isempty(L))&&(size(L,2)~=size(rho,1))
     error('matrix dimensions of L and rho must agree.');

--- a/kernel/decouple.m
+++ b/kernel/decouple.m
@@ -7,10 +7,12 @@
 %
 % Parameters:
 %
-%     L     - Liouvillian superoperator, this may be left empty
+%     L     - Liouvillian superoperator or, in zeeman-hilb,
+%             the Hamiltonian; this may be left empty
 %
-%     rho   - state vector or a horizontal stack thereof, this
-%             may be left empty
+%     rho   - state vector or a horizontal stack thereof or,
+%             in zeeman-hilb, a density matrix or a horizon-
+%             tal stack thereof; this may be left empty
 %
 %     spins - spins to be wiped, specified either by name, e.g.
 %             {'13C','1H'}, or by a list of numbers, e.g. [1 2]
@@ -26,12 +28,16 @@
 % Note: this function is an analytical equivalent of a perfect decoup-
 %       ling pulse sequence on the specified spins.
 %
-% Note: this function requires sphten-liouv or zeeman-liouv formalism
-%       and supports Fokker-Planck direct products. In zeeman-liouv the
+% Note: this function requires sphten-liouv, zeeman-liouv, or zeeman-
+%       hilb formalism; Fokker-Planck direct products are supported in
+%       the Liouville space formalisms. In the Zeeman formalisms the
 %       operation is an exact projection onto the subspace where the
 %       decoupled spins carry only their identity component, because
-%       spin involvement is not diagonal in the Zeeman basis of the
-%       Liouville space.
+%       spin involvement is not diagonal in the Zeeman basis. In
+%       zeeman-hilb, the Hamiltonian and the density matrices are
+%       stretched into Liouville space, projected there, and folded
+%       back; this replaces every decoupled-spin factor of the Hamil-
+%       tonian by its identity component average.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -72,7 +78,7 @@ switch spin_system.bas.formalism
         % Get the list of states to be wiped
         zero_mask=(sum(spin_system.bas.basis(:,dec_mask),2)~=0);
 
-    case 'zeeman-liouv'
+    case {'zeeman-liouv','zeeman-hilb'}
 
         % Hilbert space dimension and multiplicities
         dim=prod(spin_system.comp.mults);
@@ -128,6 +134,11 @@ if (nargout>0)&&(~isempty(L))
             % Apply the projector from both sides
             L=fp_proj*L*fp_proj;
 
+        case 'zeeman-hilb'
+
+            % Stretch, project, and fold the Hamiltonian
+            L=reshape(P*L(:),size(L));
+
     end
 
     % Re-evaluate sparsity
@@ -168,6 +179,11 @@ if (nargout>1)&&(~isempty(rho))
             % Apply the projector
             rho=fp_proj*rho;
 
+        case 'zeeman-hilb'
+
+            % Stretch, project, and fold the state stack
+            rho=reshape(P*reshape(rho,spn_dim^2,[]),size(rho));
+
     end
 
 end
@@ -176,8 +192,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,L,rho,spins)
-if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
-    error('analytical decoupling is only available for sphten-liouv and zeeman-liouv formalisms.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv','zeeman-hilb'})
+    error('analytical decoupling is only available for sphten-liouv, zeeman-liouv, and zeeman-hilb formalisms.');
 end
 if (~isempty(rho))&&(~isempty(L))&&(size(L,2)~=size(rho,1))
     error('matrix dimensions of L and rho must agree.');

--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -86,12 +86,15 @@
 %
 %       destination - this argument is ignored.
 %
-%  For wavefunction calculations the Liouville space call signature and
-%  options apply with L the Hamiltonian matrix, rho a wavefunction or a
+%  For wavefunction calculations the Liouville space call signature
+%  applies with L the Hamiltonian matrix, rho a wavefunction or a
 %  horizontal stack thereof, and coil a reference wavefunction: the
 %  'observable' and 'multichannel' outputs return overlap trajectories
 %  of the coil with the evolving wavefunction; expectation values of
-%  operators require a density matrix formalism.
+%  operators require a density matrix formalism. Stacks are supported
+%  by 'final', 'refocus', 'observable', and 'multichannel'; the
+%  'trajectory' output takes a single column, and 'total' is not
+%  defined for unitary wavefunction evolution.
 %
 % Outputs:
 %
@@ -273,9 +276,14 @@ switch spin_system.bas.formalism
                 report(spin_system,'data retrieval finished.');
                 
             case 'total'
-                
+
+                % Refuse integrals of unitary dynamics
+                if strcmp(spin_system.bas.formalism,'zeeman-wavef')
+                    error('total observable integral is not defined for unitary wavefunction evolution.');
+                end
+
                 % Create arrays of projections
-                L_sub=cell(nsubs,1); 
+                L_sub=cell(nsubs,1);
                 rho_sub=cell(nsubs,1); coil_sub=cell(nsubs,1);
                 report(spin_system,'splitting the space...');
                 for sub=1:nsubs
@@ -315,7 +323,12 @@ switch spin_system.bas.formalism
                 answer=full(answer);
                 
             case 'trajectory'
-                
+
+                % Refuse state vector stacks
+                if size(rho,2)>1
+                    error('trajectory output is not available for state vector stacks.');
+                end
+
                 % Create arrays of projections
                 L_sub=cell(nsubs,1); rho_sub=cell(nsubs,1);
                 rows=cell(nsubs,1); cols=cell(nsubs,1); vals=cell(nsubs,1);

--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -86,8 +86,15 @@
 %
 %       destination - this argument is ignored.
 %
+%  For wavefunction calculations the Liouville space call signature and
+%  options apply with L the Hamiltonian matrix, rho a wavefunction or a
+%  horizontal stack thereof, and coil a reference wavefunction: the
+%  'observable' and 'multichannel' outputs return overlap trajectories
+%  of the coil with the evolving wavefunction; expectation values of
+%  operators require a density matrix formalism.
+%
 % Outputs:
-% 
+%
 %       answer - a vector, a matrix, or a cell array or matrices,
 %                depending on the options set during the call
 %
@@ -119,9 +126,9 @@ if isa(rho,'gpuArray'), rho=gather(rho); end
 
 % Decide how to proceed
 switch spin_system.bas.formalism
-    
-    case {'sphten-liouv','zeeman-liouv'}
-        
+
+    case {'sphten-liouv','zeeman-liouv','zeeman-wavef'}
+
         % Apply trajectory-level reduction algorithms
         report(spin_system,'trying to reduce the problem dimension...');
         

--- a/kernel/krylov.m
+++ b/kernel/krylov.m
@@ -199,8 +199,9 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,L,coil,rho,timestep,nsteps,output)
-if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
-    error('this function only works in Lioville space.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv',...
+                                        'zeeman-wavef'})
+    error('this function requires a state vector based formalism.');
 end
 if ~isnumeric(L)
     error('Liouvillian must be numeric.');

--- a/kernel/krylov.m
+++ b/kernel/krylov.m
@@ -51,7 +51,10 @@
 %      answer - a vector or a matrix, depending on the options set during
 %               the call.
 %
-% Note: this function does not support Hilbert space formalisms.
+% Note: this function does not support the zeeman-hilb formalism; in
+%       zeeman-wavef, L is the Hamiltonian matrix, rho is a wavefunc-
+%       tion or a horizontal stack thereof, coil is a reference wave-
+%       function, and observables are overlap trajectories.
 %
 % Note: we initially had a faithful implementation of the Krylov process
 %       here - subspace, orthogonalisation, projection, etc., but in all

--- a/kernel/operators/unit_oper.m
+++ b/kernel/operators/unit_oper.m
@@ -40,13 +40,13 @@ switch spin_system.bas.formalism
         % Unit matrix
         A=speye(prod(spin_system.comp.mults.^2));
         
-    case 'zeeman-hilb'
-        
+    case {'zeeman-hilb','zeeman-wavef'}
+
         % Unit matrix
         A=speye(prod(spin_system.comp.mults));
-        
+
     otherwise
-        
+
         % Complain and bomb out
         error('unknown formalism specification.');
         

--- a/kernel/operators/unit_oper.m
+++ b/kernel/operators/unit_oper.m
@@ -1,9 +1,9 @@
 % Returns a unit operator in the current formalism and basis. The
 % operator has dimension equal to the basis size in sphten-liouv
 % formalism, the dimension equal to the product of all spin multi-
-% plicities in zeeman-hilb formalism, and the dimension of square
-% of the product of all spin multiplicities in zeeman-liouv forma-
-% lism. Syntax:
+% plicities in zeeman-hilb and zeeman-wavef formalisms, and the
+% dimension of square of the product of all spin multiplicities in
+% zeeman-liouv formalism. Syntax:
 %
 %                      A=unit_oper(spin_system)
 %

--- a/kernel/reduce.m
+++ b/kernel/reduce.m
@@ -124,6 +124,69 @@ switch spin_system.bas.formalism
         
         end
         
+    case 'zeeman-wavef'
+
+        % If a stack is supplied, choose a representative wavefunction
+        if size(rho,2)>1, rho=mean(abs(rho),2); end
+
+        % Run symmetry factorization
+        if ismember('symmetry',spin_system.sys.disable)
+
+            % Issue a reminder to the user
+            report(spin_system,'WARNING - permutation symmetry treatment disabled by user.');
+
+            % Return unit matrix
+            projectors{1}=1;
+
+        elseif ~isfield(spin_system.bas,'irrep')
+
+            % Inform the user
+            report(spin_system,'no permutation symmetry information has been supplied.');
+
+            % Return unit matrix
+            projectors{1}=1;
+
+        else
+
+            % Decide which irreps to keep
+            n_irreps=numel(spin_system.bas.irrep);
+            irrep_keep_index=true(n_irreps,1);
+            for n=1:n_irreps
+
+                % Check the irrep contribution to the total norm
+                if spin_system.bas.irrep(n).dimension==0
+
+                    % Update the user
+                    report(spin_system,['irrep #' num2str(n) ' has dimension zero - dropped.']);
+
+                    % Flag the irrep for dropping
+                    irrep_keep_index(n)=0;
+
+                elseif norm(spin_system.bas.irrep(n).projector'*rho,1)<spin_system.tols.irrep_drop
+
+                    % Update the user
+                    report(spin_system,['irrep #' num2str(n) ', dimension '...
+                                        num2str(spin_system.bas.irrep(n).dimension) ' has less than '...
+                                        num2str(spin_system.tols.irrep_drop) ' of the state norm - dropped.']);
+
+                    % Flag the irrep for dropping
+                    irrep_keep_index(n)=0;
+
+                else
+
+                    % Update the user
+                    report(spin_system,['irrep #' num2str(n) ', dimension '...
+                                        num2str(spin_system.bas.irrep(n).dimension) ' is active - kept.']);
+
+                end
+
+            end
+
+            % Compile the projector array
+            projectors={spin_system.bas.irrep(irrep_keep_index).projector};
+
+        end
+
     case {'zeeman-liouv','sphten-liouv'}
 
         % If a stack is supplied, choose a representative state vector

--- a/kernel/rotframe.m
+++ b/kernel/rotframe.m
@@ -43,11 +43,16 @@ switch spin_system.bas.formalism
         % Liouville space period for H0
         T=-2*pi/(spin(isotope)*spin_system.inter.magnet);
         
-    case {'zeeman-hilb'}
-        
+    case {'zeeman-hilb','zeeman-wavef'}
+
         % Hilbert space period for H0
         T=-4*pi/(spin(isotope)*spin_system.inter.magnet);
-        
+
+    otherwise
+
+        % Complain and bomb out
+        error('unknown formalism specification.');
+
 end
 
 % Run the interaction representation transformation

--- a/kernel/steady.m
+++ b/kernel/steady.m
@@ -13,9 +13,9 @@
 %
 %    rho - optional initial guess for the steady state,
 %          a good one can significantly accelerate this
-%          function (leave empty otherwise); the first
-%          element (it corresponds to the density mat-
-%          rix trace in sphten-liouv) must always be 1
+%          function (leave empty otherwise); the state
+%          must have unit trace, which in sphten-liouv
+%          means a first element equal to 1
 %
 %    method - 'newton' (default) for the Newton-Raphson
 %             steady state solver, 'squaring' for propa-
@@ -27,7 +27,9 @@
 %    rho - steady state under the repeated applicati-
 %          on of the propagator P
 %
-% Note: only implemented for sphten-liouv formalism so far.
+% Note: available for sphten-liouv and zeeman-liouv formalisms; the
+%       Newton-Raphson solver pins the first state vector element in
+%       sphten-liouv and the density matrix trace in zeeman-liouv.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -37,7 +39,13 @@ function rho=steady(spin_system,P,rho,method)
 
 % Default initial guess
 if (~exist('rho','var'))||isempty(rho)
-    rho=zeros([size(P,2) 1],'like',1i); rho(1)=1;
+    switch spin_system.bas.formalism
+        case 'sphten-liouv'
+            rho=zeros([size(P,2) 1],'like',1i); rho(1)=1;
+        case 'zeeman-liouv'
+            dim=sqrt(size(P,2));
+            rho=speye(dim); rho=complex(full(rho(:))/dim);
+    end
 end
 
 % Default method
@@ -56,14 +64,24 @@ switch method
         % Iteration stats
         cheap_diff=1; n_iter=1;
 
+        % Trace functional of the stretched density matrix
+        if strcmp(spin_system.bas.formalism,'zeeman-liouv')
+            dim=sqrt(size(P,2)); u0=speye(dim); u0=u0(:);
+        end
+
         % Keep going
         while cheap_diff>spin_system.tols.stst_tol
 
             % Compute the square
             Psq=clean_up(spin_system,P*P,spin_system.tols.prop_chop);
 
+            % Pin the trace conservation row exactly
+            if strcmp(spin_system.bas.formalism,'zeeman-liouv')
+                Psq=Psq-(u0/dim)*(u0'*Psq-u0');
+            end
+
             % Compute the difference and close the loop
-            cheap_diff=max(abs(Psq-P),[],'all'); 
+            cheap_diff=max(abs(Psq-P),[],'all');
             P=Psq; n_iter=n_iter+1;
 
             % Detect algorithm stagnation
@@ -79,26 +97,64 @@ switch method
         % Get the Jacobian
         J=P-speye(size(P)); du=1;
 
-        % Pre-factor the Jacobian
-        [LF,UF,RP]=lu(J(2:end,2:end));
+        % Pick the normalisation pinning strategy
+        switch spin_system.bas.formalism
 
-        % Iteration counter
-        n_iter=0;
+            case 'sphten-liouv'
 
-        % Newton iteration
-        while norm(du,2)>spin_system.tols.stst_tol
+                % Pre-factor the Jacobian
+                [LF,UF,RP]=lu(J(2:end,2:end));
 
-            % Compute the residual
-            r=P*rho-rho; r=r(2:end);
+                % Iteration counter
+                n_iter=0;
 
-            % Re-use LU factors
-            du=-UF\(LF\(RP*r));
+                % Newton iteration with unit state pinning
+                while norm(du,2)>spin_system.tols.stst_tol
 
-            % Update the steady state
-            rho(2:end)=rho(2:end)+du; n_iter=n_iter+1;
+                    % Compute the residual
+                    r=P*rho-rho; r=r(2:end);
 
-            % Detect algorithm stagnation
-            if n_iter>10, error('steady state convergence failure.'); end
+                    % Re-use LU factors
+                    du=-UF\(LF\(RP*r));
+
+                    % Update the steady state
+                    rho(2:end)=rho(2:end)+du; n_iter=n_iter+1;
+
+                    % Detect algorithm stagnation
+                    if n_iter>10, error('steady state convergence failure.'); end
+
+                end
+
+            case 'zeeman-liouv'
+
+                % Trace functional of the stretched density matrix
+                dim=sqrt(size(P,2)); u0=speye(dim); u0=u0(:);
+
+                % Border the Jacobian with the trace pinning
+                B=[J u0; u0' 0];
+
+                % Pre-factor the bordered Jacobian
+                [LF,UF,RP]=lu(B);
+
+                % Iteration counter
+                n_iter=0;
+
+                % Newton iteration with trace pinning
+                while norm(du,2)>spin_system.tols.stst_tol
+
+                    % Compute the bordered residual
+                    r=[P*rho-rho; u0'*rho-1];
+
+                    % Re-use LU factors
+                    du=-UF\(LF\(RP*r)); du=du(1:(end-1));
+
+                    % Update the steady state
+                    rho=rho+du; n_iter=n_iter+1;
+
+                    % Detect algorithm stagnation
+                    if n_iter>10, error('steady state convergence failure.'); end
+
+                end
 
         end
 
@@ -113,8 +169,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,P,rho,method)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('steady state is only available for sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('steady state is only available for sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(rho))||(~isnumeric(P))
     error('P and rho must be numeric.');
@@ -125,17 +181,34 @@ end
 if (~ischar(method))||(~ismember(method,{'newton','squaring'}))
     error('method must be ''newton'' or ''squaring''.');
 end
-if (P(1,1)~=1)||(norm(P(1,2:end),2)~=0)
-    error('P(1,:) must be [1 0 0 0 ...]');
-end
-if norm(P(2:end,1),2)==0
-    error('the relaxation superoperator must be thermalised.');
+if strcmp(spin_system.bas.formalism,'sphten-liouv')
+    if (P(1,1)~=1)||(norm(P(1,2:end),2)~=0)
+        error('P(1,:) must be [1 0 0 0 ...]');
+    end
+    if norm(P(2:end,1),2)==0
+        error('the relaxation superoperator must be thermalised.');
+    end
+else
+    dim=sqrt(size(P,2)); u0=speye(dim); u0=u0(:);
+    if norm(u0'*P-u0',2)>1e-10*norm(u0,2)
+        error('P must conserve the density matrix trace.');
+    end
+    if norm(P*u0-u0,2)==0
+        error('the relaxation superoperator must be thermalised.');
+    end
 end
 if ~iscolumn(rho)
     error('rho must be a column vector.');
 end
-if rho(1)~=1
-    error('rho(1) must be equal to 1.');
+if strcmp(spin_system.bas.formalism,'sphten-liouv')
+    if rho(1)~=1
+        error('rho(1) must be equal to 1.');
+    end
+else
+    dim=sqrt(size(P,2)); u0=speye(dim); u0=u0(:);
+    if abs(u0'*rho-1)>1e-10
+        error('rho must have unit trace.');
+    end
 end
 end
 

--- a/kernel/utilities/adelim.m
+++ b/kernel/utilities/adelim.m
@@ -5,7 +5,7 @@
 %
 % Parameters:
 %
-%   L        - Liouvillian in sphten-liouv formalism,
+%   L        - Liouvillian in a Liouville space formalism,
 %              fast subbsystem must be dissipative
 %
 %   fast_idx - a vector of integers specifying which
@@ -27,9 +27,10 @@
 %              ce the fast subspace is adiabatically
 %              eliminated
 %
-% Note: the function needs sphten-liouv formalism because
-%       there the basis states are attributable to indivi-
-%       dual spins.
+% Note: in sphten-liouv the basis states are attributable to
+%       individual spins; in zeeman-liouv the caller must
+%       supply index sets that are meaningful in the Zeeman
+%       basis of Liouville space.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -57,8 +58,8 @@ end
 
 % Consistency enforcement
 function grumble(spin_system,L,fast_idx,slow_idx)
-if ~strcmp(spin_system.bas.formalism,'sphten-liouv')
-    error('adiabatic elimination is only available for sphten-liouv formalism.');
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv'})
+    error('adiabatic elimination is only available for sphten-liouv and zeeman-liouv formalisms.');
 end
 if (~isnumeric(L))||(size(L,1)~=size(L,2))
     error('L must be a square matrix.');

--- a/kernel/utilities/sim2liouv.m
+++ b/kernel/utilities/sim2liouv.m
@@ -2,11 +2,12 @@
 % the formalism specified in the spin system object is 'zeeman-hilb',
 % this function projects the evolution generators into Liouville
 % space, converts the standard state-like and operator-like fields
-% of the parameters structure, rebuilds the basis index table, dis-
-% cards Hilbert space symmetry information, and sets the formalism
-% to 'zeeman-liouv'; for all other formalisms, every argument is
-% returned unchanged. This makes Liouville-space pulse sequences
-% callable with zeeman-hilb inputs. Syntax:
+% of the parameters structure, rebuilds the basis index table, mig-
+% rates the symmetry irrep projectors into the adjoint representa-
+% tion, and sets the formalism to 'zeeman-liouv'; for all other
+% formalisms, every argument is returned unchanged. This makes
+% Liouville-space pulse sequences callable with zeeman-hilb
+% inputs. Syntax:
 %
 %          [spin_system,parameters,H,R,K]=...
 %          sim2liouv(spin_system,parameters,H,R,K)
@@ -44,6 +45,15 @@
 %                   fields converted into Liouville space
 %
 %    H,R,K        - Liouville space evolution generators
+%
+% Note: a Hilbert space density matrix block S(n)*Y*S(k)' maps to
+%       the state vector kron(conj(S(k)),S(n))*Y(:), and so each
+%       ordered pair of Hilbert space irrep projectors yields the
+%       Liouville space irrep projector kron(conj(S(k)),S(n)).
+%       Every such subspace is invariant under superoperators
+%       built from symmetry-respecting Hilbert space generators;
+%       unpopulated subspaces are dropped by reduce.m at run time
+%       in the usual way.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -91,10 +101,34 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     % Rebuild the basis index table for the Liouville space
     spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
 
-    % Discard Hilbert space symmetry data
+    % Migrate the irreps into the adjoint representation
     if isfield(spin_system.bas,'irrep')
-        spin_system.bas=rmfield(spin_system.bas,'irrep');
-        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+
+        % Grab the Hilbert space irreps
+        hs_irreps=spin_system.bas.irrep; n_irreps=numel(hs_irreps);
+
+        % Preallocate the Liouville space irrep array
+        ls_irreps(n_irreps^2)=struct('projector',[],'dimension',[]);
+
+        % Loop over ordered pairs of Hilbert space irreps
+        for n=1:n_irreps
+            for k=1:n_irreps
+
+                % Build the irrep pair projector and dimension
+                pair_idx=n_irreps*(n-1)+k;
+                ls_irreps(pair_idx).projector=kron(conj(hs_irreps(n).projector),...
+                                                        hs_irreps(k).projector);
+                ls_irreps(pair_idx).dimension=hs_irreps(n).dimension*...
+                                              hs_irreps(k).dimension;
+
+            end
+        end
+
+        % Write the Liouville space irreps
+        spin_system.bas.irrep=ls_irreps;
+        report(spin_system,['Hilbert space irreps migrated into Liouville space, '...
+                            num2str(n_irreps^2) ' irrep pair subspaces.']);
+
     end
 
     % Update the formalism setting

--- a/kernel/utilities/sim2liouv.m
+++ b/kernel/utilities/sim2liouv.m
@@ -1,0 +1,125 @@
+% Moves a zeeman-hilb simulation context into Liouville space. When
+% the formalism specified in the spin system object is 'zeeman-hilb',
+% this function projects the evolution generators into Liouville
+% space, converts the standard state-like and operator-like fields
+% of the parameters structure, rebuilds the basis index table, dis-
+% cards Hilbert space symmetry information, and sets the formalism
+% to 'zeeman-liouv'; for all other formalisms, every argument is
+% returned unchanged. This makes Liouville-space pulse sequences
+% callable with zeeman-hilb inputs. Syntax:
+%
+%          [spin_system,parameters,H,R,K]=...
+%          sim2liouv(spin_system,parameters,H,R,K)
+%
+% Parameters:
+%
+%    spin_system  - Spinach spin system object
+%
+%    parameters   - pulse sequence parameters structure; the
+%                   state-like fields rho0, coil, and screen
+%                   (matrices or their horizontal concatena-
+%                   tions) are stretched into state vectors,
+%                   and the operator-like fields pulse_op,
+%                   mw_oper, and ez_oper are converted into
+%                   commutation superoperators, when present
+%
+%    H            - Hamiltonian operator, converted into a
+%                   commutation superoperator; an empty
+%                   matrix is passed through
+%
+%    R            - relaxation matrix, converted into an
+%                   anticommutation superoperator; an empty
+%                   matrix is passed through
+%
+%    K            - kinetics matrix, converted into an
+%                   anticommutation superoperator; an empty
+%                   matrix is passed through
+%
+% Outputs:
+%
+%    spin_system  - spin system object with zeeman-liouv
+%                   formalism and basis information
+%
+%    parameters   - parameters structure with the standard
+%                   fields converted into Liouville space
+%
+%    H,R,K        - Liouville space evolution generators
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=sim2liouv.m>
+
+function [spin_system,parameters,H,R,K]=sim2liouv(spin_system,parameters,H,R,K)
+
+% Check consistency
+grumble(spin_system,parameters,H,R,K);
+
+% Only the zeeman-hilb formalism needs the move
+if strcmp(spin_system.bas.formalism,'zeeman-hilb')
+
+    % Inform the user
+    report(spin_system,'projecting zeeman-hilb simulation into Liouville space...');
+
+    % Project the evolution generators into Liouville space
+    H=hilb2liouv(H,'comm'); R=hilb2liouv(R,'acomm'); K=hilb2liouv(K,'acomm');
+
+    % Get the Hilbert space basis table and dimension
+    zbas=spin_system.bas.basis; hdim=size(zbas,1);
+
+    % Stretch the state-like parameters
+    if isfield(parameters,'rho0')
+        parameters.rho0=reshape(parameters.rho0,hdim^2,[]);
+    end
+    if isfield(parameters,'coil')
+        parameters.coil=reshape(parameters.coil,hdim^2,[]);
+    end
+    if isfield(parameters,'screen')
+        parameters.screen=reshape(parameters.screen,hdim^2,[]);
+    end
+
+    % Project the operator-like parameters
+    if isfield(parameters,'pulse_op')
+        parameters.pulse_op=hilb2liouv(parameters.pulse_op,'comm');
+    end
+    if isfield(parameters,'mw_oper')
+        parameters.mw_oper=hilb2liouv(parameters.mw_oper,'comm');
+    end
+    if isfield(parameters,'ez_oper')
+        parameters.ez_oper=hilb2liouv(parameters.ez_oper,'comm');
+    end
+
+    % Rebuild the basis index table for the Liouville space
+    spin_system.bas.basis=[repmat(zbas,[hdim 1]) kron(zbas,ones(hdim,1))];
+
+    % Discard Hilbert space symmetry data
+    if isfield(spin_system.bas,'irrep')
+        spin_system.bas=rmfield(spin_system.bas,'irrep');
+        report(spin_system,'Hilbert space irreps discarded, proceeding without symmetry.');
+    end
+
+    % Update the formalism setting
+    spin_system.bas.formalism='zeeman-liouv';
+
+end
+
+end
+
+% Consistency enforcement
+function grumble(spin_system,parameters,H,R,K)
+if ~ismember(spin_system.bas.formalism,{'sphten-liouv','zeeman-liouv',...
+                                        'zeeman-hilb','zeeman-wavef'})
+    error('unrecognised formalism in spin_system.bas.formalism.');
+end
+if ~isstruct(parameters)
+    error('parameters must be a structure.');
+end
+if (~isnumeric(H))||(~isnumeric(R))||(~isnumeric(K))
+    error('H, R, and K must be numeric arrays.');
+end
+end
+
+% To achieve great things, two things are needed: a plan,
+% and not quite enough time.
+%
+% Leonard Bernstein
+

--- a/kernel/utilities/symmetry.m
+++ b/kernel/utilities/symmetry.m
@@ -72,7 +72,7 @@ else
     % Irreducible representation composition
     if isfield(bas,'sym_a1g_only')
         spin_system.comp.sym_a1g_only=bas.sym_a1g_only;
-    elseif strcmp(spin_system.bas.formalism,'zeeman-hilb')
+    elseif ismember(spin_system.bas.formalism,{'zeeman-hilb','zeeman-wavef'})
         spin_system.comp.sym_a1g_only=false();
     else
         spin_system.comp.sym_a1g_only=true();
@@ -142,6 +142,9 @@ else
         parfor n=1:group.order %#ok<*PFBNS>
             group_element=1:spin_system.comp.nspins;
             group_element(spins)=group_element(spins(group.elements(n,:)));
+            if strcmp(spin_system.bas.formalism,'zeeman-liouv')
+                group_element=[group_element group_element+spin_system.comp.nspins];
+            end
             permuted_basis=spin_system.bas.basis(:,group_element);
             index=spsortrows(sparse(permuted_basis));
             permutation_table(:,n)=index;
@@ -204,7 +207,7 @@ else
                 hit_index=(sum(abs(coeff_matrix),1)==0); coeff_matrix(:,hit_index)=[];
                 
                 % Remove identical columns
-                coeff_matrix=spunicols(coeff_matrix);
+                coeff_matrix=spunicols(sparse(coeff_matrix));
                 
                 % Decide how to proceed
                 if size(coeff_matrix,2)==0


### PR DESCRIPTION
Implements the formalism-extension programme agreed in #talos-dev on 2026-08-21
(Ilya's edited survey): functionality previously locked to one formalism is
extended to others wherever that is exact and cheap, with every extension
validated to machine precision against the pre-existing formalism path.

## Item 1: coherence.m and correlation.m in zeeman-liouv

Coherence order is an exact per-element label in the Zeeman basis of Liouville
space (M_ket minus M_bra), so coherence() extends pointwise, reading the new
ket/bra index tables that basis.m now builds for zeeman-liouv. Correlation
order is NOT pointwise in the Zeeman basis (elements with equal bra and ket
projections mix identity and longitudinal content), so correlation() gets an
exact projector construction: per-spin identity channels assembled in the vec
convention, combined through a generating function over the selected spins,
with cardinal weights from a Vandermonde solve. Validation through the
sphten2zeeman similarity transform on a complete-basis mixed-multiplicity
system (1H, 2H, 13C): coherence filters agree EXACTLY (error 0.0 across six
specification variants including per-isotope, numeric-list, and symbolic
specs); correlation projectors at 4.5e-15 worst case over six order/subset
variants.

## Item 2: decouple.m in zeeman-liouv

The sphten version zeroes rows and columns of L and entries of rho for basis
states involving the decoupled spins. The zeeman-liouv analogue is an exact
orthogonal projection onto the subspace where decoupled spins carry only
their identity component, applied as a projector sandwich (per-spin identity
channels, Fokker-Planck aware). Validation: states at 1.0e-16, Liouvillians
at 4.7e-15, decoupling by spin number at 1.4e-16.

## Item 4: zeeman-wavef in the propagation core

evolution.m had no zeeman-wavef case although step, multiprop, propagator,
shaped_pulse_xy, singlerot, and the GRAPE module all propagate wavefunctions;
the Liouville vector branch is the same expm-times-vector mathematics, so
zeeman-wavef joins that case list, with reduce() returning symmetry-aware
trivial projectors for wavefunctions and krylov() admitting them. For
observables, coil is a reference wavefunction and the outputs are overlap
trajectories (documented in the header; expectation values need a density
matrix formalism). unit_oper() and rotframe() gain their missing wavef cases
(rotframe previously died with an undefined variable). Validation against
zeeman-hilb sandwich propagation of the pure state: final state 4.1e-13 over
200 steps, forced krylov path 3.7e-14, observable trajectories 4.8e-13,
refocus 1.7e-16, rotframe 3.8e-16, unit_oper exact.

## Item 5: conservative gates opened to zeeman-liouv

steady.m, adelim.m, dnp_field_scan.m, dnp_freq_scan.m, and sixteen imaging
sequences (basic_1d_hard, grad_echo, spin_echo, fse, epi_2d, epi_3d,
press_1d, press_2d, press_voxel_1d/2d/3d, phase_enc_2d/3d, spiral, cpmg_dec,
udd_dec) had sphten-only grumbles with no sphten-specific machinery behind
them — with two exceptions that the probes caught and this PR fixes properly:
steady.m's Newton solver pinned state vector element 1, which is the trace
only in sphten-liouv, and now uses a trace-pinned bordered solve in
zeeman-liouv; and its grumble's propagator invariant checks were also written
in sphten coordinates and are now formalism-aware. Validation: steady at
2.5e-12 (both methods, cross-formalism); adelim same-input identity is exact;
DNP scans agree at the pre-existing solver's conditioning floor — measured by
compressing the rate spread three orders, which drops the residual from
1.1e-7 to 1.6e-10, while the Hamiltonian, untruncated Lindblad superoperator,
and anisotropic equilibrium all map at 2e-14 or better. All sixteen imaging
sequences are validated through their shipped examples (reduced grids,
identical on both sides of every pair) after fitting the exact
cross-formalism observable scale — 2 per spin, measured on stock acquire:
ratio 2.000000000, overlap 1.000000000; IST states are not unit-normalised
in the Zeeman metric — and every fitted scale came out at exactly 2^nspins.
Residuals: basic_1d_hard 8.3e-16, grad_echo 1.5e-15, spin_echo 1.3e-15,
fse 1.8e-14, epi_3d 6.6e-14, press_voxel_3d 2.9e-15, phase_enc_2d 2.5e-16,
phase_enc_3d 1.7e-15, spiral 1.4e-14, cpmg_dec 1.4e-12, udd_dec 4.8e-13;
epi_2d, press_1d/press_voxel_1d, and press_2d/press_voxel_2d sit at a
1.5e-8 to 2.9e-8 floor at stock tolerances that is the propagator chop
truncation, not the formalism — with all cleanup tolerances at eps the same
pairs collapse to 1.2e-12, 3.3e-15, and 2.5e-14 respectively, and the
same sequences below the krylov switchover (epi_3d, press_voxel_3d) are at
machine precision with stock tolerances.

## Item 6: zeeman-hilb admission into Liouville-only experiments

The slowpass.m idiom (project H, R, K with hilb2liouv, stretch the state
parameters, rebuild the basis index table, and proceed as zeeman-liouv) is
applied to fifteen experiments: relaxan (formalism flip only — it builds its
generators internally), sp_acquire, endor_cw, endor_mims, endor_mims_echo,
endor_mims_ideal, endor_davies, deer_3p_soft_deer/hole, deer_4p_soft_deer/
hole, eseem, oopeseem, holeburn, dnp_time_dep. Experiments with additional
state- or operator-valued parameters convert those too (eseem/oopeseem:
screen and pulse_op; dnp_time_dep: mw_oper and ez_oper). Validation: each
experiment run with zeeman-hilb input against the direct zeeman-liouv path
on the same reduced example system. relaxan and the benzoquinone ENDOR agree
exactly (0); oop_eseem 3.2e-15, mims_nox 5.7e-14, eseem 8.7e-14, holeburn
8.3e-13, deer3p 5.1e-13, deer4p 1.1e-12, mims_echo 1.4e-12, odnp 2.8e-11;
the projection identity itself is exact at 2.3e-16. Three residuals above
that level were chased to measured causes: davies ENDOR (1.6e-8 at stock
tolerances) collapses to 5.7e-14 with all cleanup tolerances at eps; the
Gd-DOTA sp_acquire residual (1.4e-5, tolerance-independent and
bit-reproducible) is a rotating-frame representation dependence, not the
admission preamble — rotframe() averages over the spinor period (-4*pi/w) in
Hilbert space and the coherence period (-2*pi/w) in Liouville space, and the
projected results first differ at averaging order 3 (measured: orders 1-2
agree at 4.8e-13, order 3 differs by 7.8e-6; the same pair with rframes
removed agrees at 2.3e-11) — reported as an observation, with neither period
claimed wrong in its own space; and mims ENDOR retains a deterministic
1.2e-9 in the shaped-pulse path, five orders below physical use.

## Item 9: doublerot in zeeman-hilb and zeeman-wavef; floquet stays Liouville by measurement

doublerot.m gains the singlerot dual-dispatch mirror: in Hilbert formalisms
it hands the pulse sequence the stack of spin Hamiltonians over the two-rotor
phase grid instead of the Fokker-Planck generator, with the Liouville path
byte-identical in behaviour. Validation: the Fokker-Planck diagonal blocks
equal hilb2liouv(stack,'comm') of the ported stack at 5.9e-14 — an exact
cross-formalism content identity — the stack is exactly band-limited on the
phase torus (trigonometric reconstruction at 2.4e-14), wavefunction and
density-matrix propagation on the same stack agree at 7.2e-15, and the
cross-route FID gap decomposes entirely into the Fokker-Planck reference's
own rank tail (rank-12-vs-16 self-shift 7.4e-3 equals the observed gap; the
stack route self-converges quadratically in substeps, 2.5e-7 to 1.6e-8;
best-vs-best 1.4e-4, matching the tail's geometric decay).

floquet.m is NOT ported, on measurement rather than judgement: building the
extended Floquet Hamiltonian and testing candidate detection conventions
against brute-force time-ordered propagation of the exact time-dependent
Hamiltonian shows the naive Hilbert mirror of the (correct, shipped)
Liouville delta/delta convention to be 13-17% wrong, while the correct
Shirley phase-reassembled detection (7.0e-8, at the ground truth's own
discretisation floor) requires a Floquet-aware sequence contract that no
shipped sequence consumes. Hilbert-space MAS is already served natively by
singlerot's stack branch, so the Liouville-only gate in floquet.m is by
design; the measurement is in the job records.

## Stock issues found en route (not fixed here)

- create.m:2761 conservation-of-matter check uses a strict inequality against
  10*eps*norm(rates), so an all-zero exchange rate matrix is refused; the
  shipped bright_fat_effect_cpmg/udd examples currently cannot pass create.
- zeeman-hilb symmetry treatment used to die with "A must be sparse" inside
  basis() when bas.sym_group was declared (hit via the benzoquinone ENDOR
  example) — fixed in review round one below.
- rlx_keep='diagonal' is representation-dependent by construction (truncation
  in each formalism's own basis; 5e-4 on the relaxation superoperator for a
  spin-7/2 test system) — expected behaviour, but worth knowing when
  comparing formalisms with truncated relaxation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round one (commit 0828699)

Ten Codex comments: nine accepted and fixed, one declined with evidence.
Symmetry: the zeeman-liouv permutation table now covers both ket and bra
index halves (sym-on vs sym-off at 1.0e-13; experiment level 4.6e-10 at
stock tolerances, 4e-14 class under eps tolerances); zeeman-wavef defaults
to all-irrep treatment like zeeman-hilb, and the spunicols/clean_up sparse
mismatch that had always broken declared symmetry in zeeman-hilb is fixed
(a non-A1g wavefunction now survives, sym-on equal to sym-off); the fifteen
admission preambles discard stale Hilbert irreps on conversion (S2 DNP
system through the preamble matches direct zeeman-liouv at 4.9e-10).
Evolution: 'trajectory' refuses state-vector stacks with a clear error and
'total' refuses wavefunctions; the header documents stack support per
output. Correlation: cardinal weights now come from roots-of-unity
sampling with exact discrete Fourier sums (monomial Vandermonde at
seventeen nodes loses the answer entirely, error 1.3e2 vs 3.7e-15; the
small-system sphten-transform validation is unchanged). doublerot: the
Hilbert route refuses multi-point two-angle grids, keyed on the measured
convention that the redundant angle lives in alphas. Declined: the steady()
initial-guess default is the shipped stock contract (rho(1)=1, the
maximally mixed state in sphten convention); the zeeman-liouv branch
supplies the same physical default for parity.

