### PR TITLE
tensors.m, rotations_2.m: raise errors on convention test failure

### DIFF
--- a/examples/fundamentals/convention_tests/rotations_2.m
+++ b/examples/fundamentals/convention_tests/rotations_2.m
@@ -71,7 +71,7 @@ resnorm=norm(H_A-H_B,1);
 
 % Display the diagnostics
 if resnorm>1e-3
-    report(spin_system,['rotation test failed, ' num2str(resnorm)]);
+    error(['rotation test failed, residual norm ' num2str(resnorm)]);
 else
     report(spin_system,['rotation test passed, ' num2str(resnorm)]);
 end

--- a/examples/fundamentals/convention_tests/tensors.m
+++ b/examples/fundamentals/convention_tests/tensors.m
@@ -38,6 +38,7 @@ else
     disp('Test FAILED.');
     disp(full(lin_comb_a));
     disp(full(lin_comb_b));
+    error('tensor conversion test FAILED.');
 end
 
 end


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the failure branches of these two convention tests only print diagnostics (disp/report) and return normally, so an automated run records a broken convention as a pass. Every sibling convention test in the directory throws on failure (rotations_1.m, stevens_test.m, blinv_test.m, nqi_test.m, invariants.m).

**Fix:** tensors.m raises error('tensor conversion test FAILED.') after its diagnostic dumps; the failing branch of rotations_2.m raises an error carrying the residual norm. Passing branches untouched.

**Validation:** mirrors the sibling error style; house style 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)