### PR TITLE
istraceless.m: treat the zero matrix as traceless

### DIFF
--- a/kernel/utilities/istraceless.m
+++ b/kernel/utilities/istraceless.m
@@ -28,7 +28,7 @@ precision=eps(class(M));
 norm_m=cheap_norm(M);
 
 % Decide if M is traceless
-A=(abs(trace(M))<precision*norm_m);
+A=(abs(trace(M))<=precision*norm_m);
 
 end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the strict comparison `abs(trace(M))<precision*norm_m` evaluates 0<0 for the zero matrix and wrongly returns false, although the zero matrix is exactly traceless. Measured on stock.

**Fix:** non-strict `<=`.

**Validation (measured, R2026a):** istraceless(zeros(4)) now returns true; istraceless(eye(4)) still false; istraceless(diag([1 -1])) still true. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)