### PR TITLE
rotenone examples: restore methyl coupling symmetry

### DIFF
--- a/examples/nmr_liquids/cosy45_rotenone.m
+++ b/examples/nmr_liquids/cosy45_rotenone.m
@@ -33,6 +33,10 @@ inter.coupling.scalar{10,11}=9.8;
 inter.coupling.scalar{9,11}=8.1; 
 inter.coupling.scalar{13,14}=1.5; 
 inter.coupling.scalar{12,14}=0.9; 
+inter.coupling.scalar{13,15}=1.5; 
+inter.coupling.scalar{12,15}=0.9; 
+inter.coupling.scalar{13,16}=1.5; 
+inter.coupling.scalar{12,16}=0.9; 
 inter.coupling.scalar{22,22}=0;
 
 % Algorithmic options

--- a/examples/nmr_liquids/cosy90_rotenone.m
+++ b/examples/nmr_liquids/cosy90_rotenone.m
@@ -33,6 +33,10 @@ inter.coupling.scalar{10,11}=9.8;
 inter.coupling.scalar{9,11}=8.1; 
 inter.coupling.scalar{13,14}=1.5; 
 inter.coupling.scalar{12,14}=0.9; 
+inter.coupling.scalar{13,15}=1.5; 
+inter.coupling.scalar{12,15}=0.9; 
+inter.coupling.scalar{13,16}=1.5; 
+inter.coupling.scalar{12,16}=0.9; 
 inter.coupling.scalar{22,22}=0;
 
 % Algorithmic options

--- a/examples/nmr_liquids/ct_cosy_rotenone.m
+++ b/examples/nmr_liquids/ct_cosy_rotenone.m
@@ -32,6 +32,10 @@ inter.coupling.scalar{10,11}=9.8;
 inter.coupling.scalar{9,11}=8.1; 
 inter.coupling.scalar{13,14}=1.5; 
 inter.coupling.scalar{12,14}=0.9; 
+inter.coupling.scalar{13,15}=1.5; 
+inter.coupling.scalar{12,15}=0.9; 
+inter.coupling.scalar{13,16}=1.5; 
+inter.coupling.scalar{12,16}=0.9; 
 inter.coupling.scalar{22,22}=0;
 
 % Algorithmic options

--- a/examples/nmr_spen/psyche_rotenone.m
+++ b/examples/nmr_spen/psyche_rotenone.m
@@ -44,8 +44,6 @@ bas.formalism='sphten-liouv';
 bas.approximation='IK-2';
 bas.connectivity='scalar_couplings';
 bas.space_level=1;
-bas.sym_group={'S3','S3','S3'};
-bas.sym_spins={[14 15 16],[17 18 19],[20 21 22]};
 
 % Algorithmic options
 sys.disable={'pt','colorbar'};

--- a/examples/nmr_spen/psyche_rotenone.m
+++ b/examples/nmr_spen/psyche_rotenone.m
@@ -33,6 +33,10 @@ inter.coupling.scalar{10,11}=9.8;
 inter.coupling.scalar{9,11}=8.1; 
 inter.coupling.scalar{13,14}=1.5; 
 inter.coupling.scalar{12,14}=0.9; 
+inter.coupling.scalar{13,15}=1.5; 
+inter.coupling.scalar{12,15}=0.9; 
+inter.coupling.scalar{13,16}=1.5; 
+inter.coupling.scalar{12,16}=0.9; 
 inter.coupling.scalar{22,22}=0;
 
 % Basis set
@@ -40,6 +44,8 @@ bas.formalism='sphten-liouv';
 bas.approximation='IK-2';
 bas.connectivity='scalar_couplings';
 bas.space_level=1;
+bas.sym_group={'S3','S3','S3'};
+bas.sym_spins={[14 15 16],[17 18 19],[20 21 22]};
 
 % Algorithmic options
 sys.disable={'pt','colorbar'};


### PR DESCRIPTION
**Defect (reported by the symmetry grumbler, reproduced):** `basis()` refuses four of the five rotenone examples with 'the interaction between spins 14 and 12 is not preserved by the S3 symmetry; it differs from the interaction between spins 15 and 12'. Cause: the allylic couplings of the isopropenyl methyl (J(CH3,=CH2trans)=1.5 Hz, J(CH3,=CH2cis)=0.9 Hz) were wired to only one of the three S3-equivalent methyl protons (spin 14) in cosy45, cosy90, ct_cosy, and psyche — physically all three carry them, and `pa_rotenone` already specifies exactly that.

**Literature check (per IK request):** the shifts and couplings in the shipped specification were verified against published rotenone data — the cited J. Heterocycl. Chem. 25 (1988) 148 source values are corroborated by modern measurements: the Thieme rotenoid-synthesis characterisation (10.1055/s-0037-1611654: H-10/H-11 d 8.6 Hz, OCH2 dd 12.1/3.1, H-6a dd 4.1/3.1, singlet aromatics 6.76/6.45) and Jeong et al., Int. J. Mol. Sci. 24 (2023) 6095 (acetone-d6, 600 MHz: same pattern with solvent-shifted deltas; methyl and =CH2 resonances with unresolved small allylic splittings). No shift or J value required changing; the defect was purely the symmetry-incomplete methyl wiring.

**Fix:** the two allylic couplings are extended to all three methyl protons in the four affected examples (six coupling entries, matching pa_rotenone). `psyche_rotenone` keeps its symmetry-free basis: the imaging context that runs it explicitly refuses symmetry declarations (measured: 'symmetry treatment is not supported in imaging simulations.'), so its specification is corrected in the couplings only — the review round caught an earlier draft of this PR that had added the declaration there.

**Validation (measured, R2026a):** the corrected specification passes the symmetry grumbler (previously the measured refusal above); the declared symmetry is dynamically consistent — a 256-point acquire FID with the symmetry declaration agrees with the symmetry-free reference at 2.7e-8 relative (propagation-tolerance scale); `cosy45_rotenone` runs end-to-end; the psyche imaging-context gate was measured both ways (refusal with a declaration, clean pass without). House style parity exact against stock; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)