### PR TITLE
trajan.m: remove the unreachable property default

### DIFF
--- a/kernel/trajan.m
+++ b/kernel/trajan.m
@@ -69,9 +69,6 @@ function trajan(spin_system,traj,property,time_axis)
 if ~exist('time_axis','var'), time_axis=[]; end
 grumble(spin_system,traj,property,time_axis);
 
-% Set the defaults
-if ~exist('property','var'), property='correlation_order'; end
-
 % Project out unit state
 if ~strcmp(property,'level_populations')
     unit=unit_state(spin_system);


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the grumble call references `property` before the `if ~exist('property','var')` default runs, so a two-argument call dies at the grumble line and the default is dead code - which kernel policy forbids anyway.

**Fix:** deleted the dead default block. The tautological exist() guards inside the grumble (always called with four arguments) are left as they are.

**Validation:** static caller sweep - every in-tree caller (2 test files, 9 examples) passes property explicitly; house style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)