### PR TITLE
fig_2_tau_and_field_traject.m: plot the time axis in milliseconds

### DIFF
--- a/examples/dnp_liq/jdnp/fig_2_tau_and_field_traject.m
+++ b/examples/dnp_liq/jdnp/fig_2_tau_and_field_traject.m
@@ -89,7 +89,7 @@ for n=1:numel(field_grid)
                         parameters.nsteps+1);  
         
         % Plotting
-        plot(t_axis,answer); drawnow;
+        plot(1e3*t_axis,answer); drawnow;
              
     end
     


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the time axis is built in seconds (t_step=1e-3, nsteps=200, span 0-0.2 s) but the axis label says 'time / ms', so the plotted trajectories read 200x too short.

**Fix:** plot `1e3*t_axis`; the label was correct for the intended units.

**Validation:** axis arithmetic verified from the parameter values; house style 0 violations; checkcode clean (stock and patched both 0). Plot-only change, no simulation content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)