### PR TITLE
xyz2sph.m: return azimuths in the documented range

### DIFF
--- a/kernel/conventions/transforms/xyz2sph.m
+++ b/kernel/conventions/transforms/xyz2sph.m
@@ -32,7 +32,7 @@ r=sqrt(x.^2+y.^2+z.^2);
 theta=acos(z./r); 
 
 % Azimuth 0 <= phi < 2*pi
-phi=atan2(y,x);    
+phi=mod(atan2(y,x),2*pi);
 
 end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the header documents 0<=phi<2*pi (ISO convention) but atan2 returns (-pi,pi], so every y<0 point violates the stated contract. All in-tree consumers feed phi into spherical harmonics and are 2*pi-periodic, so no numerical result changes.

**Fix:** `phi=mod(atan2(y,x),2*pi)`.

**Validation (measured, R2026a):** a y<0 point now lands in [pi,2*pi); the spherical harmonic value at phi versus phi-2*pi is identical to 1.5e-16; shipped test_transform_units_coordinates_suite and test_transform_roundtrip_suite both pass. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)