### PR TITLE
Xepr python scripts: restore Python 3 compatibility

### DIFF
--- a/interfaces/spinjet/Xepr_python/Xepr_getdata.py
+++ b/interfaces/spinjet/Xepr_python/Xepr_getdata.py
@@ -28,7 +28,7 @@ try:
 	import XeprAPI      # load the Xepr API module
 	Xepr=XeprAPI.Xepr()
 except:
-	print "xepr_import_error"
+	print("xepr_import_error")
 	sys.exit(1)
 
 try:
@@ -45,14 +45,14 @@ try:
 	if currentExp["ftEpr.PlsSPELEXPSlct"].value != str(sys.argv[2]):
 		currentExp["ftEpr.PlsSPELEXPSlct"].value = str(sys.argv[2])
 except:
-	print "error changing detection mode to TM, or experiment selection"
+	print("error changing detection mode to TM, or experiment selection")
 	sys.exit(3)
 
 # run new experiment
 try:
     currentExp.aqExpRunAndWait()
 except:
-    print "error running current experiment"
+    print("error running current experiment")
     sys.exit(4)
 
 #retrieve data
@@ -61,13 +61,13 @@ dset = Xepr.XeprDataset()
 # no data? -- try to run current experiment (if possible)
 if not dset.datasetAvailable():
     try:
-        print "Trying to run current experiment to create some data..."
+        print("Trying to run current experiment to create some data...")
         Xepr.XeprExperiment().aqExpRunAndWait()
     except XeprAPI.ExperimentError:
-        print "No dataset available and no (working) experiment to run...giving up..."
+        print("No dataset available and no (working) experiment to run...giving up...")
         sys.exit(5)
 if not dset.datasetAvailable():
-    print "(Still) no dataset available...giving up..."
+    print("(Still) no dataset available...giving up...")
     sys.exit(6)
 
 # save data
@@ -77,6 +77,6 @@ try:
     numpy.savetxt((str(sys.argv[3]) + "_rY.txt"),ordinate.real)
     numpy.savetxt((str(sys.argv[3]) + "_iY.txt"),ordinate.imag)
 except:
-    print "Problem saving dataset to file"
+    print("Problem saving dataset to file")
     sys.exit(7)
 

--- a/interfaces/spinjet/Xepr_python/Xepr_plsspel_deffile.py
+++ b/interfaces/spinjet/Xepr_python/Xepr_plsspel_deffile.py
@@ -21,14 +21,14 @@ try:
     import XeprAPI      # load the Xepr API module
     Xepr=XeprAPI.Xepr()
 except:
-    print "XeprAPI_import_error"
+    print("XeprAPI_import_error")
     sys.exit(1)
 
 # python inputs
 try:
     definitions_file=(str(sys.argv[1]))
 except:
-    print "python_input_error"
+    print("python_input_error")
     sys.exit(2)
 
 # Attempt to change the shape file
@@ -37,5 +37,5 @@ try:
 	Xepr.XeprCmds.aqPgShowDef()
 	Xepr.XeprCmds.aqPgCompile()
 except:
-	print "definitions_load_compile_error"
+	print("definitions_load_compile_error")
 	sys.exit(3)

--- a/interfaces/spinjet/Xepr_python/Xepr_plsspel_expfile.py
+++ b/interfaces/spinjet/Xepr_python/Xepr_plsspel_expfile.py
@@ -21,14 +21,14 @@ try:
     import XeprAPI      # load the Xepr API module
     Xepr=XeprAPI.Xepr()
 except:
-    print "XeprAPI_import_error"
+    print("XeprAPI_import_error")
     sys.exit(1)
 
 # python inputs
 try:
     program_file=(str(sys.argv[1]))
 except:
-    print "python_input_error"
+    print("python_input_error")
     sys.exit(2)
 
 # Attempt to change the shape file
@@ -38,5 +38,5 @@ try:
 	Xepr.XeprCmds.aqPgCompValid()
 	Xepr.XeprCmds.aqPgCompile()
 except:
-	print "program_load_compile_error"
+	print("program_load_compile_error")
 	sys.exit(3)

--- a/interfaces/spinjet/Xepr_python/Xepr_plsspel_moddefs.py
+++ b/interfaces/spinjet/Xepr_python/Xepr_plsspel_moddefs.py
@@ -25,7 +25,7 @@ try:
 	import XeprAPI      # load the Xepr API module
 	Xepr=XeprAPI.Xepr()
 except:
-	print "xepr_import_error"
+	print("xepr_import_error")
 	sys.exit(1)
 
 try:
@@ -42,7 +42,7 @@ fullDefs = currentExp.getParam("PlsSPELGlbTxt").value
 # need to check if fullDefs is empty and exit cause pulsespel not being loaded
 fullDefs = fullDefs.split("\n")
 
-no_defs=(len(sys.argv)-1)/2
+no_defs=(len(sys.argv)-1)//2
 
 try:
 	for value in fullDefs:
@@ -51,6 +51,6 @@ try:
 				cmdStr = str(sys.argv[(2*index)-1])+" = "+str(sys.argv[2*index])
 				currentExp["ftEPR.PlsSPELSetVar"].value = cmdStr
 except:
-	print "error changing pulseSPEL defs"
+	print("error changing pulseSPEL defs")
 	sys.exit(4)
 

--- a/interfaces/spinjet/Xepr_python/Xepr_plsspel_shpfile.py
+++ b/interfaces/spinjet/Xepr_python/Xepr_plsspel_shpfile.py
@@ -21,14 +21,14 @@ try:
     import XeprAPI      # load the Xepr API module
     Xepr=XeprAPI.Xepr()
 except:
-    print "XeprAPI_import_error"
+    print("XeprAPI_import_error")
     sys.exit(1)
 
 # python inputs
 try:
     shape_file=(str(sys.argv[1]))
 except:
-    print "python_input_error"
+    print("python_input_error")
     sys.exit(2)
 
 # Attempt to change the shape file
@@ -37,5 +37,5 @@ try:
 	Xepr.XeprCmds.aqPgShowShp()
 	Xepr.XeprCmds.aqPgCompile()
 except:
-	print "shape_load_compile_error"
+	print("shape_load_compile_error")
 	sys.exit(3)

--- a/interfaces/spinjet/Xepr_python/Xepr_resetexpt.py
+++ b/interfaces/spinjet/Xepr_python/Xepr_resetexpt.py
@@ -22,7 +22,7 @@ try:
     import XeprAPI      # load the Xepr API module
     Xepr=XeprAPI.Xepr()
 except:
-    print "xepr_import_error"
+    print("xepr_import_error")
     sys.exit(1)
 
 # get current experiment name


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** all six Xepr interface scripts use Python 2 print statements, and py_run.m invokes a bare `python` - wherever that resolves to Python 3 (python-is-python3, conda, modern Bruker hosts), every script dies at compile time with SyntaxError before reaching XeprAPI. Xepr_plsspel_moddefs.py additionally fed the true-division result `(len(sys.argv)-1)/2` into range(), a TypeError under Python 3.

**Fix:** converted every bare print statement to print(...) across the six files (20 lines; the form is valid under Python 2 as well) and made the definition count integer with floor division.

**Validation:** `python3 -m py_compile` passes on all six files; no bare print statements remain; indentation untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)