### PR TITLE
x2spinach.m: reject missing shielding references

### DIFF
--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -537,13 +537,18 @@ for n=1:numel(xml.children)
                 end
                 
                 % Translate shielding into shift
-                isotope=sys.isotopes{inter_spin_a};
+                isotope=sys.isotopes{inter_spin_a}; ref_found=false();
                 for k=1:numel(shielding_refs)
                     if strcmp(isotope,shielding_refs{k}{1})
-                        A=eye(3)*shielding_refs{k}{2}-A;
+                        A=eye(3)*shielding_refs{k}{2}-A; ref_found=true();
                     end
                 end
-                
+
+                % Catch a missing shielding reference
+                if ~ref_found
+                    error(['no shielding reference supplied for ' isotope '.']);
+                end
+
                 % Assign chemical shift
                 inter.zeeman.matrix{inter_spin_a}=A;
                 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** when a shielding interaction's isotope is absent from shielding_refs, the reference loop leaves the absolute shielding tensor in place and silently stores it as a chemical shift - a wrong sign convention and offset (e.g. ~31 ppm absolute 1H shielding entering as a +31 ppm shift), with no diagnostic.

**Fix:** track a ref_found flag in the reference loop and error with "no shielding reference supplied for <isotope>." when no match exists.

**Validation (measured, R2026a):** on a minimal two-spin SpinXML fixture, complete references give the correct shifts (unchanged behaviour), incomplete references now raise the new error, and the stock code was demonstrated to pass silently with the absolute 120 ppm shielding stored as a shift. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)