### PR TITLE
pa_sucrose.m, roesy_sucrose.m, tocsy_sucrose.m: separate the magnet field comment block

### DIFF
--- a/examples/nmr_liquids/pa_sucrose.m
+++ b/examples/nmr_liquids/pa_sucrose.m
@@ -11,6 +11,7 @@ function pa_sucrose()
 options.min_j=1.0;
 [sys,inter]=g2spinach(gparse('../standard_systems/sucrose.log'),...
                                      {{'H','1H'}},31.8,options);
+
 % Magnet field
 sys.magnet=14.1;
 

--- a/examples/nmr_liquids/roesy_sucrose.m
+++ b/examples/nmr_liquids/roesy_sucrose.m
@@ -10,6 +10,7 @@ function roesy_sucrose()
 options.min_j=1.0;
 [sys,inter]=g2spinach(gparse('../standard_systems/sucrose.log'),...
                                      {{'H','1H'}},31.8,options);
+
 % Magnet field
 sys.magnet=5.9;
 

--- a/examples/nmr_liquids/tocsy_sucrose.m
+++ b/examples/nmr_liquids/tocsy_sucrose.m
@@ -10,6 +10,7 @@ function tocsy_sucrose()
 options.min_j=1.0;
 [sys,inter]=g2spinach(gparse('../standard_systems/sucrose.log'),...
                                      {{'H','1H'}},31.8,options);
+
 % Magnet field
 sys.magnet=5.9;
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** in all three sucrose examples the '% Magnet field' comment sits directly against the preceding g2spinach call, missing the mandatory blank line before a comment block.

**Fix:** one blank line inserted before the comment in each file; diffs are pure blank-line insertions.

**Validation:** house style 1 to 0 violations per file; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)