### PR TITLE
magic_angle_calibration.m: rotate the spinning axis with the active convention

### DIFF
--- a/examples/nmr_solids/case_studies/magic_angle_calibration.m
+++ b/examples/nmr_solids/case_studies/magic_angle_calibration.m
@@ -54,7 +54,7 @@ time_axis=(0:1:parameters.npoints-1)/parameters.sweep;
 for n=1:numel(ma_errors)
     
     % Tilt the spinnig axis away from the magic angle
-    parameters.axis=[sqrt(2/3) 0 sqrt(1/3)]*euler2dcm(0,ma_errors(n),0);
+    parameters.axis=[sqrt(2/3) 0 sqrt(1/3)]*euler2dcm(0,ma_errors(n),0).';
 
     % Run the MAS simulation
     fid=singlerot(spin_system,@acquire,parameters,'nmr');


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** row_vector*euler2dcm(0,err,0) equals (R'*v)' - the inverse rotation, since euler2dcm documents the active convention v=R*v for column vectors. The polar angle becomes magic_angle-err while the legend labels the trace +err: the positive and negative calibration traces are swapped.

**Fix:** multiply by the transpose, parameters.axis=[...]*euler2dcm(0,ma_errors(n),0).', equivalent to (R*axis')'.

**Validation (measured, R2026a):** for err=+0.25 degrees the patched polar angle is atan(sqrt(2))+err to machine precision (0.959679941 rad); stock gives atan(sqrt(2))-err (0.950953295 rad). House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)