### PR TITLE
rotation conventions: active anax2dcm and the in-house qter quaternion family

### DIFF
--- a/etc/diamond_defects/diamond_n2vm.m
+++ b/etc/diamond_defects/diamond_n2vm.m
@@ -36,9 +36,9 @@ end
 grumble(parameters);
 
 % Build the reported frames
-c2rot=anax2dcm([0 0 1],-pi);
+c2rot=anax2dcm([0 0 1],pi);
 gframe=diamond_frame_xyz([1 1 0],[0 0 1],[1 -1 0]);
-nframe=anax2dcm([1 -1 0],3.5*pi/180)*...
+nframe=anax2dcm([1 -1 0],-3.5*pi/180)*...
        diamond_frame_xyz([1 1 -2],[1 1 1],[1 -1 0]);
 
 % Orthogonalise the carbon hyperfine frame axes
@@ -48,7 +48,7 @@ zaxis=[-1 1 1]';
 zaxis=zaxis-xaxis*dot(xaxis,zaxis);
 zaxis=zaxis/norm(zaxis,2);
 yaxis=cross(zaxis,xaxis);
-cframe=anax2dcm([-1 -1 0],-2.0*pi/180)*...
+cframe=anax2dcm([-1 -1 0],2.0*pi/180)*...
        diamond_frame_xyz(xaxis,yaxis,zaxis);
 
 % Build the electron tensors

--- a/examples/fundamentals/convention_tests/rotations_1.m
+++ b/examples/fundamentals/convention_tests/rotations_1.m
@@ -70,19 +70,19 @@ else
     error('Test 4 inconsistency detected');
 end
 
-%% Test 5: dcm2quat, quat2dcm
+%% Test 5: dcm2qter, qter2dcm
 
 % Generate a DCM
 R=euler2dcm(eulers);
 
-% Convert to quaternions and back
-if norm(R-quat2dcm(dcm2quat(R)),2)<1e-10
+% Convert to a quaternion and back
+if norm(R-qter2dcm(dcm2qter(R)),2)<1e-10
     disp('Test 5 passed.');
 else
     error('Test 5 inconsistency detected');
 end
 
-%% Test 6: anax2quat, quat2anax
+%% Test 6: anax2qter, qter2anax
 
 % Generate a unit quaternion
 q1.u=randn(); q1.i=randn();
@@ -92,8 +92,8 @@ q1.u=q1.u/qnorm; q1.i=q1.i/qnorm;
 q1.j=q1.j/qnorm; q1.k=q1.k/qnorm;
 
 % Convert to angle-axis and back
-[aa_axis,aa_angle]=quat2anax(q1);
-q2=anax2quat(aa_axis,aa_angle);
+[aa_axis,aa_angle]=qter2anax(q1);
+q2=anax2qter(aa_axis,aa_angle);
 
 % Check the difference
 if norm([q1.u-q2.u q1.i-q2.i q1.j-q2.j q1.k-q2.k],2)<1e-10
@@ -102,7 +102,7 @@ else
     error('Test 6 inconsistency detected');
 end
 
-%% Test 7: quat2anax, anax2dcm, quat2dcm
+%% Test 7: qter2anax, anax2dcm, qter2dcm
 
 % Generate a unit quaternion
 q.u=randn(); q.i=randn();
@@ -111,15 +111,15 @@ qnorm=norm([q.u q.i q.j q.k],2);
 q.u=q.u/qnorm; q.i=q.i/qnorm;
 q.j=q.j/qnorm; q.k=q.k/qnorm;
 
-% Convert directly to a passive DCM, Aerospace Toolbox convention
-R1=quat2dcm([q.u q.i q.j q.k]);
+% Convert directly to a DCM
+R1=qter2dcm(q);
 
-% Convert to an active DCM via angle-axis
-[aa_axis,aa_angle]=quat2anax(q);
+% Convert to a DCM via angle-axis
+[aa_axis,aa_angle]=qter2anax(q);
 R2=anax2dcm(aa_axis,aa_angle);
 
-% Check the transpose relation between the conventions
-if norm(R1-R2',2)<1e-10
+% Check the difference
+if norm(R1-R2,2)<1e-10
     disp('Test 7 passed.');
 else
     error('Test 7 inconsistency detected');

--- a/examples/fundamentals/convention_tests/rotations_1.m
+++ b/examples/fundamentals/convention_tests/rotations_1.m
@@ -111,15 +111,15 @@ qnorm=norm([q.u q.i q.j q.k],2);
 q.u=q.u/qnorm; q.i=q.i/qnorm;
 q.j=q.j/qnorm; q.k=q.k/qnorm;
 
-% Convert directly to DCM
+% Convert directly to a passive DCM, Aerospace Toolbox convention
 R1=quat2dcm([q.u q.i q.j q.k]);
 
-% Convert to DCM via angle-axis
+% Convert to an active DCM via angle-axis
 [aa_axis,aa_angle]=quat2anax(q);
 R2=anax2dcm(aa_axis,aa_angle);
 
-% Check the difference
-if norm(R1-R2,2)<1e-10
+% Check the transpose relation between the conventions
+if norm(R1-R2',2)<1e-10
     disp('Test 7 passed.');
 else
     error('Test 7 inconsistency detected');

--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -363,10 +363,11 @@ for n=1:numel(xml.children)
                         end
                     
                         % Get the DCM
-                        dcm=quat2dcm([q.u q.i q.j q.k]);
-                        
+                        [rot_axis,rot_angle]=quat2anax(q);
+                        dcm=anax2dcm(rot_axis,rot_angle);
+
                         % Clear temporary variables
-                        clear('q');
+                        clear('q','rot_axis','rot_angle');
                         
                     elseif strcmpi(xml.children(n).children(k).children(m).name,'dcm')
                         

--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -363,11 +363,10 @@ for n=1:numel(xml.children)
                         end
                     
                         % Get the DCM
-                        [rot_axis,rot_angle]=quat2anax(q);
-                        dcm=anax2dcm(rot_axis,rot_angle);
+                        dcm=qter2dcm(q);
 
                         % Clear temporary variables
-                        clear('q','rot_axis','rot_angle');
+                        clear('q');
                         
                     elseif strcmpi(xml.children(n).children(k).children(m).name,'dcm')
                         

--- a/kernel/conventions/transforms/anax2dcm.m
+++ b/kernel/conventions/transforms/anax2dcm.m
@@ -1,6 +1,7 @@
-% Converts angle-axis rotation parameters to directional
-% cosine matrix. Angle should be in radians, axis is nor-
-% malized by the function. Syntax:
+% Converts angle-axis rotation parameters to a direction
+% cosine matrix in the active convention, matching the one
+% used by euler2dcm.m function. Angle should be in radians,
+% axis is normalized by the function. Syntax:
 %
 %              dcm=anax2dcm(rot_axis,rot_angle)
 %
@@ -16,6 +17,14 @@
 %
 %           dcm - directional cosine matrix
 %
+% Note: the resulting rotation matrix is to be used as follows:
+%
+%         v=R*v    (for 3x1 vectors)
+%         A=R*A*R' (for 3x3 interaction tensors)
+%
+% Note: Matlab's Aerospace Toolbox quat2dcm() returns the
+%       transpose of this matrix for the same rotation.
+%
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=anax2dcm.m>
@@ -29,7 +38,7 @@ grumble(rot_axis,rot_angle);
 rot_axis=rot_axis(:)/norm(rot_axis(:),2);
 
 % Compute the DCM
-dcm=eye(3)-sin(rot_angle)*[ 0           -rot_axis(3)  rot_axis(2);
+dcm=eye(3)+sin(rot_angle)*[ 0           -rot_axis(3)  rot_axis(2);
                             rot_axis(3)  0           -rot_axis(1);
                            -rot_axis(2)  rot_axis(1)  0          ]+...
                     (1-cos(rot_angle))*(rot_axis*rot_axis'-eye(3));

--- a/kernel/conventions/transforms/anax2qter.m
+++ b/kernel/conventions/transforms/anax2qter.m
@@ -1,6 +1,6 @@
 % Converts angle-axis rotation parameters into a quaternion. Syntax:
 %
-%                  q=anax2quat(rot_axis,rot_angle)
+%                  q=anax2qter(rot_axis,rot_angle)
 %
 % Parameters:
 %
@@ -17,9 +17,9 @@
 % gareth.charnock@oerc.ox.ac.uk
 % ilya.kuprov@weizmann.ac.il
 %
-% <https://spindynamics.org/wiki/index.php?title=anax2quat.m>
+% <https://spindynamics.org/wiki/index.php?title=anax2qter.m>
 
-function q=anax2quat(rot_axis,rot_angle)
+function q=anax2qter(rot_axis,rot_angle)
 
 % Check consistency
 grumble(rot_axis,rot_angle);

--- a/kernel/conventions/transforms/dcm2euler.m
+++ b/kernel/conventions/transforms/dcm2euler.m
@@ -17,13 +17,20 @@
 %                          vention, radians
 %
 %     angles             - a row vector of Euler angles in
-%                          ZYZ active convention, ordered 
+%                          ZYZ active convention, ordered
 %                          as alpha, beta, gamma, in radians
 %
-% Note: the problem of recovering Euler angles from a DCM is, in 
+% Note: the problem of recovering Euler angles from a DCM is, in
 %       general, ill-posed. This function is a product of consi-
 %       derable work, it has passed rigorous testing: it either
 %       returns a correct answer or gives an informative error.
+%
+% Note: the angles returned are those of the proper rotation that
+%       is nearest to the input in the Frobenius norm; that rota-
+%       tion is found in closed form through the dominant eigen-
+%       vector of the Davenport matrix (I.Y. Bar-Itzhack, J. Gui-
+%       dance Control Dyn. 23 (2000) 1085), and the angles are
+%       extracted from the corresponding quaternion.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -34,29 +41,21 @@ function [arg1,arg2,arg3]=dcm2euler(dcm)
 % Check consistency
 grumble(dcm);
 
-% Get the beta angle out, clamping the cosine into [-1,1]
-beta=acos(max(-1,min(1,dcm(3,3))));
+% Build the Davenport matrix
+K=[dcm(1,1)+dcm(2,2)+dcm(3,3) dcm(3,2)-dcm(2,3)          dcm(1,3)-dcm(3,1)          dcm(2,1)-dcm(1,2);
+   dcm(3,2)-dcm(2,3)          dcm(1,1)-dcm(2,2)-dcm(3,3) dcm(1,2)+dcm(2,1)          dcm(1,3)+dcm(3,1);
+   dcm(1,3)-dcm(3,1)          dcm(1,2)+dcm(2,1)          dcm(2,2)-dcm(1,1)-dcm(3,3) dcm(2,3)+dcm(3,2);
+   dcm(2,1)-dcm(1,2)          dcm(1,3)+dcm(3,1)          dcm(2,3)+dcm(3,2)          dcm(3,3)-dcm(1,1)-dcm(2,2)];
 
-% Do a brute force surface scan with respect to alpha and gamma
-alphas=pi*linspace(0.05,1.95,20);
-gammas=pi*linspace(0.05,1.95,20);
-n_min=1; k_min=1; err_min=1;
-for n=1:20
-    for k=1:20
-        err_current=norm(euler2dcm(alphas(n),beta,gammas(k))-dcm,1);
-        if err_current<err_min
-            n_min=n; k_min=k; err_min=err_current;
-        end
-    end
-end
-alpha=alphas(n_min); gamma=gammas(k_min);
+% Get the quaternion of the nearest rotation
+[evecs,evals]=eig(K,'vector'); [~,best]=max(evals);
+q.u=evecs(1,best); q.i=evecs(2,best);
+q.j=evecs(3,best); q.k=evecs(4,best);
 
-% Run the optimisation on alpha and gamma
-options=optimset('Display','off','LargeScale','off','TolX',1e-12,'TolFun',1e-12);
-answer=fminunc(@(angles)norm(euler2dcm(angles(1),beta,angles(2))-dcm,'fro')^2,[alpha gamma],options);
-alpha=answer(1); gamma=answer(2);
+% Extract the Euler angles
+[alpha,beta,gamma]=qter2euler(q);
 
-% Wrap both angles into [0,2*pi]
+% Wrap alpha and gamma into [0,2*pi]
 alpha=mod(alpha,2*pi); gamma=mod(gamma,2*pi);
 
 % Make sure the result is good enough and bomb out if not
@@ -80,6 +79,9 @@ end
 function grumble(dcm)
 if (~isnumeric(dcm))||(~isreal(dcm))||(~all(size(dcm)==[3 3]))
     error('DCM must be a real 3x3 matrix.');
+end
+if any(~isfinite(dcm(:)))
+    error('DCM must not contain NaN or Inf elements.');
 end
 if norm(dcm'*dcm-eye(3),1)>1e-6
     warning('DCM is not orthogonal to 1e-6 tolerance - conversion accuracy not guaranteed.');

--- a/kernel/conventions/transforms/dcm2qter.m
+++ b/kernel/conventions/transforms/dcm2qter.m
@@ -1,0 +1,85 @@
+% Converts a direction cosine matrix in the active convention of
+% euler2dcm.m function into a unit quaternion. Syntax:
+%
+%                      q=dcm2qter(dcm)
+%
+% Parameters:
+%
+%    dcm - directional cosine matrix, a 3x3 orthogonal
+%          matrix with unit determinant
+%
+% Outputs:
+%
+%    q - structure with four scalar fields q.u, q.i, q.j,
+%        q.k giving the four components of the quaternion,
+%        normalised to q.u greater than or equal to zero
+%
+% Note: quaternions double-cover rotations; of the two candi-
+%       dates q and -q this function returns the one with the
+%       non-negative scalar part.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=dcm2qter.m>
+
+function q=dcm2qter(dcm)
+
+% Check consistency
+grumble(dcm);
+
+% Shepperd invariants of the four candidate pivots
+piv=[1+dcm(1,1)+dcm(2,2)+dcm(3,3);
+     1+dcm(1,1)-dcm(2,2)-dcm(3,3);
+     1-dcm(1,1)+dcm(2,2)-dcm(3,3);
+     1-dcm(1,1)-dcm(2,2)+dcm(3,3)];
+
+% Convert using the best-conditioned pivot
+[~,best]=max(piv);
+switch best
+    case 1
+        q.u=sqrt(piv(1))/2;
+        q.i=(dcm(3,2)-dcm(2,3))/(4*q.u);
+        q.j=(dcm(1,3)-dcm(3,1))/(4*q.u);
+        q.k=(dcm(2,1)-dcm(1,2))/(4*q.u);
+    case 2
+        q.i=sqrt(piv(2))/2;
+        q.u=(dcm(3,2)-dcm(2,3))/(4*q.i);
+        q.j=(dcm(1,2)+dcm(2,1))/(4*q.i);
+        q.k=(dcm(1,3)+dcm(3,1))/(4*q.i);
+    case 3
+        q.j=sqrt(piv(3))/2;
+        q.u=(dcm(1,3)-dcm(3,1))/(4*q.j);
+        q.i=(dcm(1,2)+dcm(2,1))/(4*q.j);
+        q.k=(dcm(2,3)+dcm(3,2))/(4*q.j);
+    case 4
+        q.k=sqrt(piv(4))/2;
+        q.u=(dcm(2,1)-dcm(1,2))/(4*q.k);
+        q.i=(dcm(1,3)+dcm(3,1))/(4*q.k);
+        q.j=(dcm(2,3)+dcm(3,2))/(4*q.k);
+end
+
+% Resolve the double cover towards a non-negative scalar part
+if q.u<0
+    q.u=-q.u; q.i=-q.i; q.j=-q.j; q.k=-q.k;
+end
+
+% Normalise the quaternion
+qnorm=norm([q.u q.i q.j q.k],2);
+q.u=q.u/qnorm; q.i=q.i/qnorm;
+q.j=q.j/qnorm; q.k=q.k/qnorm;
+
+end
+
+% Consistency enforcement
+function grumble(dcm)
+if (~isnumeric(dcm))||(~isreal(dcm))||(~isequal(size(dcm),[3 3]))
+    error('dcm must be a real 3x3 matrix.');
+end
+if norm(dcm'*dcm-eye(3),'fro')>1e-6
+    error('dcm must be an orthogonal matrix.');
+end
+if abs(det(dcm)-1)>1e-6
+    error('dcm must have a unit determinant.');
+end
+end
+

--- a/kernel/conventions/transforms/euler2qter.m
+++ b/kernel/conventions/transforms/euler2qter.m
@@ -1,0 +1,73 @@
+% Converts Euler angles (ZYZ active convention) into a unit
+% quaternion in the active convention, matching euler2dcm.m
+% function. Syntax:
+%
+%                q=euler2qter(alpha,beta,gamma)
+%
+%                            OR
+%
+%                q=euler2qter([alpha beta gamma])
+%
+% Parameters:
+%
+%    alpha,beta,gamma - Euler angles in radians (ZYZ active
+%                       convention), scalars or column vec-
+%                       tors of equal length
+%
+% Outputs:
+%
+%    q - structure with four fields q.u, q.i, q.j, q.k giving
+%        the four components of the quaternion; for column
+%        vector inputs each field is a column vector
+%
+% Note: the quaternion returned represents the same rotation
+%       as euler2dcm(alpha,beta,gamma); it is converted into
+%       that matrix by qter2dcm.m function.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=euler2qter.m>
+
+function q=euler2qter(arg1,arg2,arg3)
+
+% Adapt to the input style
+if nargin==1
+
+    % Assume that a single input is a 3-vector
+    alp=arg1(1); bet=arg1(2); gam=arg1(3);
+
+elseif nargin==3
+
+    % Assume that three inputs are Euler angles
+    alp=arg1; bet=arg2; gam=arg3;
+
+else
+
+    % Bomb out in all other cases
+    error('incorrect number of input arguments.');
+
+end
+
+% Check consistency
+grumble(alp,bet,gam);
+
+% Compute the quaternion
+q.u=cos(bet/2).*cos((alp+gam)/2);
+q.i=sin(bet/2).*sin((gam-alp)/2);
+q.j=sin(bet/2).*cos((gam-alp)/2);
+q.k=cos(bet/2).*sin((alp+gam)/2);
+
+end
+
+% Consistency enforcement
+function grumble(alp,bet,gam)
+if (~isnumeric(alp))||(~isreal(alp))||(~iscolumn(alp))||...
+   (~isnumeric(bet))||(~isreal(bet))||(~iscolumn(bet))||...
+   (~isnumeric(gam))||(~isreal(gam))||(~iscolumn(gam))
+    error('Euler angles must be real scalars or column vectors.');
+end
+if (numel(alp)~=numel(bet))||(numel(bet)~=numel(gam))
+    error('alpha, beta, and gamma must have the same number of elements.');
+end
+end
+

--- a/kernel/conventions/transforms/qter2anax.m
+++ b/kernel/conventions/transforms/qter2anax.m
@@ -1,7 +1,7 @@
 % Converts a quaternion representation of a rotation into angle-axis
 % rotation parameters. Syntax:
 %
-%                 [rot_axis,rot_angle]=quat2anax(q)
+%                 [rot_axis,rot_angle]=qter2anax(q)
 %
 % Parameters:
 %
@@ -18,9 +18,9 @@
 %
 % ilya.kuprov@weizmann.ac.il
 %
-% <https://spindynamics.org/wiki/index.php?title=quat2anax.m>
+% <https://spindynamics.org/wiki/index.php?title=qter2anax.m>
 
-function [rot_axis,rot_angle]=quat2anax(q)
+function [rot_axis,rot_angle]=qter2anax(q)
 
 % Check consistency
 grumble(q);

--- a/kernel/conventions/transforms/qter2dcm.m
+++ b/kernel/conventions/transforms/qter2dcm.m
@@ -1,0 +1,60 @@
+% Converts a unit quaternion into a direction cosine matrix in
+% the active convention, matching the one used by euler2dcm.m
+% function. Syntax:
+%
+%                      dcm=qter2dcm(q)
+%
+% Parameters:
+%
+%    q - structure with four scalar fields q.u, q.i, q.j,
+%        q.k giving the four components of the quaternion
+%
+% Outputs:
+%
+%    dcm - directional cosine matrix
+%
+% Note: the resulting rotation matrix is to be used as follows:
+%
+%         v=R*v    (for 3x1 vectors)
+%         A=R*A*R' (for 3x3 interaction tensors)
+%
+% Note: Matlab's Aerospace Toolbox quat2dcm() returns the
+%       transpose of this matrix for the same quaternion.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=qter2dcm.m>
+
+function dcm=qter2dcm(q)
+
+% Check consistency
+grumble(q);
+
+% Normalise the quaternion
+qnorm=norm([q.u q.i q.j q.k],2);
+q.u=q.u/qnorm; q.i=q.i/qnorm;
+q.j=q.j/qnorm; q.k=q.k/qnorm;
+
+% Compute the DCM
+dcm=[1-2*(q.j^2+q.k^2)    2*(q.i*q.j-q.u*q.k)  2*(q.i*q.k+q.u*q.j);
+     2*(q.i*q.j+q.u*q.k)  1-2*(q.i^2+q.k^2)    2*(q.j*q.k-q.u*q.i);
+     2*(q.i*q.k-q.u*q.j)  2*(q.j*q.k+q.u*q.i)  1-2*(q.i^2+q.j^2)];
+
+end
+
+% Consistency enforcement
+function grumble(q)
+if ~all(isfield(q,{'i','j','k','u'}))
+    error('quaternion data structure must contain u, i, j, and k fields.');
+end
+if (~isnumeric(q.u))||(~isreal(q.u))||(~isscalar(q.u))||...
+   (~isnumeric(q.i))||(~isreal(q.i))||(~isscalar(q.i))||...
+   (~isnumeric(q.j))||(~isreal(q.j))||(~isscalar(q.j))||...
+   (~isnumeric(q.k))||(~isreal(q.k))||(~isscalar(q.k))
+    error('quaternion components must be real scalars.');
+end
+if norm([q.u q.i q.j q.k],2)<sqrt(eps())
+    error('quaternion norm must be significantly non-zero.');
+end
+end
+

--- a/kernel/conventions/transforms/qter2euler.m
+++ b/kernel/conventions/transforms/qter2euler.m
@@ -1,0 +1,65 @@
+% Converts a unit quaternion in the active convention into Euler
+% angles (ZYZ active convention), matching euler2dcm.m function.
+% Syntax:
+%
+%              [alpha,beta,gamma]=qter2euler(q)
+%
+% Parameters:
+%
+%    q - structure with four fields q.u, q.i, q.j, q.k giving
+%        the four components of the quaternion; each field may
+%        be a column vector, in which case the conversion is
+%        performed elementwise
+%
+% Outputs:
+%
+%    alpha,beta,gamma - Euler angles in radians (ZYZ active
+%                       convention), same shape as the qua-
+%                       ternion component fields
+%
+% Note: Euler angles are not unique; the angles returned sa-
+%       tisfy euler2dcm(alpha,beta,gamma)=qter2dcm(q) with
+%       beta in the [0,pi] interval.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=qter2euler.m>
+
+function [alpha,beta,gamma]=qter2euler(q)
+
+% Check consistency
+grumble(q);
+
+% Normalise the quaternions
+qnorm=sqrt(q.u.^2+q.i.^2+q.j.^2+q.k.^2);
+q.u=q.u./qnorm; q.i=q.i./qnorm;
+q.j=q.j./qnorm; q.k=q.k./qnorm;
+
+% Compute the angle sums and differences
+sum_ag=2*atan2(q.k,q.u); dif_ga=2*atan2(q.i,q.j);
+
+% Compute the Euler angles
+beta=2*atan2(sqrt(q.i.^2+q.j.^2),sqrt(q.u.^2+q.k.^2));
+alpha=(sum_ag-dif_ga)/2; gamma=(sum_ag+dif_ga)/2;
+
+end
+
+% Consistency enforcement
+function grumble(q)
+if ~all(isfield(q,{'i','j','k','u'}))
+    error('quaternion data structure must contain u, i, j, and k fields.');
+end
+if (~isnumeric(q.u))||(~isreal(q.u))||(~iscolumn(q.u))||...
+   (~isnumeric(q.i))||(~isreal(q.i))||(~iscolumn(q.i))||...
+   (~isnumeric(q.j))||(~isreal(q.j))||(~iscolumn(q.j))||...
+   (~isnumeric(q.k))||(~isreal(q.k))||(~iscolumn(q.k))
+    error('quaternion components must be real scalars or column vectors.');
+end
+if (numel(q.u)~=numel(q.i))||(numel(q.i)~=numel(q.j))||(numel(q.j)~=numel(q.k))
+    error('quaternion component fields must have the same number of elements.');
+end
+if any(sqrt(q.u.^2+q.i.^2+q.j.^2+q.k.^2)<sqrt(eps()))
+    error('quaternion norms must be significantly non-zero.');
+end
+end
+

--- a/kernel/conventions/transforms/quat2anax.m
+++ b/kernel/conventions/transforms/quat2anax.m
@@ -30,14 +30,15 @@ qnorm=norm([q.u q.i q.j q.k],2);
 q.u=q.u/qnorm; q.i=q.i/qnorm;
 q.j=q.j/qnorm; q.k=q.k/qnorm;
 
-% Compute the angle
-rot_angle=2*atan2(norm([q.i q.j q.k],2),q.u);
+% Compute the vector part norm
+vec_norm=norm([q.i q.j q.k],2);
 
-% Compute the axis
-if rot_angle==0
-    rot_axis=[0 0 1];
+% Compute the angle and the axis
+if vec_norm==0
+    rot_angle=0; rot_axis=[0 0 1];
 else
-    rot_axis=[q.i q.j q.k]/norm([q.i q.j q.k],2);
+    rot_angle=2*atan2(vec_norm,q.u);
+    rot_axis=[q.i q.j q.k]/vec_norm;
 end
 
 end

--- a/kernel/grids/grid_kron.m
+++ b/kernel/grids/grid_kron.m
@@ -33,20 +33,24 @@ function [angles,weights]=grid_kron(angles1,weights1,angles2,weights2)
 grumble(angles1,weights1,angles2,weights2);
 
 % Convert both grids to quaternions
-quats1=angle2quat(angles1(:,1),angles1(:,2),angles1(:,3),'ZYZ');
-quats2=angle2quat(angles2(:,1),angles2(:,2),angles2(:,3),'ZYZ');
+qter1=euler2qter(angles1(:,1),angles1(:,2),angles1(:,3));
+qter2=euler2qter(angles2(:,1),angles2(:,2),angles2(:,3));
 
-% Build a table of quaternion products
-quats=[kron(quats1,ones(size(quats2,1),1)) kron(ones(size(quats1,1),1),quats2)];
+% Build a table of quaternion pairs
+n1=size(angles1,1); n2=size(angles2,1);
+u1=kron(qter1.u,ones(n2,1)); u2=kron(ones(n1,1),qter2.u);
+i1=kron(qter1.i,ones(n2,1)); i2=kron(ones(n1,1),qter2.i);
+j1=kron(qter1.j,ones(n2,1)); j2=kron(ones(n1,1),qter2.j);
+k1=kron(qter1.k,ones(n2,1)); k2=kron(ones(n1,1),qter2.k);
 
 % Multiply up quaternions
-quats=[quats(:,1).*quats(:,5)-quats(:,2).*quats(:,6)-quats(:,3).*quats(:,7)-quats(:,4).*quats(:,8),...
-       quats(:,1).*quats(:,6)+quats(:,2).*quats(:,5)+quats(:,3).*quats(:,8)-quats(:,4).*quats(:,7),...
-       quats(:,1).*quats(:,7)-quats(:,2).*quats(:,8)+quats(:,3).*quats(:,5)+quats(:,4).*quats(:,6),...
-       quats(:,1).*quats(:,8)+quats(:,2).*quats(:,7)-quats(:,3).*quats(:,6)+quats(:,4).*quats(:,5)];
-   
+qter.u=u1.*u2-i1.*i2-j1.*j2-k1.*k2;
+qter.i=u1.*i2+i1.*u2+j1.*k2-k1.*j2;
+qter.j=u1.*j2-i1.*k2+j1.*u2+k1.*i2;
+qter.k=u1.*k2+i1.*j2-j1.*i2+k1.*u2;
+
 % Convert quaternions into angles
-[alphas,betas,gammas]=quat2angle(quats,'ZYZ'); angles=real([alphas betas gammas]);
+[alphas,betas,gammas]=qter2euler(qter); angles=[alphas betas gammas];
 
 % Tile the weights
 weights=kron(weights1,weights2);

--- a/kernel/grids/repulsion.m
+++ b/kernel/grids/repulsion.m
@@ -108,7 +108,9 @@ switch ndims
     case 4
         
         % In 4D case return Euler angles
-        [alphas,betas,gammas]=quat2angle(R','ZYZ');
+        qter.u=R(1,:)'; qter.i=R(2,:)';
+        qter.j=R(3,:)'; qter.k=R(4,:)';
+        [alphas,betas,gammas]=qter2euler(qter);
        
 end
 

--- a/tests/kernel/test_transform_rotation_suite.m
+++ b/tests/kernel/test_transform_rotation_suite.m
@@ -78,16 +78,28 @@ result=test_close(result,'anax2dcm active convention, Y axis',anax2dcm([0 1 0],0
                   'a rotation about the Y axis must match the corresponding active ZYZ Euler rotation');
 
 % Round-trip a non-zero angle through quaternion form
-q=anax2quat(axis_vec,angle);
-[axis_obs,angle_obs]=quat2anax(q);
+q=anax2qter(axis_vec,angle);
+[axis_obs,angle_obs]=qter2anax(q);
 axis_ref=(axis_vec/norm(axis_vec,2)).';
 q_norm=sqrt(q.u^2+q.i^2+q.j^2+q.k^2);
-result=test_close(result,'anax2quat unit norm',q_norm,1,1e-15,1e-15,...
+result=test_close(result,'anax2qter unit norm',q_norm,1,1e-15,1e-15,...
                   'rotation quaternions must have unit norm');
-result=test_close(result,'quat2anax axis',axis_obs,axis_ref,1e-15,1e-15,...
+result=test_close(result,'qter2anax axis',axis_obs,axis_ref,1e-15,1e-15,...
                   'for angles below pi the quaternion axis is the normalised input axis');
-result=test_close(result,'quat2anax angle',angle_obs,angle,1e-15,1e-15,...
+result=test_close(result,'qter2anax angle',angle_obs,angle,1e-15,1e-15,...
                   'for angles below pi the quaternion angle is recovered without branch ambiguity');
+
+% Check the quaternion conversions against the Euler convention
+qtr=euler2qter(0.4,1.1,-0.7);
+result=test_close(result,'euler2qter unit norm',sqrt(qtr.u^2+qtr.i^2+qtr.j^2+qtr.k^2),1,1e-15,1e-15,...
+                  'rotation quaternions must have unit norm');
+result=test_close(result,'euler2qter/qter2dcm convention',qter2dcm(qtr),euler2dcm(0.4,1.1,-0.7),1e-14,1e-14,...
+                  'the quaternion route must reproduce the active ZYZ rotation matrix');
+[alp_obs,bet_obs,gam_obs]=qter2euler(qtr);
+result=test_close(result,'qter2euler recovery',euler2dcm(alp_obs,bet_obs,gam_obs),euler2dcm(0.4,1.1,-0.7),1e-14,1e-14,...
+                  'Euler angles are not unique, but the recovered angles must give the same rotation');
+result=test_close(result,'dcm2qter/qter2dcm rotation',qter2dcm(dcm2qter(euler2dcm(0.4,1.1,-0.7))),euler2dcm(0.4,1.1,-0.7),1e-14,1e-14,...
+                  'the DCM round trip through the quaternion must be exact to machine precision');
 
 % Check that identity rotation has identity second-rank Wigner matrix
 D=dcm2wigner(eye(3));

--- a/tests/kernel/test_transform_rotation_suite.m
+++ b/tests/kernel/test_transform_rotation_suite.m
@@ -72,6 +72,10 @@ result=test_close(result,'anax2dcm proper orthogonality',R_one'*R_one,eye(3),1e-
                   'direction cosine matrices preserve lengths');
 result=test_close(result,'anax2dcm determinant',det(R_one),1,1e-14,1e-14,...
                   'proper rotations have determinant +1');
+result=test_close(result,'anax2dcm active convention, Z axis',anax2dcm([0 0 1],0.31),euler2dcm(0,0,0.31),1e-14,1e-14,...
+                  'a rotation about the Z axis must match the corresponding active ZYZ Euler rotation');
+result=test_close(result,'anax2dcm active convention, Y axis',anax2dcm([0 1 0],0.27),euler2dcm(0,0.27,0),1e-14,1e-14,...
+                  'a rotation about the Y axis must match the corresponding active ZYZ Euler rotation');
 
 % Round-trip a non-zero angle through quaternion form
 q=anax2quat(axis_vec,angle);

--- a/tests/kernel/test_transform_rotation_suite.m
+++ b/tests/kernel/test_transform_rotation_suite.m
@@ -46,8 +46,15 @@ result=test_true(result,'euler_equiv tolerance fail',~euler_equiv([0 0 0],[2e-6 
 angles=[0.37 0.91 -0.42];
 R=euler2dcm(angles);
 angles_obs=dcm2euler(R);
-result=test_close(result,'dcm2euler reconstruction',euler2dcm(angles_obs),R,1e-7,1e-7,...
-                  'Euler angles are not unique, but the reconstructed DCM must be the same rotation to optimiser tolerance');
+result=test_close(result,'dcm2euler reconstruction',euler2dcm(angles_obs),R,1e-14,1e-14,...
+                  'Euler angles are not unique, but the reconstructed DCM must be the same rotation to machine precision');
+result=test_close(result,'dcm2euler beta zero',euler2dcm(dcm2euler(euler2dcm(0.4,0,1.1))),euler2dcm(0.4,0,1.1),1e-14,1e-14,...
+                  'the beta=0 gimbal case must reconstruct exactly');
+result=test_close(result,'dcm2euler beta pi',euler2dcm(dcm2euler(euler2dcm(0.4,pi,1.1))),euler2dcm(0.4,pi,1.1),1e-14,1e-14,...
+                  'the beta=pi gimbal case must reconstruct exactly');
+R_dirty=R+1e-7*[0.3 -0.7 0.2; 0.1 0.4 -0.6; -0.5 0.2 0.3];
+result=test_close(result,'dcm2euler corrupted input',euler2dcm(dcm2euler(R_dirty)),R,1e-6,1e-6,...
+                  'a subtly corrupted DCM must return the angles of the nearest proper rotation');
 
 % Compose two active rotations in the documented order
 rot_one=[0.2 0.4 -0.3];

--- a/tests/kernel/test_transform_roundtrip_suite.m
+++ b/tests/kernel/test_transform_roundtrip_suite.m
@@ -30,11 +30,11 @@ result=test_close(result,'anax2dcm determinant',det(R),1,1e-14,1e-14,...
 
 % Quaternion and angle-axis representations must describe the same rotation
 axis=[1 2 3]; angle=0.37*pi;
-q=anax2quat(axis,angle);
-[axis_back,angle_back]=quat2anax(q);
+q=anax2qter(axis,angle);
+[axis_back,angle_back]=qter2anax(q);
 R_from_axis=anax2dcm(axis,angle);
 R_from_quat=anax2dcm(axis_back,angle_back);
-result=test_close(result,'anax2quat/quat2anax rotation',R_from_quat,R_from_axis,1e-14,1e-14,...
+result=test_close(result,'anax2qter/qter2anax rotation',R_from_quat,R_from_axis,1e-14,1e-14,...
                   'quaternion round-trip must preserve the represented rotation');
 
 % Euler conversion is ill-conditioned in angles, but DCM reconstruction is unique

--- a/tests/kernel/test_transform_roundtrip_suite.m
+++ b/tests/kernel/test_transform_roundtrip_suite.m
@@ -41,8 +41,8 @@ result=test_close(result,'anax2qter/qter2anax rotation',R_from_quat,R_from_axis,
 angles=[0.21*pi 0.37*pi 0.43*pi];
 R=euler2dcm(angles);
 angles_back=dcm2euler(R);
-result=test_close(result,'dcm2euler/euler2dcm rotation',euler2dcm(angles_back),R,1e-7,1e-7,...
-                  'Euler-angle recovery must reconstruct the original active ZYZ rotation to the documented numerical accuracy of the inverse problem');
+result=test_close(result,'dcm2euler/euler2dcm rotation',euler2dcm(angles_back),R,1e-14,1e-14,...
+                  'Euler-angle recovery must reconstruct the original active ZYZ rotation to machine precision');
 
 % Axiality/rhombicity to matrix with zero Euler angles gives the Mehring-order eigenvalues
 iso=4; ax=6; rh=2;


### PR DESCRIPTION
**Finding (full-codebase Codex sweep, verified; migration decided by IK):** anax2dcm returned exactly the transpose of euler2dcm's documented active convention (measured: transposed difference 0, direct difference 0.86 on a test rotation) — the family had been built around Matlab's Aerospace Toolbox passive convention. Consequence inside the tree: x2spinach applies `A=dcm*A*dcm'` with an euler2dcm branch alongside quaternion and angle-axis branches, so quaternion- and angle-axis-specified SpinXML rotations were imported transposed relative to Euler-specified ones (measured mismatch 2.03 on a unit test tensor).

**Round 1 — active convention migration:**
- `anax2dcm.m`: sine term sign flipped — now the active Rodrigues formula exactly; header documents the convention, the `v=R*v` / `A=R*A*R'` usage, and the Aerospace-Toolbox transpose relation.
- `x2spinach.m`: quaternion branch moved in-family, making all four orientation inputs consistent.
- `diamond_n2vm.m`: the three angle-axis tilt angles sign-compensated so the shipped N2V⁻ frames (Green et al., PRB 92, 165204) are **bit-identical** before and after the migration — if the paper's intended tilt sense was the literal active reading, drop the compensation instead; flagged for Alexey/Ilya.
- `quat2anax`: negative-identity quaternion pole fixed (branches on the vector-part norm; review finding).
- Convention pins added to the rotation suite; `axis_tsymm` measured convention-invariant (5.4e-15), unchanged.

**Round 2 — qter family and full Aerospace Toolbox disengagement (IK request):**
- Renamed to avoid any collision surface with the toolbox: `anax2quat`→`anax2qter`, `quat2anax`→`qter2anax`.
- New functions on the active ZYZ convention, house style throughout: `euler2qter` (closed-form ZYZ half-angle composition, vectorised), `qter2euler` (well-conditioned atan2 extraction, beta in [0,pi], degenerate cases clean, vectorised), `qter2dcm` (active quaternion DCM), `dcm2qter` (Shepperd best-pivot method, non-negative scalar part).
- Consumers rewired off the toolbox: `grid_kron` (euler2qter → same inline Hamilton product → qter2euler), `repulsion` 4-D branch (qter2euler), `rotations_1` tests 5–7 (now close entirely in-family), both transform suites (renames plus four new convention pins), `x2spinach` quaternion branch (direct `qter2dcm`, pole-free).
- **Zero Aerospace Toolbox calls remain anywhere in kernel, experiments, interfaces, etc, tests, or examples** (measured: sweep of all 150 toolbox names over the tree, no call sites; name-collision intersection also empty).

**Validation (measured, R2026a, 200-sample random sweeps):** against the toolbox with transposes in place — qter2dcm equals quat2dcm-transpose at 1.2e-15, dcm2qter equals dcm2quat-of-transpose at 4.6e-16, euler2qter equals angle2quat-ZYZ at 5.6e-16, qter2euler equals quat2angle-ZYZ as rotations at 1.7e-15. In-family closures (dcm/euler/anax round trips through the quaternion) all at or below 1.4e-15; degenerate Euler cases 5.3e-16; all four dcm2qter pivot branches and the ±identity poles exact. Consumers: grid_kron reproduces the stock (toolbox) product grid to 2.2e-15 in rotation with weights exactly equal; the repulsion conversion matches the stock route at 2.3e-15; rotation (27), roundtrip (14), and grid-geometry (42) suites pass; rotations_1 runs clean; the seven-spin SpinXML probe agrees across all four orientation paths (0 to 1.7e-15) and the quaternion pole imports exactly. House style and checkcode clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Round 3 — closed-form dcm2euler (IK request):** the grid-search-plus-fminunc implementation is replaced by the closed form: the quaternion of the Frobenius-nearest proper rotation is the dominant eigenvector of the 4×4 Davenport matrix built linearly from the nine DCM elements (Bar-Itzhack, J. Guid. Control Dyn. 23 (2000) 1085), and the angles come out through the branch-free `qter2euler`. Interface, output ranges, the correct-answer-or-informative-error contract, and all grumble gates are preserved verbatim; one gate is added: NaN/Inf inputs are now refused (previously they silently passed both tolerance gates, because NaN comparisons are false, and returned garbage). The suite reconstruction pins tighten from 1e-7 to 1e-14 and gain β=0, β=π, and corrupted-input cases.

**Adversarial validation (measured, R2026a):** reconstruction at 3.4e-15 or better over 200,000 random rotations, a 64,000-point Euler lattice including both gimbal endpoints, gimbal offsets down to 1e-15 from both poles, and all Shepperd pivot classes including 180° rotations. On corrupted input: never worse than the generating rotation (optimality margin exactly 0 over 5,000 cases up to the warning zone), agrees with an independent SVD polar projection to 8.6e-15, recovers exact angles under uniform scaling, error bounded by 4.4× the noise scale. Head-to-head against stock on identical inputs: clean-input accuracy 2.2e-4 (old, optimiser floor) vs 2.7e-15 (new); on 2,000 corrupted DCMs the new residual is strictly smaller in **2,000 of 2,000** cases; 85× faster (0.20 s vs 16.98 s per 4,000 calls). All refusal paths fire (reflections, gross corruption, NaN/Inf); the orthogonality warning fires in its documented zone; rotation/roundtrip suites and rotations_1 pass; the euler_sup consumer is at 1e-15.