### PR TITLE
py_run.m: quote the script path and arguments

### DIFF
--- a/interfaces/spinjet/py_run.m
+++ b/interfaces/spinjet/py_run.m
@@ -55,9 +55,14 @@ if ~isempty(arg_in)
         
         % Ensure input as characters
         if ~ischar(arg_in{inputs})
-            arg_in{inputs}=num2str(arg_in{inputs}); 
+            arg_in{inputs}=num2str(arg_in{inputs});
         end
-        
+
+        % Strip pre-existing surrounding quotes
+        if (numel(arg_in{inputs})>1)&&(arg_in{inputs}(1)=='"')&&(arg_in{inputs}(end)=='"')
+            arg_in{inputs}=arg_in{inputs}(2:end-1);
+        end
+
         % Append the command string
         command_string=[command_string '"' arg_in{inputs} '" ']; %#ok<AGROW>
         

--- a/interfaces/spinjet/py_run.m
+++ b/interfaces/spinjet/py_run.m
@@ -40,9 +40,9 @@ grumble(spin_system,pyscript,arg_in);
 arg_out={};
 
 % Initialise command string to run the selected python script file
-command_string=['python ' spin_system.sys.root_dir filesep ...
+command_string=['python "' spin_system.sys.root_dir filesep ...
                 'interfaces' filesep 'spinjet' filesep ...
-                'Xepr_python' filesep pyscript '.py'];
+                'Xepr_python' filesep pyscript '.py"'];
 
 % Process extra argument cell, if needed
 if ~isempty(arg_in)
@@ -59,7 +59,7 @@ if ~isempty(arg_in)
         end
         
         % Append the command string
-        command_string=[command_string arg_in{inputs} ' ']; %#ok<AGROW>
+        command_string=[command_string '"' arg_in{inputs} '" ']; %#ok<AGROW>
         
     end
     


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the python command string was concatenated unquoted from sys.root_dir, the script name, and the arguments, so a Spinach root or argument containing spaces (common on Windows) splits into multiple shell tokens and the system() call fails or misbehaves.

**Fix:** the assembled script path and each appended argument are wrapped in double quotes; the existing separator spaces are preserved.

**Validation:** command assembly re-read end to end (path quote closes before the argument separator, arguments quoted individually); house style gains no violations; checkcode clean. No Xepr host is available here, so no live spectrometer test was possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)