### PR TITLE
noe_strychnine.m: square the state norm in the inversion projector

### DIFF
--- a/examples/nmr_liquids/noe_strychnine.m
+++ b/examples/nmr_liquids/noe_strychnine.m
@@ -46,7 +46,7 @@ rho_eq=equilibrium(spin_system,hamiltonian(assume(spin_system,'labframe'),'left'
 
 % Start in a state with one spin inverted
 Lz9=state(spin_system,{'Lz'},{9});
-rho=rho_eq-2*Lz9*(Lz9'*rho_eq)/norm(Lz9);
+rho=rho_eq-2*Lz9*(Lz9'*rho_eq)/norm(Lz9)^2;
 
 % Evolve for 500 ms under the relaxation superoperator
 rho=evolution(spin_system,1i*R,[],rho,0.5,1,'final');


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the selective-inversion projector divided by norm(Lz9) where the projection formula needs norm(Lz9)^2. Spinach state vectors here have norm 0.5, so the stock expression subtracts exactly one Lz9 component - saturating spin 9 to zero instead of inverting it as the header documents. All four sibling NOE examples use /norm(Lz1)^2.

**Fix:** added the ^2, matching the siblings.

**Validation (measured, R2026a):** two-proton probe: norm(Lz)=0.500000 confirmed; the patched projector flips <Lz2> exactly (+0.25 -> -0.25) while the stock formula returns 0 (saturation); spectator spin expectation untouched. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)