### PR TITLE
run_tests.m: add the production directories to the path

### DIFF
--- a/tests/run_tests.m
+++ b/tests/run_tests.m
@@ -22,6 +22,13 @@ addpath(fullfile(root_dir,'lib'));
 addpath(genpath(fullfile(root_dir,'kernel')));
 addpath(genpath(fullfile(root_dir,'interfaces')));
 
+% Add the Spinach production directories to the path
+spinach_root=fileparts(root_dir);
+addpath(genpath(fullfile(spinach_root,'etc')));
+addpath(genpath(fullfile(spinach_root,'experiments')));
+addpath(genpath(fullfile(spinach_root,'interfaces')));
+addpath(genpath(fullfile(spinach_root,'kernel')));
+
 % Parse options
 options=test_options(varargin{:});
 
@@ -84,3 +91,4 @@ if n_fail>0
 end
 
 end
+


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the runner adds only test-tree paths (its 'kernel' and 'interfaces' genpath calls resolve to tests/kernel and tests/interfaces), while tests/README.md documents the complete invocation as `addpath('tests'); results=run_tests();` from the repository root, with no fix_path step. In a fresh MATLAB session every test then dies on unresolved production functions (pauli, comm, the @ttclass/@cell overload dispatch) and is reported as a blanket FAIL.

**Fix:** the runner adds the four production trees (etc, experiments, interfaces, kernel) via genpath from the repository root, mirroring fix_path's own list; idempotent when the path is already configured. Also restores the missing trailing blank line at end of file.

**Validation (measured, R2026a):** in a fresh session with only `addpath('tests')` per the README, `run_tests('pattern','kinetics')` now runs both kinetics suites to PASS. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)