### PR TITLE
ilpcs.m, ippcs.m: restore the caller warning state

### DIFF
--- a/experiments/pseudocon/ilpcs.m
+++ b/experiments/pseudocon/ilpcs.m
@@ -73,8 +73,8 @@ grumble(nxyz,expt_pcs,ranks,mguess);
 n_mvars=sum(2*nonzeros(ranks)+1);
 
 % Suppress the method switch warning, restore on exit
-ws=warning('off','optim:fminunc:SwitchingMethod');
-cleanup_obj=onCleanup(@()warning(ws));
+warn_state=warning('off','optim:fminunc:SwitchingMethod');
+cleanup_obj=onCleanup(@()warning(warn_state));
 
 % Set optimisation options
 options=optimset('Display','iter','MaxIter',inf,'UseParallel',true,...

--- a/experiments/pseudocon/ilpcs.m
+++ b/experiments/pseudocon/ilpcs.m
@@ -72,8 +72,11 @@ grumble(nxyz,expt_pcs,ranks,mguess);
 % Count the multipole variables
 n_mvars=sum(2*nonzeros(ranks)+1);
 
+% Suppress the method switch warning, restore on exit
+ws=warning('off','optim:fminunc:SwitchingMethod');
+cleanup_obj=onCleanup(@()warning(ws));
+
 % Set optimisation options
-warning('off','optim:fminunc:SwitchingMethod');
 options=optimset('Display','iter','MaxIter',inf,'UseParallel',true,...
                  'MaxFunEvals',inf,'FinDiffType','central');
 

--- a/experiments/pseudocon/ippcs.m
+++ b/experiments/pseudocon/ippcs.m
@@ -43,8 +43,11 @@ function [mxyz,chi,pred_pcs,s_mxyz,s_chi]=ippcs(nxyz,mguess,expt_pcs)
 % Check consistency
 grumble(nxyz,mguess,expt_pcs);
 
+% Suppress the method switch warning, restore on exit
+ws=warning('off','optim:fminunc:SwitchingMethod');
+cleanup_obj=onCleanup(@()warning(ws));
+
 % Set optimisation options
-warning('off','optim:fminunc:SwitchingMethod');
 options=optimset('Display','iter','MaxIter',inf,'UseParallel',true,...
                  'MaxFunEvals',inf,'FinDiffType','central');
 

--- a/experiments/pseudocon/ippcs.m
+++ b/experiments/pseudocon/ippcs.m
@@ -44,8 +44,8 @@ function [mxyz,chi,pred_pcs,s_mxyz,s_chi]=ippcs(nxyz,mguess,expt_pcs)
 grumble(nxyz,mguess,expt_pcs);
 
 % Suppress the method switch warning, restore on exit
-ws=warning('off','optim:fminunc:SwitchingMethod');
-cleanup_obj=onCleanup(@()warning(ws));
+warn_state=warning('off','optim:fminunc:SwitchingMethod');
+cleanup_obj=onCleanup(@()warning(warn_state));
 
 % Set optimisation options
 options=optimset('Display','iter','MaxIter',inf,'UseParallel',true,...


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** warning('off','optim:fminunc:SwitchingMethod') with no restore leaks session-global warning state to the caller, surviving both normal return and errors.

**Fix:** capture the prior state and restore it with an onCleanup handler in both fitters. Note: the same unrestored pattern exists in kernel/plotting/int_2d.m and slice_2d.m - scope here is the two flagged fitters; extending it is a separate decision.

**Validation (measured, R2026a):** caller warning state is 'on' before and after each fitter (stock leaks 'off'), with fits numerically unaffected. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)