### PR TITLE
kernelest.m: require all six arguments

### DIFF
--- a/kernel/optimcon/distortions/kernelest.m
+++ b/kernel/optimcon/distortions/kernelest.m
@@ -11,11 +11,11 @@
 %
 %    ker_len  - kernel length (number of taps)
 %
-%    method   - 'backslash' (default) | 'pinv' | 'svd' | 'tikh'
+%    method   - 'backslash' | 'pinv' | 'svd' | 'tikh'
 %
-%    align    - 'causal' (default) or 'same' output alignment
+%    align    - 'causal' or 'same' output alignment
 %
-%    lambda   - Tikhonov parameter for 'tikh' (optional)
+%    lambda   - Tikhonov parameter for 'tikh'
 %
 % Outputs:
 %
@@ -26,11 +26,6 @@
 % <https://spindynamics.org/wiki/index.php?title=kernelest.m>
 
 function h=kernelest(x,y,ker_len,method,align,lambda)
-
-% Set the defaults
-if nargin<4, method='backslash'; end
-if nargin<5, align='causal'; end
-if nargin<6, lambda=1e-6; end
 
 % Check consistency
 grumble(x,y,ker_len,method,align,lambda);

--- a/tests/kernel/test_dynamic_optimcon_remaining.m
+++ b/tests/kernel/test_dynamic_optimcon_remaining.m
@@ -124,7 +124,7 @@ h_ref=[0.60; -0.20; 0.10];
 y=conv(x,h_ref); y=y(1:numel(x));
 methods={'backslash','pinv','svd'};
 for n=1:numel(methods)
-    h_est=kernelest(x,y,numel(h_ref),methods{n},'causal');
+    h_est=kernelest(x,y,numel(h_ref),methods{n},'causal',1e-6);
     result=test_close(result,['kernelest ' methods{n}],h_est,h_ref,1e-12,1e-12,...
                       'kernelest must recover a full-rank causal FIR kernel');
 end
@@ -137,7 +137,7 @@ conv_mat=toeplitz([x; zeros(numel(h_ref)-1,1)],...
                   [x(1) zeros(1,numel(h_ref)-1)]);
 row_start=floor(numel(h_ref)/2)+1;
 y_same=conv_mat(row_start:(row_start+numel(x)-1),:)*h_ref;
-h_same=kernelest(x,y_same,numel(h_ref),'backslash','same');
+h_same=kernelest(x,y_same,numel(h_ref),'backslash','same',1e-6);
 result=test_close(result,'kernelest same align',h_same,h_ref,1e-12,1e-12,...
                   'same-aligned kernel estimation must use the central convolution rows');
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** nargin-based defaults for method, align, and lambda violate the repository's no-defaults rule, and the lambda=1e-6 silent guess is exactly the "never assume" target of that policy. The defaults were exercised by two shipped test calls; the only other caller passes all six arguments.

**Fix:** deleted the defaults, removed "(default)"/"(optional)" from the header, and made the two test calls pass the explicit lambda=1e-6 the deleted default supplied.

**Validation (measured, R2026a):** a short call now raises the natural missing-argument error; both updated test code paths complete and recover the reference kernel to better than 1e-10. House style and checkcode clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)