### PR TITLE
destreak.m: process nonscalar structure arrays element by element

### DIFF
--- a/etc/data_processing/destreak.m
+++ b/etc/data_processing/destreak.m
@@ -28,13 +28,18 @@ if isstruct(spectrum)
     
     % Get the field names
     struct_fieldnames=fieldnames(spectrum);
-    
-    % Loop over field names
-    for n=1:length(struct_fieldnames)
-        
-        % Call itself for each field name
-        spectrum.(struct_fieldnames{n})=destreak(spectrum.(struct_fieldnames{n}));
-                      
+
+    % Loop over structure elements
+    for m=1:numel(spectrum)
+
+        % Loop over field names
+        for n=1:length(struct_fieldnames)
+
+            % Call itself for each field of each element
+            spectrum(m).(struct_fieldnames{n})=destreak(spectrum(m).(struct_fieldnames{n}));
+
+        end
+
     end
 
     % Done


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the struct branch called `spectrum.(fname)=destreak(spectrum.(fname))`, which dies with "Too many input arguments" for nonscalar structure arrays (comma-separated list expansion), although the header promises recursive processing of "structures thereof". Measured on stock.

**Fix:** iterate over structure elements as well as field names, indexing `spectrum(m).(fname)`; cell and matrix branches untouched.

**Validation (measured, R2026a):** a 1x2 struct array now processes and each element equals the direct matrix-path result; scalar struct and plain matrix behaviour unchanged; house style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)