### PR TITLE
cpmas_glycine_match_2.m, cpmas_valine_match_2.m: transpose intensity maps for display

### DIFF
--- a/examples/nmr_overtone/cpmas_glycine_match_2.m
+++ b/examples/nmr_overtone/cpmas_glycine_match_2.m
@@ -101,7 +101,7 @@ end
 % Plot as image
 kfigure();
 imagesc([min(rf_powers)  max(rf_powers)]/1000,...
-        [min(spin_rates) max(spin_rates)]/1000,intensities);
+        [min(spin_rates) max(spin_rates)]/1000,intensities.');
 kxlabel('1H nutation frequency, kHz');
 kylabel('Sample spinning rate, kHz');
 set(gca,'YDir','normal'); colorbar;

--- a/examples/nmr_overtone/cpmas_valine_match_2.m
+++ b/examples/nmr_overtone/cpmas_valine_match_2.m
@@ -102,7 +102,7 @@ end
 % Plot as image
 kfigure();
 imagesc([min(rf_powers) max(rf_powers)],...
-        [min(spin_rates) max(spin_rates)],intensities);
+        [min(spin_rates) max(spin_rates)],intensities.');
 kxlabel('1H RF power, Hz'); set(gca,'YDir','normal');
 kylabel('Sample spinning rate, Hz');
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the Hartmann-Hahn matching maps store intensities as (rf_power_index, spin_rate_index) - confirmed from the preallocation and the ind2sub decode - but imagesc(x_power, y_rate, C) assigns matrix columns to x, so both maps display transposed. Silent, because both dimensions are 50.

**Fix:** pass intensities.' in both imagesc calls.

**Validation:** indexing chain re-verified from the code; house style 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)