### PR TITLE
plot_uf.m: build one F1 tick per ultrafast data row

### DIFF
--- a/kernel/plotting/plot_uf.m
+++ b/kernel/plotting/plot_uf.m
@@ -83,8 +83,8 @@ if (uf_dim_size) ~= (ga_points_number)
     error('the size of the uf dimension must be equal to the product of the maximal k-value and the sample dimension.');
 end
 
-% Get axis in the uf dimension 
-axis_f1=(-sweep_uf/2:res_uf:sweep_uf/2)+parameters.offset(1); 
+% Get axis in the uf dimension
+axis_f1=-sweep_uf/2+res_uf*(0:(uf_dim_size-1))+parameters.offset(1);
 
 % Get the units 
 switch parameters.axis_units


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the F1 axis was built with an inclusive colon range whose point count depends on floating-point rounding of sweep_uf/res_uf (algebraically dims*k_max), while the preceding safety check pins the spectrum to exactly ga_points_number rows. Whenever the ratio lands at or above the integer, the axis carries one extra element and `contour` rejects a valid spectrum - measured: an exact-ratio parameter set gives a stock axis of 11 ticks against 10 rows.

**Fix:** build the axis with exactly uf_dim_size points at res_uf spacing from -sweep_uf/2; the count matches the spectrum by construction on both sides of the rounding (a half-open colon range is fragile in the opposite direction, which the probe also demonstrated).

**Validation (measured, R2026a):** the exact-ratio case that kills stock now completes through the real `plot_uf` contour call with a 10-point axis. House style: the file's 8 pre-existing legacy violations (inline comments elsewhere) are unchanged; the edited line is clean; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)