### PR TITLE
lindbladian.m: require a finite non-negative relaxation rate

### DIFF
--- a/kernel/operators/lindbladian.m
+++ b/kernel/operators/lindbladian.m
@@ -53,7 +53,7 @@ if (~isnumeric(A_left))||(~isnumeric(A_right))||...
     error('all inputs must be numeric.');
 end
 if (~isnumeric(rlx_rate))||(~isscalar(rlx_rate))||...
-   (~isreal(rlx_rate))
+   (~isreal(rlx_rate))||(~isfinite(rlx_rate))||(rlx_rate<0)
     error('rlx_rate must be a non-negative real number.');
 end
 end

--- a/kernel/operators/lindbladian.m
+++ b/kernel/operators/lindbladian.m
@@ -54,7 +54,7 @@ if (~isnumeric(A_left))||(~isnumeric(A_right))||...
 end
 if (~isnumeric(rlx_rate))||(~isscalar(rlx_rate))||...
    (~isreal(rlx_rate))||(~isfinite(rlx_rate))||(rlx_rate<0)
-    error('rlx_rate must be a non-negative real number.');
+    error('rlx_rate must be a finite non-negative real number.');
 end
 end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the grumble error message promises "a non-negative real number" but the condition only checked numeric/scalar/real - NaN, Inf, and negative rates all passed. A negative rate flips the calibration `R=-rlx_rate*R/(rho'*R*rho)` into amplification, contradicting the documented contract.

**Fix:** extend the condition with `||(~isfinite(rlx_rate))||(rlx_rate<0)`.

**Validation (measured, R2026a):** two-level ladder-operator probe - rate 1 accepted with the correct -rlx_rate calibration; -1, NaN, and Inf each rejected with the grumble message; the stock code was demonstrated to return an amplifying superoperator (+1 expectation) for rate -1. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)