### PR TITLE
totsum.m: use the sparse path only for all-sparse cells

### DIFF
--- a/kernel/overloads/@cell/totsum.m
+++ b/kernel/overloads/@cell/totsum.m
@@ -24,7 +24,7 @@ grumble(A);
 
 % Check array type
 r_u_sparse=cellfun(@issparse,A);
-sparse_path=any(r_u_sparse(:));
+sparse_path=all(r_u_sparse(:));
 
 % Run the addition
 if sparse_path


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** any(r_u_sparse(:)) selected the sparse triplet assembly for mixed cells, contradicting the header (sparse result promised only when ALL elements are sparse) and pushing every dense operand through find() into large triplet arrays. Values stayed correct; the defect is type and memory behaviour.

**Fix:** all(r_u_sparse(:)).

**Validation (measured, R2026a):** a mixed sparse/dense cell now takes the dense path (issparse false) with values equal to the elementwise sum to 1e-14; all-sparse stays sparse, all-dense stays dense. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)