### PR TITLE
beam_dnp examples: move parameter comments above their assignments

### DIFF
--- a/examples/dnp_sol/beam_dnp/beam_contact_curve.m
+++ b/examples/dnp_sol/beam_dnp/beam_contact_curve.m
@@ -41,12 +41,24 @@ parameters.coil=state(spin_system,'Lz','1H');
 
 % Experiment parameters
 parameters.spins={'E','1H'};
-parameters.offset=[(-3.3+5.0)*1e6 0];    % -13 MHz reference point, 5.0 MHz offset
-parameters.irr_powers=32.0e6;            % Electron nutation frequency [Hz]
-parameters.pulse_dur=[20.0e-9 28.7e-9];  % Pulse durations, seconds
-parameters.nloops=165;                   % Number of BEAM DNP blocks
-parameters.grid='rep_2ang_800pts_sph';   % Powder averaging grid
-parameters.needs={'aniso_eq'};           % Sequence needs rho_eq
+
+% -13 MHz reference point, 5.0 MHz offset
+parameters.offset=[(-3.3+5.0)*1e6 0];
+
+% Electron nutation frequency [Hz]
+parameters.irr_powers=32.0e6;
+
+% Pulse durations, seconds
+parameters.pulse_dur=[20.0e-9 28.7e-9];
+
+% Number of BEAM DNP blocks
+parameters.nloops=165;
+
+% Powder averaging grid
+parameters.grid='rep_2ang_800pts_sph';
+
+% Sequence needs rho_eq
+parameters.needs={'aniso_eq'};
 
 % Run the calculation
 contact_curve=powder(spin_system,@beamdnp,parameters,'esr');

--- a/examples/dnp_sol/beam_dnp/beam_field_profile.m
+++ b/examples/dnp_sol/beam_dnp/beam_field_profile.m
@@ -45,11 +45,21 @@ parameters.coil=state(spin_system,'Lz','1H');
 
 % Experiment parameters
 parameters.spins={'E','1H'};
-parameters.irr_powers=32.0e6;            % Electron nutation frequency [Hz]
-parameters.pulse_dur=[20.0e-9 28.7e-9];  % Pulse durations, seconds
-parameters.nloops=165;                   % Number of BEAM DNP blocks
-parameters.grid='rep_2ang_800pts_sph';   % Powder averaging grid
-parameters.needs={'aniso_eq'};           % Sequence needs rho_eq
+
+% Electron nutation frequency [Hz]
+parameters.irr_powers=32.0e6;
+
+% Pulse durations, seconds
+parameters.pulse_dur=[20.0e-9 28.7e-9];
+
+% Number of BEAM DNP blocks
+parameters.nloops=165;
+
+% Powder averaging grid
+parameters.grid='rep_2ang_800pts_sph';
+
+% Sequence needs rho_eq
+parameters.needs={'aniso_eq'};
 
 % MW resonance offset grid, Hz
 offsets=linspace(-60e6,60e6,120);

--- a/examples/dnp_sol/beam_dnp/beam_parameter_scan.m
+++ b/examples/dnp_sol/beam_dnp/beam_parameter_scan.m
@@ -42,10 +42,18 @@ parameters.coil=state(spin_system,'Lz','1H');
 
 % Experiment parameters
 parameters.spins={'E','1H'};
-parameters.pulse_dur=[20.0e-9 28.7e-9];  % Pulse durations, seconds
-parameters.nloops=165;                   % Number of BEAM DNP blocks
-parameters.grid='rep_2ang_800pts_sph';   % Powder averaging grid
-parameters.needs={'aniso_eq'};           % Sequence needs rho_eq
+
+% Pulse durations, seconds
+parameters.pulse_dur=[20.0e-9 28.7e-9];
+
+% Number of BEAM DNP blocks
+parameters.nloops=165;
+
+% Powder averaging grid
+parameters.grid='rep_2ang_800pts_sph';
+
+% Sequence needs rho_eq
+parameters.needs={'aniso_eq'};
 
 % MW resonance offset grid, Hz
 offsets=linspace(-60e6,60e6,120);


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the experiment parameter blocks in all three beam_dnp examples carry inline comments after code, violating the repository comment layout rule (one-line comments above code, blank line before).

**Fix:** each inline comment moved to its own line above its assignment, text preserved verbatim; no code lines altered.

**Validation:** house style violations drop 15 to 0 across the three files; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)