### PR TITLE
exorcise.m: require the operating mode argument

### DIFF
--- a/kernel/integrity/exorcise.m
+++ b/kernel/integrity/exorcise.m
@@ -6,7 +6,7 @@
 %
 % Parameters:
 %
-%   mode   - 'online' (default) checks the documentation
+%   mode   - 'online' checks the documentation
 %            Wiki for the corresponding page; 'offline'
 %            skips the Wiki check 
 %
@@ -21,9 +21,6 @@
 % <https://spindynamics.org/wiki/index.php?title=exorcise.m>
 
 function exorcise(mode)
-
-% Default mode is online
-if ~exist('mode','var'), mode='online'; end
 
 % Check consistency
 grumble(mode);


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the mode='online' default made a bare exorcise() silently start per-file Wiki HTTP checks; optional arguments and defaults are forbidden in kernel functions. The default dates to the original import and is flagged here as a policy conformance fix - maintainer judgement welcome.

**Fix:** deleted the default line and the "(default)" claim in the header, making mode required. The only in-tree caller is a bad-mode error-path test, which is unaffected.

**Validation (measured, R2026a):** bare exorcise() now raises MATLAB's missing-argument error; exorcise('nonsense') still raises the existing bad-mode grumble; neither scanning mode is entered. Legacy style violations unchanged; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)