### PR TITLE
spiral.m: sample the gradient waveform on the propagation time grid

### DIFF
--- a/experiments/imaging/spiral.m
+++ b/experiments/imaging/spiral.m
@@ -55,7 +55,7 @@ rho=step(spin_system,Hy,rho,pi);
 rho=evolution(spin_system,L,[],rho,parameters.t_echo,1,'final');
 
 % Build the spiral
-time_grid=linspace(0,parameters.spiral_dur,parameters.spiral_npts);
+time_grid=(0:(parameters.spiral_npts-1))*(parameters.spiral_dur/parameters.spiral_npts);
 spiral_x=time_grid*(parameters.grad_amp/parameters.spiral_dur).*cos(parameters.spiral_frq*time_grid);
 spiral_y=time_grid*(parameters.grad_amp/parameters.spiral_dur).*sin(parameters.spiral_frq*time_grid);
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the spiral gradient waveform was sampled on linspace(0,dur,npts) - spacing dur/(npts-1) - while k-space accumulation and propagation both use time_step=dur/npts: two dwell conventions for the same waveform, so the realised spiral differs from the nominal parameters by npts/(npts-1). The shipped acquisition was internally self-consistent (signal and k-coordinates use the same samples), so images were not distorted; the realised waveform simply did not match the nominal spiral.

**Fix:** left-endpoint grid (0:npts-1)*(dur/npts), matching the propagation step exactly.

**Validation (measured, R2026a):** patched grid spacing equals the propagation dwell exactly (1.000000000e-06 s vs the stock 1.001001001e-06 s at npts=1000), npts samples from 0. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)