### PR TITLE
ttclass/kron.m: keep propagated tolerances non-negative

### DIFF
--- a/kernel/overloads/@ttclass/kron.m
+++ b/kernel/overloads/@ttclass/kron.m
@@ -54,7 +54,7 @@ if a.coeff==0 || b.coeff==0
     c.tolerance=0;
 else
     % The relative tolerances sum up
-    c.tolerance=a.coeff*b.tolerance+b.coeff*a.tolerance;
+    c.tolerance=abs(a.coeff)*b.tolerance+abs(b.coeff)*a.tolerance;
 end
 
 end


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** tolerance propagation used signed (legally complex) coefficients, so a negative-coefficient operand produced a negative tolerance, violating the constructor invariant (real, non-negative) that downstream truncate.m relies on. The sibling mtimes.m consistently uses magnitudes.

**Fix:** abs() on both coefficient factors.

**Validation (measured, R2026a):** with a real negative post-shrink coefficient (a.coeff=-6), the stock formula yields tolerance -6e-4 while the patched code gives +6e-4, exactly the abs-formula value; the value path is untouched (full() of the product matches flat kron to 1.7e-15). Legacy style violations unchanged; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)