### PR TITLE
v2spinach.m, b2spinach.m: Varian and Bruker time-domain data import from GNAT

### DIFF
--- a/interfaces/b2spinach.m
+++ b/interfaces/b2spinach.m
@@ -43,7 +43,14 @@
 %
 %     bdata.ndims_data  - number of dimensions in the data set
 %
-%     bdata.arraydim    - number of fids in the data set
+%     bdata.arraydim    - number of fids the status parameter
+%                         files declare as acquired
+%
+%     bdata.fids_in_file - number of fid slots held by the bina-
+%                         ry file, and the column count of the
+%                         fid matrix; exceeds arraydim when the
+%                         acquisition was preallocated or inter-
+%                         rupted
 %
 %     bdata.npoints     - complex points per fid
 %
@@ -165,7 +172,12 @@ else
 end
 
 % Digital filter group delay in complex points
-if isfield(bdata.acqus,'GRPDLY')&&(bdata.acqus.GRPDLY~=-1)
+if isfield(bdata.acqus,'DIGMOD')&&(bdata.acqus.DIGMOD==0)
+
+    % Analogue filtering has no group delay
+    bdata.digshift=0;
+
+elseif isfield(bdata.acqus,'GRPDLY')&&(bdata.acqus.GRPDLY~=-1)
 
     % Modern hardware reports the group delay directly
     bdata.digshift=bdata.acqus.GRPDLY;
@@ -177,31 +189,49 @@ elseif isfield(bdata.acqus,'DECIM')&&(bdata.acqus.DECIM~=1)
             256 384 512 768 1024 1536 2048];
 
     % Group delay table, one row per DECIM, columns DSPFVS 10 to 12
-    delays=[44.750  46.000  46.311; 33.500  36.500  36.530;
-            66.625  48.000  47.870; 59.083  50.167  50.229;
-            68.563  53.250  53.289; 60.375  69.500  69.551;
-            69.531  72.250  71.600; 61.021  70.167  70.184;
-            70.016  72.750  72.138; 61.344  70.500  70.528;
-            70.258  73.000  72.348; 61.505  70.667  70.700;
-            70.379  72.500  72.524; 61.586  71.333     NaN;
-            70.439  72.250     NaN; 61.626  71.667     NaN;
-            70.470  72.125     NaN; 61.647  71.833     NaN;
-            70.485  72.063     NaN; 61.657  71.917     NaN;
-            70.492  72.031     NaN];
+    delays=[44.7500000000  46.000  46.311; 33.5000000000  36.500  36.530;
+            66.6250000000  48.000  47.870; 59.0833333333  50.167  50.229;
+            68.5625000000  53.250  53.289; 60.3750000000  69.500  69.551;
+            69.5312500000  72.250  71.600; 61.0208333333  70.167  70.184;
+            70.0156250000  72.750  72.138; 61.3437500000  70.500  70.528;
+            70.2578125000  73.000  72.348; 61.5052083333  70.667  70.700;
+            70.3789062500  72.500  72.524; 61.5859375000  71.333     NaN;
+            70.4394531250  72.250     NaN; 61.6263020833  71.667     NaN;
+            70.4697265625  72.125     NaN; 61.6464843750  71.833     NaN;
+            70.4848632813  72.063     NaN; 61.6565755208  71.917     NaN;
+            70.4924316406  72.031     NaN];
 
     % Make sure the firmware version is present
     if ~isfield(bdata.acqus,'DSPFVS')
         error('DECIM without DSPFVS in acqus: cannot get the group delay.');
     end
 
-    % Locate the firmware and decimation combination
+    % Locate the decimation factor
     decim_row=find(decims==bdata.acqus.DECIM,1);
-    dspfvs_col=bdata.acqus.DSPFVS-9;
-    if isempty(decim_row)||(dspfvs_col<1)||(dspfvs_col>3)||...
-       isnan(delays(decim_row,dspfvs_col))
-        error('unknown DECIM and DSPFVS combination in acqus.');
+    if isempty(decim_row)
+        error('unknown DECIM value in acqus.');
     end
-    bdata.digshift=delays(decim_row,dspfvs_col);
+
+    % Branch on the firmware version
+    if (bdata.acqus.DSPFVS>=10)&&(bdata.acqus.DSPFVS<=12)
+
+        % Tabulated group delays of the DMX generation
+        bdata.digshift=delays(decim_row,bdata.acqus.DSPFVS-9);
+        if isnan(bdata.digshift)
+            error('unknown DECIM and DSPFVS combination in acqus.');
+        end
+
+    elseif bdata.acqus.DSPFVS==13
+
+        % Closed form group delay of the 13 firmware family
+        bdata.digshift=3-1/(2*bdata.acqus.DECIM);
+
+    else
+
+        % Complain and bomb out
+        error('unknown DSPFVS value in acqus.');
+
+    end
 
 else
 
@@ -248,24 +278,24 @@ bin_file=fopen(bin_path,'r',byte_order);
 data_pts=fread(bin_file,inf,data_type);
 fclose(bin_file);
 
-% Match the point count to padded or unpadded layout
-if numel(data_pts)==padded_pts*bdata.arraydim
-
-    % Reshape and drop the block padding
-    data_pts=reshape(data_pts,[padded_pts bdata.arraydim]);
-    data_pts=data_pts(1:(2*bdata.npoints),:);
-
-elseif numel(data_pts)==2*bdata.npoints*bdata.arraydim
-
-    % Reshape the unpadded data
-    data_pts=reshape(data_pts,[2*bdata.npoints bdata.arraydim]);
-
+% Get the per-fid stride, padded or unpadded
+if mod(numel(data_pts),padded_pts)==0
+    fid_stride=padded_pts;
+elseif mod(numel(data_pts),2*bdata.npoints)==0
+    fid_stride=2*bdata.npoints;
 else
-
-    % Complain and bomb out
     error('the size of the data file does not match the acqus parameters.');
-
 end
+
+% Count the fids held by the file, at least the declared number
+bdata.fids_in_file=numel(data_pts)/fid_stride;
+if bdata.fids_in_file<bdata.arraydim
+    error('the data file holds fewer fids than the status parameters declare.');
+end
+
+% Reshape and drop the block padding
+data_pts=reshape(data_pts,[fid_stride bdata.fids_in_file]);
+data_pts=data_pts(1:(2*bdata.npoints),:);
 
 % Assemble complex fids using the Bruker sign convention
 bdata.fid=data_pts(1:2:end,:)-1i*data_pts(2:2:end,:);

--- a/interfaces/b2spinach.m
+++ b/interfaces/b2spinach.m
@@ -50,7 +50,10 @@
 %                         ry file, and the column count of the
 %                         fid matrix; exceeds arraydim when the
 %                         acquisition was preallocated or inter-
-%                         rupted
+%                         rupted, and falls short of it for non-
+%                         uniformly sampled data sets, where the
+%                         fids follow the acquisition order of
+%                         the sampling schedule in nus_list
 %
 %     bdata.npoints     - complex points per fid
 %
@@ -167,8 +170,8 @@ bdata.at=bdata.npoints/(bdata.sw_ppm*bdata.sfrq);
 if isfield(bdata,'procs')
     bdata.spec_start=bdata.procs.OFFSET-bdata.sw_ppm;
 else
-    bdata.spec_start=1e6*(bdata.acqus.SFO1/bdata.acqus.BF1-1)+...
-                     (0.5*bdata.acqus.SFO1/bdata.acqus.BF1-1)*bdata.sw_ppm;
+    bdata.spec_start=1e6*(bdata.acqus.SFO1/bdata.acqus.BF1-1)-...
+                     0.5*bdata.sw_ppm*bdata.acqus.SFO1/bdata.acqus.BF1;
 end
 
 % Digital filter group delay in complex points
@@ -254,7 +257,9 @@ end
 switch bdata.acqus.DTYPA
     case 0
         data_type='int32'; block_pts=256;
-    case {1,2}
+    case 1
+        data_type='float32'; block_pts=256;
+    case 2
         data_type='float64'; block_pts=128;
     otherwise
         error('unknown DTYPA value in acqus.');
@@ -289,7 +294,7 @@ end
 
 % Count the fids held by the file, at least the declared number
 bdata.fids_in_file=numel(data_pts)/fid_stride;
-if bdata.fids_in_file<bdata.arraydim
+if (bdata.fids_in_file<bdata.arraydim)&&(~isfile([inpath filesep 'nuslist']))
     error('the data file holds fewer fids than the status parameters declare.');
 end
 
@@ -416,6 +421,8 @@ for n=1:numel(all_lines)
     % Convert time unit suffixes into multipliers
     text_line=all_lines{n};
     switch text_line(end)
+        case 'n'
+            multiplier=1e-9; text_line=text_line(1:(end-1));
         case 'u'
             multiplier=1e-6; text_line=text_line(1:(end-1));
         case 'm'

--- a/interfaces/b2spinach.m
+++ b/interfaces/b2spinach.m
@@ -1,0 +1,427 @@
+% Imports time-domain NMR data recorded by Bruker instruments:
+% reads the binary fid or ser file together with the acquisiti-
+% on and processing parameter files from the numbered experi-
+% ment directory. Syntax:
+%
+%                      bdata=b2spinach(inpath)
+%
+% Parameters:
+%
+%     inpath  -  character string with the path to the numbered
+%                Bruker experiment directory containing the ac-
+%                qus file and the fid or ser file
+%
+% Outputs:
+%
+%     bdata.fid         - matrix of complex free induction de-
+%                         cays, one per column, in the order
+%                         they are stored in the file; for data
+%                         sets with three and more dimensions
+%                         the loop order over the indirect di-
+%                         mensions is determined by the AQSEQ
+%                         parameter of the acqus structure
+%
+%     bdata.acqus       - structure with every parameter found
+%                         in the acqus file: numeric parameters
+%                         as scalars or column vectors, string
+%                         parameters as character strings or
+%                         cell arrays thereof
+%
+%     bdata.acqu2s      - same for the acqu2s file of data sets
+%                         with two or more dimensions
+%
+%     bdata.acqu3s      - same for the acqu3s file of data sets
+%                         with three or more dimensions
+%
+%     bdata.acqu4s      - same for the acqu4s file of four-di-
+%                         mensional data sets
+%
+%     bdata.procs       - same for the procs file of the first
+%                         processed data directory when present
+%
+%     bdata.dirname     - experiment directory name
+%
+%     bdata.ndims_data  - number of dimensions in the data set
+%
+%     bdata.arraydim    - number of fids in the data set
+%
+%     bdata.npoints     - complex points per fid
+%
+%     bdata.pulprog     - pulse programme name
+%
+%     bdata.nucleus     - observe nucleus, e.g. '1H'
+%
+%     bdata.gamma       - magnetogyric ratio of the observe
+%                         nucleus, rad/(s*T)
+%
+%     bdata.sfrq        - spectrometer frequency, MHz
+%
+%     bdata.at          - acquisition time, seconds
+%
+%     bdata.sw_ppm      - spectral width, ppm
+%
+%     bdata.spec_start  - lower edge of the spectrum, ppm
+%
+%     bdata.digshift    - group delay of the digital filter in
+%                         complex points; the first round(dig-
+%                         shift) points of each fid precede the
+%                         start of the true signal
+%
+%     bdata.grad_amps   - gradient amplitudes, T/m, present
+%                         when the difflist file exists
+%
+%     bdata.vd_list     - variable delay list, seconds, present
+%                         when the vdlist file exists
+%
+%     bdata.vc_list     - variable counter list, present when
+%                         the vclist file exists
+%
+%     bdata.nus_list    - non-uniform sampling schedule, pre-
+%                         sent when the nuslist file exists
+%
+% Adapted from the brukerimport() function of the GNAT package by:
+%
+%   Dr. Mathias Nilsson
+%   School of Chemistry, University of Manchester,
+%   Oxford Road, Manchester M13 9PL, UK
+%   mathias.nilsson@manchester.ac.uk
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=b2spinach.m>
+
+function bdata=b2spinach(inpath)
+
+% Check consistency
+grumble(inpath);
+
+% Store the directory name
+bdata.dirname=inpath;
+
+% Refuse data with more than four dimensions
+if isfile([inpath filesep 'acqu5s'])
+    error('data sets with more than four dimensions are not supported.');
+end
+
+% Detect data dimension from the status parameter files
+if isfile([inpath filesep 'acqu4s'])
+    bdata.ndims_data=4;
+elseif isfile([inpath filesep 'acqu3s'])
+    bdata.ndims_data=3;
+elseif isfile([inpath filesep 'acqu2s'])
+    bdata.ndims_data=2;
+else
+    bdata.ndims_data=1;
+end
+
+% Read acquisition status parameters for every dimension
+bdata.acqus=read_jcamp([inpath filesep 'acqus']);
+if bdata.ndims_data>=2
+    bdata.acqu2s=read_jcamp([inpath filesep 'acqu2s']);
+end
+if bdata.ndims_data>=3
+    bdata.acqu3s=read_jcamp([inpath filesep 'acqu3s']);
+end
+if bdata.ndims_data>=4
+    bdata.acqu4s=read_jcamp([inpath filesep 'acqu4s']);
+end
+
+% Read processing parameters when present
+if isfile([inpath filesep 'pdata' filesep '1' filesep 'procs'])
+    bdata.procs=read_jcamp([inpath filesep 'pdata' filesep '1' filesep 'procs']);
+end
+
+% Count the fids in the data set
+bdata.arraydim=1;
+if bdata.ndims_data>=2, bdata.arraydim=bdata.arraydim*bdata.acqu2s.TD; end
+if bdata.ndims_data>=3, bdata.arraydim=bdata.arraydim*bdata.acqu3s.TD; end
+if bdata.ndims_data>=4, bdata.arraydim=bdata.arraydim*bdata.acqu4s.TD; end
+
+% Complex points per fid
+bdata.npoints=bdata.acqus.TD/2;
+
+% Pulse programme name and observe nucleus
+bdata.pulprog=bdata.acqus.PULPROG;
+bdata.nucleus=bdata.acqus.NUC1;
+
+% Magnetogyric ratio of the observe nucleus
+bdata.gamma=spin(bdata.nucleus);
+
+% Spectrometer frequency, MHz
+bdata.sfrq=bdata.acqus.SFO1;
+
+% Spectral width, ppm
+bdata.sw_ppm=bdata.acqus.SW;
+
+% Acquisition time, seconds
+bdata.at=bdata.npoints/(bdata.sw_ppm*bdata.sfrq);
+
+% Spectrum lower edge from processing or acquisition parameters
+if isfield(bdata,'procs')
+    bdata.spec_start=bdata.procs.OFFSET-bdata.sw_ppm;
+else
+    bdata.spec_start=1e6*(bdata.acqus.SFO1/bdata.acqus.BF1-1)+...
+                     (0.5*bdata.acqus.SFO1/bdata.acqus.BF1-1)*bdata.sw_ppm;
+end
+
+% Digital filter group delay in complex points
+if isfield(bdata.acqus,'GRPDLY')&&(bdata.acqus.GRPDLY~=-1)
+
+    % Modern hardware reports the group delay directly
+    bdata.digshift=bdata.acqus.GRPDLY;
+
+elseif isfield(bdata.acqus,'DECIM')&&(bdata.acqus.DECIM~=1)
+
+    % Decimation factors of older DSP firmware
+    decims=[2 3 4 6 8 12 16 24 32 48 64 96 128 192 ...
+            256 384 512 768 1024 1536 2048];
+
+    % Group delay table, one row per DECIM, columns DSPFVS 10 to 12
+    delays=[44.750  46.000  46.311; 33.500  36.500  36.530;
+            66.625  48.000  47.870; 59.083  50.167  50.229;
+            68.563  53.250  53.289; 60.375  69.500  69.551;
+            69.531  72.250  71.600; 61.021  70.167  70.184;
+            70.016  72.750  72.138; 61.344  70.500  70.528;
+            70.258  73.000  72.348; 61.505  70.667  70.700;
+            70.379  72.500  72.524; 61.586  71.333     NaN;
+            70.439  72.250     NaN; 61.626  71.667     NaN;
+            70.470  72.125     NaN; 61.647  71.833     NaN;
+            70.485  72.063     NaN; 61.657  71.917     NaN;
+            70.492  72.031     NaN];
+
+    % Make sure the firmware version is present
+    if ~isfield(bdata.acqus,'DSPFVS')
+        error('DECIM without DSPFVS in acqus: cannot get the group delay.');
+    end
+
+    % Locate the firmware and decimation combination
+    decim_row=find(decims==bdata.acqus.DECIM,1);
+    dspfvs_col=bdata.acqus.DSPFVS-9;
+    if isempty(decim_row)||(dspfvs_col<1)||(dspfvs_col>3)||...
+       isnan(delays(decim_row,dspfvs_col))
+        error('unknown DECIM and DSPFVS combination in acqus.');
+    end
+    bdata.digshift=delays(decim_row,dspfvs_col);
+
+else
+
+    % Data without digital filtering
+    bdata.digshift=0;
+
+end
+
+% Binary data byte order
+switch bdata.acqus.BYTORDA
+    case 0
+        byte_order='l';
+    case 1
+        byte_order='b';
+    otherwise
+        error('unknown BYTORDA value in acqus.');
+end
+
+% Binary data type and file block size in points
+switch bdata.acqus.DTYPA
+    case 0
+        data_type='int32'; block_pts=256;
+    case {1,2}
+        data_type='float64'; block_pts=128;
+    otherwise
+        error('unknown DTYPA value in acqus.');
+end
+
+% Stored points per fid, padded to whole 1024-byte blocks
+padded_pts=block_pts*ceil(2*bdata.npoints/block_pts);
+
+% Locate the binary data file
+if bdata.ndims_data==1
+    bin_path=[inpath filesep 'fid'];
+else
+    bin_path=[inpath filesep 'ser'];
+end
+if ~isfile(bin_path)
+    error(['file not found: ' bin_path]);
+end
+
+% Read the binary data
+bin_file=fopen(bin_path,'r',byte_order);
+data_pts=fread(bin_file,inf,data_type);
+fclose(bin_file);
+
+% Match the point count to padded or unpadded layout
+if numel(data_pts)==padded_pts*bdata.arraydim
+
+    % Reshape and drop the block padding
+    data_pts=reshape(data_pts,[padded_pts bdata.arraydim]);
+    data_pts=data_pts(1:(2*bdata.npoints),:);
+
+elseif numel(data_pts)==2*bdata.npoints*bdata.arraydim
+
+    % Reshape the unpadded data
+    data_pts=reshape(data_pts,[2*bdata.npoints bdata.arraydim]);
+
+else
+
+    % Complain and bomb out
+    error('the size of the data file does not match the acqus parameters.');
+
+end
+
+% Assemble complex fids using the Bruker sign convention
+bdata.fid=data_pts(1:2:end,:)-1i*data_pts(2:2:end,:);
+
+% Apply the binary scaling exponent
+bdata.fid=(2^bdata.acqus.NC)*bdata.fid;
+
+% Gradient amplitudes in T/m when a difflist file is present
+if isfile([inpath filesep 'difflist'])
+    bdata.grad_amps=0.01*read_list([inpath filesep 'difflist']);
+elseif isfile([inpath filesep 'difflist.txt'])
+    bdata.grad_amps=0.01*read_list([inpath filesep 'difflist.txt']);
+end
+
+% Variable delay list in seconds when present
+if isfile([inpath filesep 'vdlist'])
+    bdata.vd_list=read_list([inpath filesep 'vdlist']);
+end
+
+% Variable counter list when present
+if isfile([inpath filesep 'vclist'])
+    bdata.vc_list=read_list([inpath filesep 'vclist']);
+end
+
+% Non-uniform sampling schedule when present
+if isfile([inpath filesep 'nuslist'])
+    bdata.nus_list=read_list([inpath filesep 'nuslist']);
+end
+
+end
+
+% Reads a Bruker JCAMP-DX parameter file into a structure
+function params=read_jcamp(file_path)
+
+% Read the file as a cell array of lines
+all_lines=regexp(fileread(file_path),'\r?\n','split');
+
+% Loop over the lines
+params=struct(); line_num=1;
+while line_num<=numel(all_lines)
+
+    % Read the next line
+    text_line=all_lines{line_num}; line_num=line_num+1;
+
+    % Only private parameter lines are of interest
+    if ~strncmp(text_line,'##$',3), continue; end
+
+    % Cut off inline comments
+    dollar_pos=strfind(text_line,'$$');
+    if ~isempty(dollar_pos)
+        text_line=text_line(1:(dollar_pos(1)-1));
+    end
+
+    % Split the name from the value
+    eq_pos=find(text_line=='=',1);
+    par_name=text_line(4:(eq_pos-1));
+    par_value=strtrim(text_line((eq_pos+1):end));
+
+    % Assemble multi-line array values
+    if ~isempty(regexp(par_value,'^\(\d+\.\.\d+\)$','once'))
+        par_value='';
+        while line_num<=numel(all_lines)
+            next_line=all_lines{line_num};
+            if strncmp(next_line,'##',2)||strncmp(next_line,'$$',2)
+                break;
+            end
+            par_value=[par_value ' ' next_line]; line_num=line_num+1; %#ok<AGROW>
+        end
+        par_value=strtrim(par_value);
+    end
+
+    % Branch on the value type
+    if any(par_value=='<')
+
+        % Strip the angle brackets from strings
+        str_toks=regexp(par_value,'<([^<>]*)>','tokens');
+        str_toks=[str_toks{:}];
+
+        % Store single strings as characters, string lists as cells
+        if isscalar(str_toks)
+            params.(par_name)=str_toks{1};
+        else
+            params.(par_name)=str_toks;
+        end
+
+    else
+
+        % Convert to numbers with text fallback
+        [num_value,~,~,next_idx]=sscanf(par_value,'%f');
+        if isempty(num_value)||(next_idx<=numel(par_value))
+            params.(par_name)=par_value;
+        else
+            params.(par_name)=num_value;
+        end
+
+    end
+
+end
+
+end
+
+% Reads a Bruker list file with optional time unit suffixes
+function vals=read_list(file_path)
+
+% Read the file as a cell array of lines
+all_lines=regexp(fileread(file_path),'\r?\n','split');
+
+% Drop empty lines
+all_lines=strtrim(all_lines);
+all_lines=all_lines(~cellfun(@isempty,all_lines));
+
+% Preallocate the values
+vals=zeros(numel(all_lines),1);
+
+% Loop over the lines
+for n=1:numel(all_lines)
+
+    % Convert time unit suffixes into multipliers
+    text_line=all_lines{n};
+    switch text_line(end)
+        case 'u'
+            multiplier=1e-6; text_line=text_line(1:(end-1));
+        case 'm'
+            multiplier=1e-3; text_line=text_line(1:(end-1));
+        case 's'
+            multiplier=1;    text_line=text_line(1:(end-1));
+        otherwise
+            multiplier=1;
+    end
+
+    % Convert the value into a number
+    vals(n)=multiplier*str2double(text_line);
+
+    % Make sure the conversion succeeded
+    if isnan(vals(n))
+        error(['cannot interpret list file entry: ' all_lines{n}]);
+    end
+
+end
+
+end
+
+% Consistency enforcement
+function grumble(inpath)
+if ~ischar(inpath)
+    error('inpath must be a character string.');
+end
+if ~isfolder(inpath)
+    error(['directory ' inpath ' does not exist.']);
+end
+if ~isfile([inpath filesep 'acqus'])
+    error(['no acqus file in ' inpath]);
+end
+end
+
+% The purpose of computing is insight, not numbers.
+%
+% Richard Hamming
+

--- a/interfaces/skills/spinach-simulations/references/inputs.md
+++ b/interfaces/skills/spinach-simulations/references/inputs.md
@@ -396,10 +396,14 @@ chemical shifts, J-couplings, a non-selective line width and the magnet field;
 everything else has to be added by hand.
 `[sys,inter]=x2spinach(filename,shielding_refs)` reads SpinXML files.
 
-Two importers handle data rather than parameters, and neither produces `sys` or
-`inter`. `vdata=v2spinach(inpath)` reads an experimental FID in Varian format
-from a data directory, returning `vdata.fid` and the acquisition header fields;
-it has nothing to do with VASP. `mesh=comsol_import(comsol)` imports a COMSOL 2D
+Three importers handle data rather than parameters, and none of them produces
+`sys` or `inter`. `vdata=v2spinach(inpath)` reads experimental FIDs in Varian
+format from a data directory, returning `vdata.fid`, the acquisition header
+fields, the fully parsed `procpar`, and derived spectral and diffusion
+parameters; it has nothing to do with VASP. `bdata=b2spinach(inpath)` does the
+same for Bruker experiment directories: fid or ser data, the acquisition and
+processing parameter files, the digital filter group delay, and the gradient
+and delay lists when present. `mesh=comsol_import(comsol)` imports a COMSOL 2D
 mesh for the `meshflow` context from `comsol.mesh_file` and `comsol.velo_file`,
 with `comsol.crop` and `comsol.inactivate` controlling the retained region.
 

--- a/interfaces/v2spinach.m
+++ b/interfaces/v2spinach.m
@@ -1,24 +1,95 @@
-% Imports NMR fid data in Varian format. Syntax:
+% Imports time-domain NMR data recorded by Varian and Agilent inst-
+% ruments: reads the binary fid file and the procpar parameter file
+% from the experiment directory. Syntax:
 %
-%               vdata=v2spinach(inpath)
+%                      vdata=v2spinach(inpath)
 %
 % Parameters:
 %
-%  inpath - character strong with the path to the 
-%           Varian data folder
+%     inpath  -  character string with the path to the experiment
+%                directory containing fid and procpar files
 %
 % Outputs:
 %
-%  vdata.fid      - complex free induction decay, one
-%                   column per trace in file order
+%     vdata.fid         - matrix of complex free induction decays,
+%                         one per column, in the order they appear
+%                         in the file: traces within a data block
+%                         run first, data blocks run second
 %
-% Modified for Spinach from the function by:
+%     vdata.procpar     - structure with every parameter found in
+%                         the procpar file: numeric parameters as
+%                         column vectors, string parameters as
+%                         character strings or cell arrays thereof
+%
+%     vdata.dirname     - experiment directory name
+%
+%     vdata.nblocks     - number of data blocks in the fid file
+%
+%     vdata.ntraces     - number of traces in each data block
+%
+%     vdata.np          - stored points per trace, real and imagi-
+%                         nary parts counted separately
+%
+%     vdata.ebytes      - bytes per stored data point
+%
+%     vdata.tbytes      - bytes per trace
+%
+%     vdata.bbytes      - bytes per data block
+%
+%     vdata.version_id  - VnmrJ version identifier
+%
+%     vdata.status      - fid file status bitfield
+%
+%     vdata.nbheaders   - number of block headers per data block
+%
+%     vdata.block       - block header array with fields: scale,
+%                         status, bitstatus, index, mode, ctcount,
+%                         lpval, rpval, lvl, and tlt
+%
+%     vdata.npoints     - complex points per trace
+%
+%     vdata.arraydim    - number of elements in the parameter array
+%
+%     vdata.sfrq        - spectrometer frequency, MHz
+%
+%     vdata.at          - acquisition time, seconds
+%
+%     vdata.sw_ppm      - spectral width, ppm
+%
+%     vdata.spec_start  - lower edge of the spectrum, ppm
+%
+%     vdata.ni          - increment count of the indirect dimensi-
+%                         on, present when procpar specifies it
+%
+%     vdata.grad_amps   - diffusion gradient amplitudes, T/m, pre-
+%                         sent when procpar holds a gradient array
+%                         and a gradient calibration factor
+%
+%     vdata.big_delta   - diffusion delay, seconds, present when
+%                         procpar specifies it
+%
+%     vdata.small_delta - diffusion encoding gradient duration,
+%                         seconds, present when procpar specifies it
+%
+%     vdata.gamma       - magnetogyric ratio used by the diffusion
+%                         sequence, rad/(s*T), present when procpar
+%                         specifies it
+%
+%     vdata.dosy_const  - Stejskal-Tanner time factor: gamma^2 mul-
+%                         tiplied by the effective delta^2*(DELTA-
+%                         delta/3) term of the pulse sequence, pre-
+%                         sent when procpar specifies it; the sig-
+%                         nal attenuation in a pulsed field gradi-
+%                         ent experiment is exp(-dosy_const*g^2*D)
+%                         where g is the gradient amplitude in T/m
+%                         and D is the diffusion coefficient
+%                         in m^2/s
+%
+% Adapted from the varianimport() function of the GNAT package by:
 %
 %   Dr. Mathias Nilsson
 %   School of Chemistry, University of Manchester,
 %   Oxford Road, Manchester M13 9PL, UK
-%   Telephone: +44 (0) 161 306 4465
-%   Fax: +44 (0) 161 275 4598
 %   mathias.nilsson@manchester.ac.uk
 %
 % ilya.kuprov@weizmann.ac.il
@@ -27,86 +98,231 @@
 
 function vdata=v2spinach(inpath)
 
-% Get the fid file
-if nargin==0
-    inpath=uigetdir(pwd,'Varian data directory');
-end
-
 % Check consistency
 grumble(inpath);
-
-% Open the file
-fileid_fid=fopen([inpath filesep 'fid'],'r','b');
 
 % Store the directory name
 vdata.dirname=inpath;
 
-% Read the header
-vdata.nblocks=fread(fileid_fid,1,'int32');
-vdata.ntraces=fread(fileid_fid,1,'int32');
-vdata.np=fread(fileid_fid,1,'int32');
-vdata.ebytes=fread(fileid_fid,1,'int32'); 
-vdata.tbytes=fread(fileid_fid,1,'int32'); 
-vdata.bbytes=fread(fileid_fid,1,'int32'); 
-vdata.version_id=fread(fileid_fid,1,'int16'); 
-vdata.status=fread(fileid_fid,1,'int16'); 
-vdata.nbheaders=fread(fileid_fid,1,'int32');
+% Open the fid file, big-endian
+fid_file=fopen([inpath filesep 'fid'],'r','b');
 
-% Preallocate fid array
-vdata.fid=zeros(vdata.np/2,vdata.ntraces*vdata.nblocks,'like',1i);
+% Read the fid file header
+vdata.nblocks=fread(fid_file,1,'int32');
+vdata.ntraces=fread(fid_file,1,'int32');
+vdata.np=fread(fid_file,1,'int32');
+vdata.ebytes=fread(fid_file,1,'int32');
+vdata.tbytes=fread(fid_file,1,'int32');
+vdata.bbytes=fread(fid_file,1,'int32');
+vdata.version_id=fread(fid_file,1,'int16');
+vdata.status=fread(fid_file,1,'int16');
+vdata.nbheaders=fread(fid_file,1,'int32');
 
-% Read in fid blocks
-for m=1:vdata.nblocks
-    
-    % Read in block header
-    vdata.block(m).scale=fread(fileid_fid,1,'int16');
-    vdata.block(m).status=fread(fileid_fid,1,'int16');
-    vdata.block(m).bitstatus=bitget(uint16(vdata.block(m).status),1:16);
-    vdata.block(m).index=fread(fileid_fid,1,'int16'); 
-    vdata.block(m).mode=fread(fileid_fid,1,'int16'); 
-    vdata.block(m).ctcount=fread(fileid_fid,1,'int32');
-    vdata.block(m).lpval=fread(fileid_fid,1,'float32'); 
-    vdata.block(m).rpval=fread(fileid_fid,1,'float32'); 
-    vdata.block(m).lvl=fread(fileid_fid,1,'float32');
-    vdata.block(m).tlt=fread(fileid_fid,1,'float32');
+% Check the header for internal consistency
+if (vdata.tbytes~=vdata.np*vdata.ebytes)||...
+   (vdata.bbytes~=28*vdata.nbheaders+vdata.ntraces*vdata.tbytes)
+    error('inconsistent trace and block sizes in the fid file header.');
+end
 
-    % Skip any further block headers
-    fseek(fileid_fid,28*(vdata.nbheaders-1),'cof');
+% Preallocate the fid array
+vdata.fid=zeros(vdata.np/2,vdata.nblocks*vdata.ntraces,'like',1i);
 
-    % Read in block fid
-    if vdata.block(m).bitstatus(4)==1
-        fid_data=fread(fileid_fid,vdata.ntraces*vdata.np,'float32');
-    elseif vdata.block(m).bitstatus(3)==1
-        fid_data=fread(fileid_fid,vdata.ntraces*vdata.np,'int32');
-    elseif vdata.block(m).bitstatus(3)==0
-        fid_data=fread(fileid_fid,vdata.ntraces*vdata.np,'int16');
+% Preallocate the block header array
+vdata.block(vdata.nblocks)=struct('scale',[],'status',[],'bitstatus',[],...
+                                  'index',[],'mode',[],'ctcount',[],...
+                                  'lpval',[],'rpval',[],'lvl',[],'tlt',[]);
+
+% Loop over the data blocks
+for n=1:vdata.nblocks
+
+    % Read the block header
+    vdata.block(n).scale=fread(fid_file,1,'int16');
+    vdata.block(n).status=fread(fid_file,1,'int16');
+    vdata.block(n).bitstatus=bitget(uint16(vdata.block(n).status),1:16);
+    vdata.block(n).index=fread(fid_file,1,'int16');
+    vdata.block(n).mode=fread(fid_file,1,'int16');
+    vdata.block(n).ctcount=fread(fid_file,1,'int32');
+    vdata.block(n).lpval=fread(fid_file,1,'float32');
+    vdata.block(n).rpval=fread(fid_file,1,'float32');
+    vdata.block(n).lvl=fread(fid_file,1,'float32');
+    vdata.block(n).tlt=fread(fid_file,1,'float32');
+
+    % Skip hypercomplex block headers
+    fseek(fid_file,28*(vdata.nbheaders-1),'cof');
+
+    % Get the data type from the block status bits
+    if vdata.block(n).bitstatus(4)==1
+        data_type='float32';
+    elseif vdata.block(n).bitstatus(3)==1
+        data_type='int32';
     else
-        error('illegal combination in file header status.')
+        data_type='int16';
     end
 
-    % Add to the fid array
-    fid_data=reshape(fid_data,[vdata.np vdata.ntraces]);
-    vdata.fid(:,(m-1)*vdata.ntraces+(1:vdata.ntraces))=...
-        fid_data(1:2:vdata.np,:)+1i*fid_data(2:2:vdata.np,:);
-    
+    % Read the data points of the current block
+    points=fread(fid_file,vdata.np*vdata.ntraces,data_type);
+
+    % Make sure the block was complete
+    if numel(points)<vdata.np*vdata.ntraces
+        error('unexpected end of the fid file.');
+    end
+
+    % Assemble complex fids, one trace per column
+    points=reshape(points,[vdata.np vdata.ntraces]);
+    vdata.fid(:,(n-1)*vdata.ntraces+(1:vdata.ntraces))=...
+                             points(1:2:end,:)+1i*points(2:2:end,:);
+
 end
 
 % Close the fid file
-fclose(fileid_fid);
+fclose(fid_file);
+
+% Open the procpar file
+par_file=fopen([inpath filesep 'procpar'],'rt');
+
+% Loop over the parameters
+while true
+
+    % Read the parameter description line
+    name_line=fgetl(par_file);
+
+    % Exit the loop at the end of the file
+    if ~ischar(name_line), break; end
+
+    % Skip stray empty lines
+    if isempty(strtrim(name_line)), continue; end
+
+    % Get the parameter name and the basic type
+    descr=textscan(name_line,'%s %f %f',1);
+    par_name=descr{1}{1}; basic_type=descr{3};
+
+    % Read the value line
+    val_line=fgetl(par_file);
+
+    % Branch on the basic type
+    if basic_type==1
+
+        % Read the value count and the values
+        numbers=sscanf(val_line,'%f');
+        val_count=numbers(1); par_vals=numbers(2:end);
+
+        % Read further lines if the values continue
+        while numel(par_vals)<val_count
+            val_line=fgetl(par_file);
+            par_vals=[par_vals; sscanf(val_line,'%f')]; %#ok<AGROW>
+        end
+
+        % Store the numeric parameter
+        vdata.procpar.(par_name)=par_vals;
+
+    elseif basic_type==2
+
+        % Read the value count
+        val_count=sscanf(val_line,'%d',1);
+
+        % Loop over the string values
+        str_vals=cell(val_count,1);
+        for k=1:val_count
+
+            % Move on to the next line
+            if k>1, val_line=fgetl(par_file); end
+
+            % Append lines until the closing quote arrives
+            while nnz(val_line=='"')<2
+                next_line=fgetl(par_file);
+                if ~ischar(next_line)
+                    error('unexpected end of the procpar file.');
+                end
+                val_line=[val_line newline next_line]; %#ok<AGROW>
+            end
+
+            % Extract the text between the outermost quotes
+            quote_pos=find(val_line=='"');
+            str_vals{k}=val_line((quote_pos(1)+1):(quote_pos(end)-1));
+
+        end
+
+        % Store single strings as characters, string arrays as cells
+        if val_count==1
+            vdata.procpar.(par_name)=str_vals{1};
+        else
+            vdata.procpar.(par_name)=str_vals;
+        end
+
+    else
+
+        % Complain and bomb out
+        error(['unknown basic type in procpar parameter ' par_name]);
+
+    end
+
+    % Skip the enumeration line
+    fgetl(par_file);
+
+end
+
+% Close the procpar file
+fclose(par_file);
+
+% Complex points per trace
+vdata.npoints=vdata.np/2;
+
+% Array dimension
+vdata.arraydim=vdata.procpar.arraydim;
+
+% Spectrometer frequency, MHz
+vdata.sfrq=vdata.procpar.sfrq;
+
+% Acquisition time, seconds
+vdata.at=vdata.procpar.at;
+
+% Spectral width and lower edge, ppm
+vdata.sw_ppm=vdata.procpar.sw/vdata.procpar.sfrq;
+vdata.spec_start=(vdata.procpar.rfp-vdata.procpar.rfl)/vdata.procpar.sfrq;
+
+% Indirect dimension increment count when present
+if isfield(vdata.procpar,'ni')
+    vdata.ni=vdata.procpar.ni;
+end
+
+% Gradient amplitudes in T/m when calibration data is present
+if isfield(vdata.procpar,'gzlvl1')&&isfield(vdata.procpar,'gcal_')
+    vdata.grad_amps=0.01*vdata.procpar.gcal_*vdata.procpar.gzlvl1;
+elseif isfield(vdata.procpar,'gzlvl1')&&isfield(vdata.procpar,'DAC_to_G')
+    vdata.grad_amps=0.01*vdata.procpar.DAC_to_G*vdata.procpar.gzlvl1;
+end
+
+% Diffusion delay and gradient duration when present
+if isfield(vdata.procpar,'del'), vdata.big_delta=vdata.procpar.del; end
+if isfield(vdata.procpar,'gt1'), vdata.small_delta=vdata.procpar.gt1; end
+
+% Magnetogyric ratio and Stejskal-Tanner factor when present
+if isfield(vdata.procpar,'dosygamma')
+    vdata.gamma=vdata.procpar.dosygamma;
+    if isfield(vdata.procpar,'dosytimecubed')
+        vdata.dosy_const=(vdata.procpar.dosygamma^2)*vdata.procpar.dosytimecubed;
+    end
+end
 
 end
 
 % Consistency enforcement
 function grumble(inpath)
-if isempty(inpath)
-    error('the path string cannot be empty');
-end
 if ~ischar(inpath)
     error('inpath must be a character string.');
 end
+if ~isfolder(inpath)
+    error(['directory ' inpath ' does not exist.']);
+end
+if ~isfile([inpath filesep 'fid'])
+    error(['no fid file in ' inpath]);
+end
+if ~isfile([inpath filesep 'procpar'])
+    error(['no procpar file in ' inpath]);
+end
 end
 
-% I do know how one must live, but I don't 
+% I do know how one must live, but I don't
 % want to live like that.
 %
 % Dmitry Bykov


### PR DESCRIPTION
Ports the Varian and Bruker import functions of the GNAT package (Manchester NMR Methodology Group, Mathias Nilsson et al.) into Spinach house style, as two self-contained files in `interfaces/`.

## v2spinach.m (overwritten)

The previous version read only the fid binary. The new version keeps its output fields and adds:

- full procpar parsing (numeric parameters as column vectors, string parameters as character strings or cell arrays);
- multi-trace data blocks and hypercomplex block headers, which both GNAT and the previous version mishandled (they read one trace per block and one block header);
- fid file header consistency checks;
- derived parameters: complex point count, array dimension, spectrometer frequency, acquisition time, spectral width and lower edge in ppm, and for diffusion data sets the gradient amplitudes in T/m (gcal_ or DAC_to_G calibration), diffusion delays, and the Stejskal-Tanner factor.

Removed relative to the previous version: the zero-argument `uigetdir` branch (optional arguments are against current house policy) and a dead error branch.

## b2spinach.m (new)

Raw Bruker time-domain import for data sets of dimension one to four: acqus/acqu2s/acqu3s/acqu4s and procs parsing, BYTORDA byte order, DTYPA int32/float64 data types, 1024-byte block padding of ser files, the 2^NC binary scaling exponent, digital filter group delay (GRPDLY, with the legacy DECIM/DSPFVS lookup table for older firmware), magnetogyric ratio via kernel `spin()`, and difflist/vdlist (with time unit suffixes)/vclist/nuslist import when those files are present.

Deliberately not ported from GNAT: GUI dialogs and waitbars, per-pulse-sequence diffusion parameter guessing with hardcoded defaults (against Spinach no-guessing policy - all raw parameters are available in the returned acqus structures), and processed-data (1r/2rr) pseudo-fid reconstruction, which is processing rather than import.

## Validation

- Bit-for-bit identical fids against nmrglue 0.12 (independent implementation) on five real data sets from the GNAT paper's companion data (Mendeley 10.17632/pyr9688wvb.2): Varian Oneshot DOSY (780 fids), Bruker Avance II+ 1D int32, Avance NEO 1D float64, 2D Oneshot DOSY ser, 3D PSYCHE-iDOSY ser.
- Bit-for-bit identical fids and identical parameters against the original GNAT functions run headless on the same data. Two deliberate differences: the group delay is returned exact rather than rounded, and 3D fids are returned in file storage order (nmrglue-consistent) rather than GNAT's DOSY-specific reordering - verified to be exactly that column permutation.
- Synthetic edge cases all exact: Varian int16/int32/float32, three traces per block, two block headers per block; Bruker big-endian, unpadded and padded files, legacy DECIM/DSPFVS table, vdlist unit suffixes, and the informative error on unknown filter combinations.
- checkcode clean on both files; house style checker clean.

The Wiki page for v2spinach.m will need a refresh after merge, and a b2spinach.m page creating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)