### PR TITLE
top_q_con_time ensemble examples: label B1 curves with range centres

### DIFF
--- a/examples/dnp_sol/steady_state/top_q_con_time_ensemble_b1.m
+++ b/examples/dnp_sol/steady_state/top_q_con_time_ensemble_b1.m
@@ -145,7 +145,7 @@ contact_times=(parameters.pulse_dur+parameters.delay_dur)*loop_counts;
 kfigure(); plot(contact_times*1e6,real(dnp_a));
 hold on; plot(contact_times*1e6,real(dnp_b));
 kylabel('$I_\textrm{z}$ expectation value on $^{1}$H');
-klegend({'TOP, 18 MHz','TOP, 33 MHz'});
+klegend({'TOP, 15 MHz','TOP, 30 MHz'});
 kxlabel('Total contact time, $\mu$s'); 
 kgrid; xlim tight; ylim padded;
 

--- a/examples/dnp_sol/steady_state/top_q_con_time_ensemble_b1_r.m
+++ b/examples/dnp_sol/steady_state/top_q_con_time_ensemble_b1_r.m
@@ -149,7 +149,7 @@ contact_times=(parameters.pulse_dur+parameters.delay_dur)*loop_counts;
 kfigure(); plot(contact_times*1e6,real(dnp_a));
 hold on; plot(contact_times*1e6,real(dnp_b));
 kylabel('$I_\textrm{z}$ expectation value on $^{1}$H');
-klegend({'TOP, 18 MHz','TOP, 33 MHz'});
+klegend({'TOP, 15 MHz','TOP, 30 MHz'});
 kxlabel('Total contact time, $\mu$s'); 
 kgrid; xlim tight; ylim padded;
 


### PR DESCRIPTION
**Findings (full-codebase Codex sweep, verified; decision by IK):** both B1-ensemble TOP examples average over 10–20 MHz and 25–35 MHz (Gauss–Legendre, centres 15 and 30 MHz) but label the curves "18 MHz" and "33 MHz" — the nominal single-value parameter sets, not what is simulated. Ilya's call: relabel the legends.

**Fix:** both klegend calls now read "TOP, 15 MHz" / "TOP, 30 MHz", matching the ensemble centres.

**Validation:** string-constant change; house-style parity exact against stock (zero new violations) and checkcode clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)