### PR TITLE
stitch.m: require matching midpoint event and duration counts

### DIFF
--- a/kernel/utilities/stitch.m
+++ b/kernel/utilities/stitch.m
@@ -189,6 +189,9 @@ for n=1:numel(mec_time)
         error('elements of mec_time must be a positive real scalars.');
     end
 end
+if numel(mec_oper)~=numel(mec_time)
+    error('mec_oper and mec_time must have the same number of elements.');
+end
 end
 
 % A wolf hates both men and dogs, but dogs he hates more.


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified):** the midpoint-event loop indexes mec_time{n} over numel(mec_oper) with no count-equality check in the grumbler - a shorter mec_time dies with a raw index error, a longer one silently drops durations. Every other input in this file is exhaustively grumbled.

**Fix:** a count-equality check in the grumbler next to the existing mec validation.

**Validation (measured, R2026a):** mismatched cell counts are now caught in the grumbler with the new message; matched counts pass that check. House style and checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)