### PR TITLE
polyadic/simplify.m: clear affix slots before absorbing their coefficients

### DIFF
--- a/kernel/overloads/@polyadic/simplify.m
+++ b/kernel/overloads/@polyadic/simplify.m
@@ -53,16 +53,14 @@ while changes_made
         
         % Absorb opium prefixes
         if isa(p.prefix{n},'opium')
-            p=p.prefix{n}.coeff*p;
-            p.prefix{n}=[];
-            changes_made=true();
+            coeff=p.prefix{n}.coeff;
+            p.prefix(n)=[]; p=coeff*p; return;
         end
 
         % Absorb scalar prefixes
         if isnumeric(p.prefix{n})&&isscalar(p.prefix{n})
-            p=p.prefix{n}*p;
-            p.prefix{n}=[];
-            changes_made=true();
+            coeff=p.prefix{n};
+            p.prefix(n)=[]; p=coeff*p; return;
         end
 
     end
@@ -87,16 +85,14 @@ while changes_made
         
         % Absorb opium suffixes
         if isa(p.suffix{n},'opium')
-            p=p.suffix{n}.coeff*p;
-            p.suffix{n}=[];
-            changes_made=true();
+            coeff=p.suffix{n}.coeff;
+            p.suffix(n)=[]; p=coeff*p; return;
         end
 
         % Absorb scalar suffixes
         if isnumeric(p.suffix{n})&&isscalar(p.suffix{n})
-            p=p.suffix{n}*p;
-            p.suffix{n}=[];
-            changes_made=true();
+            coeff=p.suffix{n};
+            p.suffix(n)=[]; p=coeff*p; return;
         end
 
     end


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the opium- and scalar-affix absorption branches ran `p=p.prefix{n}.coeff*p` with the affix still attached. `mtimes(scalar,polyadic)` ends in `simplify`, which hits the same branch again - measured on stock: `simplify` on an opium-prefixed polyadic dies with "Out of memory... infinite recursion". All four branches (opium/scalar x prefix/suffix) share the defect.

**Fix:** extract the coefficient, delete the affix cell with paren indexing, then scale and return (the `mtimes` path re-simplifies the cleaned object, so the recursion terminates after one level per affix). Deleting the slot rather than emptying it matters: an emptied `{[]}` slot would satisfy the `nnz==0` zero-flush test on re-entry and silently annihilate the operator.

**Validation (measured, R2026a):** opium prefix, scalar prefix, opium suffix, scalar suffix, and a mixed prefix+suffix case all absorb with error exactly 0 against the dense reference; sparse-matrix prefixes stay attached; the zero-prefix flush and unit-prefix drop regressions are intact; shipped `test_overload_arithmetic_suite` (40 checks) and `test_dynamic_overload_sparse_polyadic_suite` (63 checks) pass; house style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)