### PR TITLE
respiration.m: decouple the configured high-gamma channel

### DIFF
--- a/experiments/respiration.m
+++ b/experiments/respiration.m
@@ -76,7 +76,7 @@ for n=1:parameters.nloops
 end
 
 % Acquisition
-[L,rho]=decouple(spin_system,L,rho,{'1H'});
+[L,rho]=decouple(spin_system,L,rho,parameters.spins(1));
 fid=evolution(spin_system,L,parameters.coil,rho,...
               1/parameters.sweep,parameters.npoints-1,'observable');
           


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the pulse channels come from parameters.spins, but acquisition hard-coded decouple(spin_system,L,rho,{'1H'}) - on non-1H systems the sequence errors (decouple's grumble rejects absent isotopes) or decouples the wrong channel. Latent: the sole shipped caller uses {'1H','13C'}.

**Fix:** pass parameters.spins(1) (parenthesis indexing keeps the cell).

**Validation (measured, R2026a):** on a proton-free 19F/13C system - which stock cannot execute at all - decouple now wipes the configured 19F channel exactly (residual 0, 13C retained at 0.25) and respiration runs end to end with a finite FID. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)