### PR TITLE
holeburn.m: project pulse operators into the spatial space

### DIFF
--- a/experiments/holeburn.m
+++ b/experiments/holeburn.m
@@ -67,6 +67,7 @@ L=H+1i*R+1i*K;
 
 % Pulse operators
 Ep=operator(spin_system,'L+',parameters.spins{1});
+Ep=kron(speye(parameters.spc_dim),Ep);
 Ex=(Ep+Ep')/2; Ey=(Ep-Ep')/2i;
 
 % A soft pulse


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the hole-burning pulse operator was built in spin space only; against a Fokker-Planck Liouvillian (spc_dim>1 contexts such as singlerot or meshflow) the dimensions do not match and shaped_pulse_af's grumble rejects the call. Eight sibling experiments and sp_acquire.m carry the kron(speye(parameters.spc_dim),...) projection.

**Fix:** the sp_acquire projection line, a no-op for spc_dim=1 (which every context sets).

**Validation (measured, R2026a):** spc_dim=1 output unchanged (finite FID regression); a three-cell replicated Fokker-Planck problem - which crashes on stock - returns exactly three times the single-cell FID (error 2e-16). House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)