### PR TITLE
noveldnp_steady.m, topdnp_steady.m: preserve offset vector output shape

### DIFF
--- a/experiments/hyperpol/noveldnp_steady.m
+++ b/experiments/hyperpol/noveldnp_steady.m
@@ -114,7 +114,7 @@ for n=1:numel(parameters.el_offs)
     rho=steady(spin_system,P,[],'newton');
    
     % Get the observable at the steady state
-    dnp(:,n)=gather(parameters.coil'*rho);
+    dnp(n)=gather(parameters.coil'*rho);
 
 end
 

--- a/experiments/hyperpol/topdnp_steady.m
+++ b/experiments/hyperpol/topdnp_steady.m
@@ -95,7 +95,7 @@ for n=1:numel(parameters.el_offs)
     rho=steady(spin_system,P,[],'newton');
    
     % Get the observable at the steady state
-    dnp(:,n)=gather(parameters.coil'*rho);
+    dnp(n)=gather(parameters.coil'*rho);
 
 end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** dnp(:,n)=<scalar> scalar-expands a full column and silently grows the output to an NxN matrix of garbage whenever parameters.el_offs is a column vector, which the grumble accepts. All shipped callers happen to pass rows, so the bug is latent in the documented API.

**Fix:** linear indexing dnp(n)=..., right-hand side unchanged, in both steady-state DNP experiments; the zeros(size(el_offs)) preallocation is consistent with linear indexing for either orientation.

**Validation (measured, R2026a):** the stock pattern demonstrably grows a 3x1 preallocation to 3x2; linear indexing preserves 3x1. House style unchanged (two pre-existing legacy violations in noveldnp_steady.m untouched); checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)