### PR TITLE
optimcon.m: reject non-finite pulse durations

### DIFF
--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -571,7 +571,8 @@ if isfield(control,'pulse_dt')
 
     % Input validation
     if (~isnumeric(control.pulse_dt))||(~isreal(control.pulse_dt))||...
-       (~isrow(control.pulse_dt))||any(control.pulse_dt(:)<=0)
+       (~isrow(control.pulse_dt))||any(~isfinite(control.pulse_dt(:)))||...
+       any(control.pulse_dt(:)<=0)
         error('control.pulse_dt must be a row vector of positive real numbers.');
     end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the control.pulse_dt validation tested only <=0; NaN<=0 and Inf<=0 are both false, so non-finite durations passed and silently produced NaN propagators and fidelities downstream with no diagnostic. The sibling grumble in tgrape.m already includes the finite check this validator omits.

**Fix:** add `any(~isfinite(control.pulse_dt(:)))` to the rejection condition.

**Validation:** static - NaN/Inf fail the new condition while all previously valid inputs are unaffected, mirroring tgrape.m's established check; house style gains no violations (the file's 9 pre-existing legacy inline-comment violations are untouched); checkcode clean. A full optimcon control-structure construction was judged disproportionate for a one-condition grumble change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)