### PR TITLE
weblab2nqi.m: reject phi in the fixed-grid output modes

### DIFF
--- a/kernel/conventions/transforms/weblab2nqi.m
+++ b/kernel/conventions/transforms/weblab2nqi.m
@@ -1,7 +1,10 @@
 % Converts the Weblab one-cone model parameters (see weblab_cone.png)
 % into NQI tensors used by Spinach. Syntax:
 %
-%         [Q1,Q2,...]=weblab2nqi(C_q,eta_q,I,alpha,theta,phi)
+%     [Q1,Q2]=weblab2nqi(C_q,eta_q,I,alpha,theta,phi)
+%     [Q1,Q2,Q3]=weblab2nqi(C_q,eta_q,I,alpha,theta,phi)
+%     [Q1,Q2,Q3,Q4]=weblab2nqi(C_q,eta_q,I,alpha,theta)
+%     [Q1,Q2,Q3,Q4,Q5,Q6]=weblab2nqi(C_q,eta_q,I,alpha,theta)
 %
 % Parameters:
 %
@@ -14,8 +17,12 @@
 %
 %     alpha
 %     theta
-%     phi          - the three angles of Weblab cone model 
-%                    (see weblab_cone.png), in radians
+%     phi          - the three angles of Weblab cone model
+%                    (see weblab_cone.png), in radians; the
+%                    four- and six-site modes place the sites
+%                    on fixed azimuth grids, [0 1 2 3]*pi/2
+%                    and [0 1 2 3 4 5]*pi/3 respectively, and
+%                    must therefore be called without phi
 %
 % Outputs:
 %
@@ -29,8 +36,11 @@
 
 function varargout=weblab2nqi(C_q,eta_q,I,alpha,theta,phi)
 
+% Four- and six-output modes take no phi
+if nargin<6, phi=[]; end
+
 % Check consistency
-grumble(C_q,eta_q,I,alpha,theta,phi);
+grumble(C_q,eta_q,I,alpha,theta,phi,nargin,nargout);
 
 % Translate conventions and call eeqq2nqi
 switch nargout
@@ -50,10 +60,7 @@ switch nargout
         
     case 4
         
-        % Four output arguments, fixed phi values
-        if ~isempty(phi)
-            disp('WARNING: phi was overwritten to [0 1 2 3]*pi/4');
-        end
+        % Four output arguments, fixed azimuth grid
         varargout{1}=eeqq2nqi(C_q,eta_q,I,[0*pi/2 theta alpha]);
         varargout{2}=eeqq2nqi(C_q,eta_q,I,[1*pi/2 theta alpha]);
         varargout{3}=eeqq2nqi(C_q,eta_q,I,[2*pi/2 theta alpha]);
@@ -61,10 +68,7 @@ switch nargout
         
     case 6
         
-        % Six output arguments, fixed phi values
-        if ~isempty(phi)
-            disp('WARNING: phi was overwritten to [0 1 2 3 4 5]*pi/6');
-        end
+        % Six output arguments, fixed azimuth grid
         varargout{1}=eeqq2nqi(C_q,eta_q,I,[0*pi/3 theta alpha]);
         varargout{2}=eeqq2nqi(C_q,eta_q,I,[1*pi/3 theta alpha]);
         varargout{3}=eeqq2nqi(C_q,eta_q,I,[2*pi/3 theta alpha]);
@@ -82,7 +86,13 @@ end
 end
 
 % Consistency enforcement
-function grumble(C_q,eta_q,I,alpha,theta,phi)
+function grumble(C_q,eta_q,I,alpha,theta,phi,n_ins,n_outs)
+if ((n_outs==2)||(n_outs==3))&&(n_ins~=6)
+    error('phi is required in the two- and three-output modes.');
+end
+if ((n_outs==4)||(n_outs==6))&&(n_ins~=5)
+    error('phi is not accepted in the four- and six-output modes.');
+end
 if (~isnumeric(C_q))||(~isnumeric(eta_q))||(~isnumeric(I))||...
    (~isnumeric(alpha))||(~isnumeric(theta))||(~isnumeric(phi))
     error('all inputs must be numeric.');
@@ -92,7 +102,8 @@ if (~isreal(C_q))||(~isreal(eta_q))||(~isreal(I))||...
     error('all inputs must be real.');
 end
 if (~isscalar(C_q))||(~isscalar(eta_q))||(~isscalar(I))||...
-   (~isscalar(alpha))||(~isscalar(theta))||(~isscalar(phi))
+   (~isscalar(alpha))||(~isscalar(theta))||...
+   ((n_ins==6)&&(~isscalar(phi)))
     error('all inputs must be scalar.');
 end
 if (numel(I)~=1)||(I<1)||(mod(2*I+1,1)~=0)


### PR DESCRIPTION
**Finding:** the four- and six-output modes place the sites on fixed azimuth grids, so `phi` carries no information there. Stock accepted it, silently overwrote it, and printed a warning — and the warning text was itself wrong, quoting `[0 1 2 3]*pi/4` and `[0 1 2 3 4 5]*pi/6` where the code uses `pi/2` and `pi/3`.

**Fix:** presence of `phi` is now an error in the four- and six-output modes, and its absence is an error in the two- and three-output modes. The overwrite warning and the empty-`phi` affordance are both gone. The header carries the four supported call syntaxes and the true azimuth grids.

**Validation (measured, R2026a):**
- two-, three-, four-, and six-output results bitwise identical to the stock `eeqq2nqi` calls (`isequal` true in all four modes);
- `phi` supplied in the four- or six-output mode, scalar or empty, errors with `phi is not accepted in the four- and six-output modes.`;
- `phi` omitted in the two- or three-output mode errors with `phi is required in the two- and three-output modes.`;
- empty, non-scalar, complex, and non-numeric `phi` still rejected by the existing messages; the spin quantum number gate fires in both arities; unsupported output counts still bomb out; four-input calls give MATLAB's natural `Not enough input arguments.`;
- shipped `test_transform_tensor_suite` passes, 28 checks, no error;
- `checkcode` empty, house-style gate clean.

No call site in the tree uses the four- or six-output mode: the three examples and the one test all call the two- or three-output form, whose behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
