### PR TITLE
eeqq2nqi.m: remove the trace from the diagonal only

### DIFF
--- a/kernel/conventions/transforms/eeqq2nqi.m
+++ b/kernel/conventions/transforms/eeqq2nqi.m
@@ -47,7 +47,7 @@ R=euler2dcm(eulers);
 Q=R*diag([XX YY ZZ])*R';
 
 % Clean up small rounding errors
-Q=Q-trace(Q)/3; Q=(Q+Q')/2;
+Q=Q-eye(3)*trace(Q)/3; Q=(Q+Q')/2;
 
 end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** `Q=Q-trace(Q)/3` subtracts the scalar from all nine elements through scalar expansion, shifting every off-diagonal by trace(Q)/3. The magnitude is O(eps*C_q) - the reviewer's severity was overstated - but the code deviates from its own clean-up intent and from the sibling idiom in zfs2mat.m.

**Fix:** the house idiom `Q=Q-eye(3)*trace(Q)/3`.

**Validation (measured, R2026a):** output trace exactly zero, symmetry exact, off-diagonals bitwise equal to the symmetrised pre-subtraction matrix. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)