### PR TITLE
ilpcs.m, ippcs.m: differentiate unsquared residuals for covariance estimates

### DIFF
--- a/experiments/pseudocon/ilpcs.m
+++ b/experiments/pseudocon/ilpcs.m
@@ -80,7 +80,11 @@ options=optimset('Display','iter','MaxIter',inf,'UseParallel',true,...
 % Vector of squared residuals 
 vec_res_sq=@(x)(expt_pcs-lpcs(nxyz,x(1:3),ranks,...
                 multipack(ranks,[0.5/sqrt(pi) x(9:end)]),x(4:8))).^2;
-             
+
+% Vector of residuals
+vec_res=@(x)(expt_pcs-lpcs(nxyz,x(1:3),ranks,...
+             multipack(ranks,[0.5/sqrt(pi) x(9:end)]),x(4:8)));
+
 % Sum of squared residuals 
 sum_res_sq=@(x)sum(vec_res_sq(x));
 
@@ -105,7 +109,7 @@ pred_pcs=lpcs(nxyz,p(1:3),ranks,Ilm,p(4:8));
 if nargout>4
 
     % Compute Jacobian at the optimal point
-    jac=jacobianest(vec_res_sq,p);
+    jac=jacobianest(vec_res,p);
 
     % Get the Studentized residual
     sdr=sqrt(sum_res_sq(p)/(numel(expt_pcs)-n_mvars-8));

--- a/experiments/pseudocon/ippcs.m
+++ b/experiments/pseudocon/ippcs.m
@@ -51,6 +51,9 @@ options=optimset('Display','iter','MaxIter',inf,'UseParallel',true,...
 % Vector of squared residuals
 vec_res_sq=@(x)(expt_pcs-ppcs(nxyz,x(1:3),x(4:8))).^2;
 
+% Vector of residuals
+vec_res=@(x)(expt_pcs-ppcs(nxyz,x(1:3),x(4:8)));
+
 % Sum of squared residuals 
 sum_res_sq=@(x)sum(vec_res_sq(x));
 
@@ -61,7 +64,7 @@ p=fminunc(sum_res_sq,[mguess 0.1 0.1 0.1 0.1 0.1],options);
 pred_pcs=ppcs(nxyz,p(1:3),p(4:8));
 
 % Compute the Jacobian at the optimal point
-jac=jacobianest(vec_res_sq,p);
+jac=jacobianest(vec_res,p);
 
 % Get the Studentized residual
 sdr=sqrt(sum_res_sq(p)/(numel(expt_pcs)-8));


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** parameter covariance was computed from jacobianest applied to SQUARED residuals. Mathematically jac=2*diag(r)*J, which collapses toward zero as the fit improves, so the reported standard deviations were not covariance estimates - measured inflation by a median factor of 1344 at the optimum of a synthetic problem.

**Fix:** both fitters define an unsquared residual handle alongside the existing squared objective and pass THAT to jacobianest for the uncertainty block; the optimiser keeps the squared form.

**Validation (measured, R2026a):** synthetic round trips through both fitters (15 nuclei, known centre position and susceptibility, 1e-3 ppm noise) recover position and chi to five decimals with finite, error-consistent standard deviations (recovery errors within reported sigma); the stock-style jacobian at the same optimum inflates sdevs ~1300x. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)