### PR TITLE
cpmas valine examples: convert Euler angles with pi/180

### DIFF
--- a/examples/nmr_overtone/cpmas_valine_accum.m
+++ b/examples/nmr_overtone/cpmas_valine_accum.m
@@ -18,7 +18,7 @@ function cpmas_valine_accum()
 sys.magnet=14.10220742; sys.isotopes={'14N','1H'};
 inter.coupling.matrix{1,1}=eeqq2nqi(3.21e6,0.27,1,[0 0 0]);
 inter.zeeman.eigs={[57.5 81.0 227.0],[0 0 0]};
-inter.zeeman.euler={[-90 -90 -17]/(pi*180),[0 0 0]};
+inter.zeeman.euler={[-90 -90 -17]*(pi/180),[0 0 0]};
 inter.coupling.matrix{2,2}=[];
 inter.coordinates={[0.00 0.00 0.00]
                    [1.00 0.00 0.00]};

--- a/examples/nmr_overtone/cpmas_valine_match_1.m
+++ b/examples/nmr_overtone/cpmas_valine_match_1.m
@@ -19,7 +19,7 @@ function cpmas_valine_match_1()
 sys.magnet=14.10220742; sys.isotopes={'14N','1H'};
 inter.coupling.matrix{1,1}=eeqq2nqi(3.21e6,0.27,1,[0 0 0]);
 inter.zeeman.eigs={[57.5 81.0 227.0],[0 0 0]};
-inter.zeeman.euler={[-90 -90 -17]/(pi*180),[0 0 0]};
+inter.zeeman.euler={[-90 -90 -17]*(pi/180),[0 0 0]};
 inter.coupling.matrix{2,2}=[];
 inter.coordinates={[0.00 0.00 0.00]
                    [1.00 0.00 0.00]};

--- a/examples/nmr_overtone/cpmas_valine_match_2.m
+++ b/examples/nmr_overtone/cpmas_valine_match_2.m
@@ -19,7 +19,7 @@ function cpmas_valine_match_2()
 sys.magnet=14.10220742; sys.isotopes={'14N','1H'};
 inter.coupling.matrix{1,1}=eeqq2nqi(3.21e6,0.27,1,[0 0 0]);
 inter.zeeman.eigs={[57.5 81.0 227.0],[0 0 0]};
-inter.zeeman.euler={[-90 -90 -17]/(pi*180),[0 0 0]};
+inter.zeeman.euler={[-90 -90 -17]*(pi/180),[0 0 0]};
 inter.coupling.matrix{2,2}=[];
 inter.coordinates={[0.00 0.00 0.00]
                    [1.00 0.00 0.00]};

--- a/examples/nmr_overtone/cpmas_valine_simple.m
+++ b/examples/nmr_overtone/cpmas_valine_simple.m
@@ -16,7 +16,7 @@ function cpmas_valine_simple()
 sys.magnet=14.10220742; sys.isotopes={'14N','1H'};
 inter.coupling.matrix{1,1}=eeqq2nqi(3.21e6,0.27,1,[0 0 0]);
 inter.zeeman.eigs={[57.5 81.0 227.0],[0 0 0]};
-inter.zeeman.euler={[-90 -90 -17]/(pi*180),[0 0 0]};
+inter.zeeman.euler={[-90 -90 -17]*(pi/180),[0 0 0]};
 inter.coupling.matrix{2,2}=[];
 inter.coordinates={[0.00 0.00 0.00]
                    [1.00 0.00 0.00]};


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** four CPMAS valine examples divide the CSA Euler angles by (pi*180) instead of multiplying by (pi/180) - [-90 -90 -17] degrees becomes [-0.159 -0.159 -0.030] rad instead of [-1.571 -1.571 -0.297] rad, silently mis-orienting the shift tensor in all four spectra. The MAS valine examples with the same tensor data (mas_valine_1.m, mas_valine_2.m) use the correct form.

**Fix:** *(pi/180) in cpmas_valine_accum.m, cpmas_valine_match_1.m, cpmas_valine_match_2.m, and cpmas_valine_simple.m.

**Validation:** conversion arithmetic checked against the correct siblings; house style 0 violations; checkcode clean on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)