### PR TITLE
one_vcell_solidangle.m: keep the quadrant when accumulating triangle angles

### DIFF
--- a/kernel/grids/one_vcell_solidangle.m
+++ b/kernel/grids/one_vcell_solidangle.m
@@ -39,7 +39,7 @@ if nargin<2
         T=v(:,[1 k k+1]);
         num=det(T);
         denom=1+sum(sum(T.*T(:,[2 3 1]),1),2);
-        s(k-1)=num/denom;
+        s(k-1)=atan2(num,denom);
     end
 else
     v(:,end+1)=v(:,1);
@@ -49,10 +49,10 @@ else
         T=[centre, v(:,[k k+1])];
         num=det(T);
         denom=1+sum(sum(T.*T(:,[2 3 1]),1),2);
-        s(k)=num/denom;
+        s(k)=atan2(num,denom);
     end
 end
-S=atan(s); S=2*sum(S);
+S=2*sum(s);
 
 end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the Van Oosterom-Strackee accumulation stored num/denom ratios and applied atan at the end, losing the quadrant whenever the denominator is non-positive (large spherical triangles): a near-hemispherical cell returns ~0 instead of ~2*pi. Latent for the shipped quasi-uniform grids, whose fan triangles always have denom>0.

**Fix:** both accumulation branches store atan2(num,denom) per triangle; the final line sums them.

**Validation (measured, R2026a):** the hemisphere-scale triangle recovers 2*pi (stock -0.104, patched 6.179, correction exactly 2*pi to 1e-12); small triangles bitwise identical to stock; shipped test_grid_geometry_suite passes including the solid-angle checks. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)