### PR TITLE
shaped_pulse_af.m: gather trajectory cells element by element

### DIFF
--- a/kernel/pulses/shaped_pulse_af.m
+++ b/kernel/pulses/shaped_pulse_af.m
@@ -244,7 +244,11 @@ rho=squeeze(sum(reshape(full(rho),[spn_dim spc_dim stk_dim]),2));
 % Gather results from the GPU
 if ismember('gpu',spin_system.sys.enable)
     rho=gather(rho);
-    if nargout>1, traj=gather(traj); end
+    if nargout>1
+        for n=1:numel(traj)
+            traj{n}=gather(traj{n});
+        end
+    end
     if nargout>2, P=gather(P); end
 end
 


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** with GPU execution enabled and the trajectory output requested, traj is a cell array of gpuArrays, and gather() does not recurse into cell containers - the trajectory came back full of gpuArrays. The sibling shaped_pulse_xy.m gathers per element.

**Fix:** the sibling's per-element gather loop, inside the GPU output block only; the CPU path is untouched.

**Validation (measured, R2026a, live on a 2-GPU host):** the stock premise was demonstrated (cell-level gather leaves 2 of 2 elements as gpuArrays); after the fix a real shaped_pulse_af GPU run returns trajectories with 0 of 4 gpuArray cells and matches the CPU run to 8.9e-17. Legacy style violations unchanged; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)