### PR TITLE
homospoil.m: preserve stacked state vectors in the Zeeman basis

### DIFF
--- a/kernel/homospoil.m
+++ b/kernel/homospoil.m
@@ -49,13 +49,12 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     rho=spdiags(rhod,0,dim,dim); return;
 end
 
-% In Zeeman basis of Liouville space, fold back
-% into Hilbert space, keep diagonal, and unfold
+% In Zeeman basis of Liouville space, zero off-diagonals in every stacked column
 if strcmp(spin_system.bas.formalism,'zeeman-liouv')
     dim=sqrt(size(rho,1));
-    rho=reshape(rho,[dim dim]);
-    rho=spdiags(diag(rho),0,dim,dim);
-    rho=rho(:); return;
+    offdiag_mask=true(dim^2,1);
+    offdiag_mask(1:(dim+1):dim^2)=false;
+    rho(offdiag_mask,:)=0; return;
 end
 
 % Store dimension statistics


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the header admits "a state vector or a horizontal stack thereof", but the zeeman-liouv branch reshaped `rho` to a single [dim dim] matrix - any stack with more than one column dies with a reshape element-count error. This is a reachable production path: `noesy.m` (default non-oldschool route), `hoesy.m`, `noesyhsqc.m`, and `spinlock.m` all pass multi-column trajectory stacks through `homospoil`, and `noesy.m` explicitly admits the zeeman-liouv formalism. The sphten-liouv branch below already handles stacks.

**Fix:** zero the off-diagonal (in the folded Hilbert sense) rows in place across all columns - the diagonal of the folded matrix sits at linear indices `1:(dim+1):dim^2` of each column. This also matches the in-place semantics of the sphten-liouv branch.

**Validation (measured, R2026a):** single column agrees with the stock fold/spdiags/unfold reference to 0; the exact production pattern (a 16x6 `evolution` trajectory stack from a two-proton zeeman-liouv system) now processes with 0 error against the per-column reference, for both 'destroy' and 'keep'; the stock reshape failure is demonstrated inline in the probe log; house style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)