### PR TITLE
bloch_axis.m: preserve the rotation axis orientation

### DIFF
--- a/kernel/plotting/bloch_axis.m
+++ b/kernel/plotting/bloch_axis.m
@@ -28,9 +28,9 @@ dy_dt=fdvec(y,5,1); d2y_dt2=fdvec(y,5,2);
 dz_dt=fdvec(z,5,1); d2z_dt2=fdvec(z,5,2);
 
 % Get instantaneous rotation axis
-ax=dz_dt.*d2y_dt2-dy_dt.*d2z_dt2;
-ay=dx_dt.*d2z_dt2-dz_dt.*d2x_dt2;
-az=dy_dt.*d2x_dt2-dx_dt.*d2y_dt2;
+ax=dy_dt.*d2z_dt2-dz_dt.*d2y_dt2;
+ay=dz_dt.*d2x_dt2-dx_dt.*d2z_dt2;
+az=dx_dt.*d2y_dt2-dy_dt.*d2x_dt2;
 
 end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the instantaneous rotation axis was computed as acceleration crossed with velocity (a x v), the negative of the physical angular-velocity direction v x a. For a counter-clockwise circular trajectory the reconstructed axis pointed along -Z where the right-hand rule requires +Z.

**Fix:** the three components now implement v x a (operands swapped in each line).

**Validation (measured, R2026a):** a densely sampled counter-clockwise unit circle now yields a positive z-component of the reconstructed axis and the clockwise circle a negative one (magnitudes carry fdvec's per-sample units, as before; the function is a direction utility with no in-tree callers, so no downstream compensation exists). House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)