### PR TITLE
equilibrate.m: group one-way reactions by weak connectivity

### DIFF
--- a/kernel/kinetics/equilibrate.m
+++ b/kernel/kinetics/equilibrate.m
@@ -28,7 +28,7 @@ grumble(K,c0);
 if norm(c0,2)==0, c=c0; return; end
 
 % Recursive calls for independent reactions
-indep_rxn_idx=scomponents(logical(K));
+indep_rxn_idx=scomponents(logical(K)|logical(K)');
 n_indep_rxns=numel(unique(indep_rxn_idx));
 if n_indep_rxns>1
     c=zeros(size(c0));


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** independent reaction networks were separated with strongly connected components of `logical(K)`. An irreversible reaction such as `K=[-k 0; k 0]` splits into two SCCs, and the recursive call then receives a submatrix whose column sums are no longer zero, so the conservation grumble kills a perfectly valid one-way network. Measured on stock: `equilibrate([-1 0; 1 0],[1;0])` dies with "K violates conservation of matter".

**Fix:** split on weak connectivity, `scomponents(logical(K)|logical(K)')` — mass flows along reactions regardless of direction, so weakly connected components are the correct independence classes.

**Validation (measured, R2026a):** one-way network now returns [0 1] with mass conserved (two initial conditions); reversible pair unchanged [1 1]; two disconnected reversible networks return [2/3 1/3 1/2 3/2] exactly as derived; one-way pair plus inert species gives [0 1 5]; shipped `test_kinetics_invariants_suite` (6 checks) and `test_kinetics_generator_suite` (7 checks) pass; house style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)