### PR TITLE
ttclass/ttort.m, shrink.m: honour the requested orthogonalisation direction

### DIFF
--- a/kernel/overloads/@ttclass/shrink.m
+++ b/kernel/overloads/@ttclass/shrink.m
@@ -24,8 +24,8 @@ function ttrain=shrink(ttrain)
 % Summation
 ttrain=pack(ttrain);
 
-% Right-to-left orthogonalization
-ttrain=ttort(ttrain);
+% Left-to-right orthogonalisation
+ttrain=ttort(ttrain,+1);
 
 % Check the norm and escape if the object is zero
 nrm=ttrain.coeff*norm(ttrain.cores{d,1}(:),2);

--- a/kernel/overloads/@ttclass/ttort.m
+++ b/kernel/overloads/@ttclass/ttort.m
@@ -5,7 +5,7 @@
 %
 % Parameters:
 %
-%    direct=+1 - {default} gives you left-to-right orthogonality,
+%    direct=+1 - gives left-to-right orthogonality,
 %    direct=-1 - gives right-to-left orthogonality
 %
 %    tt     - tensor train object, possibly with buffered sums
@@ -34,9 +34,6 @@ function [tt,lognrm]=ttort(tt,direct)
 % Read tensor ranks and dimensions
 sz=tt.sizes; rnk=tt.ranks;
 d=tt.ncores; N=tt.ntrains;
-
-% Set the default dir if it is not present
-if ~exist('dir','var'), direct=+1; end
 
 % Compute logs of norms
 if (nargout>1)


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** `ttort` guarded its direction default with `exist('dir','var')` - `dir` is a builtin, never a variable here, so the guard always fired and `direct` was reset to +1 on every call. Every `ttort(tt,-1)` in the kernel (norm.m, amensum.m, amensolve.m) silently ran left-to-right, and the right-to-left branch had never executed in production.

**Measured blast radius:** `norm(ttclass,'fro')` reads the first core after a right-to-left pass; fed the left-to-right result instead, it returns sqrt(rank) times the true norm - measured 73% relative error at rank 3 on stock behaviour.

**Fix:** the misspelt guard was meant to default the one-argument call from `shrink.m` (the only caller that omits the direction). Deleted the broken guard and made `shrink.m` pass `+1` explicitly - which is what its `truncate` right-to-left SVD sweep requires (the stale "right-to-left" comment described the output state and is corrected). All other callers now get the direction they ask for.

**Validation (measured, R2026a):** after the fix, `+1` yields left-orthogonal cores (5e-16) and `-1` right-orthogonal cores (3e-16), both preserving the represented matrix to 4e-16; `norm(tt,'fro')` agrees with the dense reference to 3e-16 at rank 3; `shrink` compresses a duplicated train back to rank 3 with 7e-16 drift; shipped `test_dynamic_overload_ttclass_suite` (60 checks) passes and both AMEn examples (`amensum_test_1`, `amensolve_test_1`) run to completion. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)