### PR TITLE
rlx_scalar.m: preserve H0 across correlation function components

### DIFF
--- a/kernel/utilities/rlx_scalar.m
+++ b/kernel/utilities/rlx_scalar.m
@@ -48,11 +48,11 @@ for n=1:numel(tau_c_array)
         % Set the upper integration limit according to the accuracy goal
         upper_limit=2*tau_c*log(1/spin_system.tols.rlx_integration);
 
-        % Remove inconsequential non-zeroes from H0
-        H0=clean_up(spin_system,H0,1e-2/upper_limit);
+        % Remove inconsequential non-zeroes from a copy of H0
+        H0c=clean_up(spin_system,H0,1e-2/upper_limit);
 
         % Take the integral using the auxiliary matrix exponential technique
-        R=R-weight*H1*expmint(spin_system,H0,H1',H0+(1i/tau_c)*speye(size(H0)),upper_limit);
+        R=R-weight*H1*expmint(spin_system,H0c,H1',H0c+(1i/tau_c)*speye(size(H0c)),upper_limit);
     
     end
     

--- a/kernel/utilities/rlx_scalar.m
+++ b/kernel/utilities/rlx_scalar.m
@@ -49,10 +49,10 @@ for n=1:numel(tau_c_array)
         upper_limit=2*tau_c*log(1/spin_system.tols.rlx_integration);
 
         % Remove inconsequential non-zeroes from a copy of H0
-        h0_clean=clean_up(spin_system,H0,1e-2/upper_limit);
+        H0c=clean_up(spin_system,H0,1e-2/upper_limit);
 
         % Take the integral using the auxiliary matrix exponential technique
-        R=R-weight*H1*expmint(spin_system,h0_clean,H1',h0_clean+(1i/tau_c)*speye(size(h0_clean)),upper_limit);
+        R=R-weight*H1*expmint(spin_system,H0c,H1',H0c+(1i/tau_c)*speye(size(H0c)),upper_limit);
     
     end
     

--- a/kernel/utilities/rlx_scalar.m
+++ b/kernel/utilities/rlx_scalar.m
@@ -49,10 +49,10 @@ for n=1:numel(tau_c_array)
         upper_limit=2*tau_c*log(1/spin_system.tols.rlx_integration);
 
         % Remove inconsequential non-zeroes from a copy of H0
-        H0c=clean_up(spin_system,H0,1e-2/upper_limit);
+        h0_clean=clean_up(spin_system,H0,1e-2/upper_limit);
 
         % Take the integral using the auxiliary matrix exponential technique
-        R=R-weight*H1*expmint(spin_system,H0c,H1',H0c+(1i/tau_c)*speye(size(H0c)),upper_limit);
+        R=R-weight*H1*expmint(spin_system,h0_clean,H1',h0_clean+(1i/tau_c)*speye(size(h0_clean)),upper_limit);
     
     end
     


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** inside the correlation-component loop, `H0=clean_up(spin_system,H0,1e-2/upper_limit)` overwrote the input Hamiltonian with a component-specific truncation. With multiple components, matrix elements discarded for a short-tau_c component (large threshold) could never be recovered for a subsequent longer-tau_c component, making the relaxation superoperator depend on the order of `tau_c_array`.

**Fix:** clean into a per-component copy `H0c`; the input `H0` is never modified.

**Validation (measured, R2026a):** on a 16-dimensional sparse Hermitian pair with element magnitudes spanning twelve decades, the two-component relaxation superoperator is now identical under component reordering (relative difference 0, previously order-dependent by construction), matches a manually assembled per-component reference exactly, and the single-component path is unchanged against the same formula. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)