### PR TITLE
retrieve_file.m: return the documented downloaded file path

### DIFF
--- a/interfaces/retrieve_file.m
+++ b/interfaces/retrieve_file.m
@@ -13,13 +13,13 @@
 %
 % Outputs:
 %
-%     this function writes a file
+%     file_path - full path of the downloaded file on disk
 %
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=retrieve_file.m>
 
-function retrieve_file(file_url,file_name,dest_dir)
+function file_path=retrieve_file(file_url,file_name,dest_dir)
 
 % Check consistency
 grumble(file_url,file_name,dest_dir);


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the header documents file_path=retrieve_file(...), but the function declared no output; file_path was computed internally and discarded, so the documented call form dies with "Too many output arguments".

**Fix:** declare the output in the function line and document it in the Outputs section.

**Validation:** nargout is now 1; checkcode and house style unchanged (network path untouched, no callers in the tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)