### PR TITLE
lorentz.m: use the full representation dimension in the adjoint

### DIFF
--- a/etc/textbook/lorentz.m
+++ b/etc/textbook/lorentz.m
@@ -49,13 +49,13 @@ if nargout>2
     for n=1:numel(gens)
         
         % Get the first operator adjoint
-        AdA=kron(eye(D,D),gens{n})-kron(transpose(gens{n}),eye(D,D));
+        AdA=kron(eye(2*D,2*D),gens{n})-kron(transpose(gens{n}),eye(2*D,2*D));
         
         % Loop over generators
         for k=1:numel(gens)
             
             % Get the second operator adjoint
-            AdB=kron(eye(D,D),gens{k})-kron(transpose(gens{k}),eye(D,D));
+            AdB=kron(eye(2*D,2*D),gens{k})-kron(transpose(gens{k}),eye(2*D,2*D));
             
             % Get the Killing form element
             Kil(n,k)=trace(AdA*AdB);


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the generators of the (L,0)+(0,L) representation are 2D x 2D block matrices (D=2L+1), but the adjoint construction used `eye(D,D)`, producing an operator of dimension 2D^2 instead of (2D)^2. The subtraction still conforms, so nothing errors - but the operator is not the adjoint of anything, and the third output (Killing form) is wrong. Measured on stock: for L=1/2 the shipped Killing diagonal is [4 4 4 -4 -4 -4] where the true tr(ad ad) gives [8 8 8 -8 -8 -8].

**Fix:** `eye(2*D,2*D)` in both adjoint constructions.

**Validation (measured, R2026a):** the adjoint identity `Ad*vec(X) = vec(A*X - X*A)` now holds to 0 (L=1/2) and 8e-16 (L=1) for all six generators; the Killing form comes out diagonal to machine precision with diag [8 8 8 -8 -8 -8] (L=1/2) and [48 48 48 -48 -48 -48] (L=1), with the correct so(3,1) signature split between rotation and boost blocks. checkcode and house style clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)