### PR TITLE
g2spinach.m: remove purged nuclei from the coordinate list

### DIFF
--- a/interfaces/g2spinach.m
+++ b/interfaces/g2spinach.m
@@ -174,6 +174,7 @@ switch ismember('E',[particles{:}])
             inter.coupling.matrix(killing_pattern,:)=[];
             inter.zeeman.matrix(killing_pattern)=[];
             sys.isotopes(killing_pattern)=[];
+            if include_xyz, inter.coordinates(killing_pattern)=[]; end
         end
         
     % NMR parameterization    


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the EPR-mode purge block trims sys.isotopes, the Zeeman array, and the coupling arrays with killing_pattern but never inter.coordinates, so a purge that removes nuclei leaves a coordinate list longer than the spin list and create() rejects the output with a count mismatch. Reachable through the documented purge option.

**Fix:** apply the same killing_pattern to inter.coordinates inside the purge block, gated by the same include_xyz flag under which the coordinates were built (one line).

**Validation (measured, R2026a):** on the shipped nitroxide.log, purge shrinks 20 spins to 2 with coordinates trimmed to the exact surviving subset, and create() accepts both purge-on and purge-off outputs; the purge-off path is unchanged. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)