### PR TITLE
Optimal control module: worker-resident ensemble parallel architecture

### DIFF
--- a/examples/nmr_solids/case_studies/cp_square_vs_ramp/cp_adiabatic_vs_optimcon.m
+++ b/examples/nmr_solids/case_studies/cp_square_vs_ramp/cp_adiabatic_vs_optimcon.m
@@ -88,7 +88,6 @@ control.penalties={'SNS'};                % Penalty
 control.p_weights=100;                    % Penalty weight
 control.method='lbfgs';                   % Optimisation method
 control.max_iter=30;                      % Termination tolerance
-control.parallel='ensemble';              % Parallelisation
 
 % Spinach housekeeping
 spin_system=optimcon(spin_system,control);

--- a/examples/optimal_control/case_studies/Tosner_JMR_2009/bb_inversion_pulse.m
+++ b/examples/optimal_control/case_studies/Tosner_JMR_2009/bb_inversion_pulse.m
@@ -56,7 +56,6 @@ control.penalties={'NS','SNSA'};                 % Penalties
 control.p_weights=[0.01 10];                     % Penalty weights
 control.method='lbfgs';                          % Optimiser
 control.max_iter=200;                            % Max iterations
-control.parallel='ensemble';                     % Parallel mode
 control.plotting={'phi_controls','amp_controls',...
                   'robustness','spectrogram'};
 

--- a/examples/optimal_control/case_studies/Tosner_JMR_2009/bb_refocusing_pulse.m
+++ b/examples/optimal_control/case_studies/Tosner_JMR_2009/bb_refocusing_pulse.m
@@ -53,7 +53,6 @@ control.penalties={'NS','SNS'};                 % Penalties
 control.p_weights=[0.01 100];                   % Penalty weights
 control.method='lbfgs';                         % Optimiser
 control.max_iter=200;                           % Max iterations
-control.parallel='ensemble';                    % Parallel mode
 
 % Visual diagnostics
 control.plotting={'phi_controls','xy_controls',...

--- a/examples/optimal_control/case_studies/Tosner_JMR_2009/coherence_transfer.m
+++ b/examples/optimal_control/case_studies/Tosner_JMR_2009/coherence_transfer.m
@@ -61,7 +61,6 @@ control.penalties={'NS'};                      % Penalties
 control.p_weights=0.01;                        % Penalty weight
 control.method='lbfgs';                        % Optimiser
 control.max_iter=200;                          % Max iterations
-control.parallel='ensemble';                   % Parallel mode
 
 % Visual diagnostics
 control.plotting={'xy_controls','spectrogram','robustness'};

--- a/examples/optimal_control/distortions/distortions_figure_3.m
+++ b/examples/optimal_control/distortions/distortions_figure_3.m
@@ -55,7 +55,6 @@ control.method='lbfgs';                            % Optimisation method
 control.penalties={'NS','SNS'};                    % Penalty types
 control.p_weights=[0.01 10.0];                     % Penalty weights
 control.max_iter=200;                              % Termination condition
-control.parallel='ensemble';                       % Parallelisation
 
 % Last five slices are dead time
 control.freeze=zeros(2,45);

--- a/examples/optimal_control/distortions/distortions_figure_4_bot.m
+++ b/examples/optimal_control/distortions/distortions_figure_4_bot.m
@@ -55,7 +55,6 @@ control.method='lbfgs';                            % Optimisation method
 control.penalties={'NS','SNS'};                    % Penalty types
 control.p_weights=[0.01 0.10];                     % Penalty weights
 control.max_iter=50;                               % Termination condition
-control.parallel='ensemble';                       % Parallelisation
 
 % Last 5 slices are dead time
 control.freeze=zeros(2,125);

--- a/examples/optimal_control/distortions/distortions_figure_4_top.m
+++ b/examples/optimal_control/distortions/distortions_figure_4_top.m
@@ -55,7 +55,6 @@ control.method='lbfgs';                            % Optimisation method
 control.penalties={'NS','SNS'};                    % Penalty types
 control.p_weights=[0.01 0.10];                     % Penalty weights
 control.max_iter=25;                               % Termination condition
-control.parallel='ensemble';                       % Parallelisation
 
 % Last 5 slices are dead time
 control.freeze=zeros(2,125);

--- a/examples/optimal_control/distortions/rlc_response_2.m
+++ b/examples/optimal_control/distortions/rlc_response_2.m
@@ -68,7 +68,6 @@ control.dead_time=100e-6;                      % Dead time
 control.penalties={'NS'};                      % Penalty types
 control.p_weights=1;                           % Penalty weights
 control.method='goodwin';                      % Optimisation method
-control.parallel='ensemble';                   % Parallel strategy
 control.integrator='rectangle';                % Piecewise-constant
 
 % Freeze the edges

--- a/examples/optimal_control/distortions/rlc_response_3.m
+++ b/examples/optimal_control/distortions/rlc_response_3.m
@@ -68,7 +68,6 @@ control.dead_time=100e-6;                      % Dead time
 control.penalties={'NS'};                      % Penalty types
 control.p_weights=1;                           % Penalty weights
 control.method='lbfgs';                        % Optimisation method
-control.parallel='ensemble';                   % Parallel strategy
 control.integrator='trapezium';                % Piecewise-linear
 
 % Freeze the edges

--- a/examples/optimal_control/features_ampl.m
+++ b/examples/optimal_control/features_ampl.m
@@ -61,7 +61,6 @@ control.max_iter=1000;                          % Termination condition
 control.amplitudes=exp(-linspace(-2,2,250).^2); % Amplitude profile
 control.penalties={'DNS'};                      % Penalise non-smooth
 control.p_weights=1;                            % Penalty weight
-control.parallel='ensemble';                    % Parallelisation 
 
 % Plotting options
 control.plotting={'xy_controls','phi_controls',...

--- a/examples/optimal_control/features_curv.m
+++ b/examples/optimal_control/features_curv.m
@@ -58,7 +58,6 @@ control.penalties={'SNS'};                        % Penalty
 control.p_weights=100;                            % Penalty weight
 control.method='lbfgs';                           % Optimisation method
 control.max_iter=100;                             % Termination condition
-control.parallel='ensemble';                      % Parallelisation
 
 % Diagnostic output
 control.plotting={'correlation_order','coherence_order',...

--- a/examples/optimal_control/features_diss_drift.m
+++ b/examples/optimal_control/features_diss_drift.m
@@ -101,7 +101,6 @@ control.penalties={'NS'};                         % Penalties
 control.p_weights=0.01;                           % Penalty weights
 control.method='lbfgs';                           % Optimisation method
 control.max_iter=500;                             % Termination tolerance
-control.parallel='ensemble';                      % Parallelisation
 
 % Control trajectory analysis plots
 control.plotting={'correlation_order','local_each_spin',...

--- a/examples/optimal_control/features_freeze.m
+++ b/examples/optimal_control/features_freeze.m
@@ -78,7 +78,6 @@ control.penalties={'NS'};                       % Penalty type
 control.p_weights=0.01;                         % Penalty weight
 control.method='goodwin';                       % Optimisation method
 control.max_iter=100;                           % Termination condition
-control.parallel='ensemble';                    % Parallelisation
 
 % Initial guess
 guess=randn(6,100)/10; 

--- a/examples/optimal_control/features_keyhole.m
+++ b/examples/optimal_control/features_keyhole.m
@@ -67,7 +67,6 @@ control.penalties={'SNS'};                        % Penalty
 control.p_weights=100;                            % Penalty weight
 control.method='lbfgs';                           % Optimisation method
 control.max_iter=200;                             % Termination condition
-control.parallel='ensemble';                      % Parallelisation
 
 % Set the keyhole
 control.keyholes=cell(1,50);

--- a/examples/optimal_control/features_multitarget.m
+++ b/examples/optimal_control/features_multitarget.m
@@ -80,7 +80,6 @@ control.penalties={'SNS'};              % Penalty
 control.p_weights=100;                  % Penalty weight
 control.method='lbfgs';                 % Optimisation method
 control.max_iter=150;                   % Termination condition
-control.parallel='ensemble';            % Parallelisation
 
 % Control trajectory analysis plots
 control.plotting={'correlation_order','local_each_spin',...

--- a/examples/optimal_control/features_newton.m
+++ b/examples/optimal_control/features_newton.m
@@ -75,7 +75,6 @@ control.penalties={'NS'};                       % Penalty type
 control.p_weights=0.01;                         % Penalty weight
 control.method='newton';                        % Optimisation method
 control.max_iter=50;                            % Termination condition
-control.parallel='ensemble';                    % Parallelisation
 
 % Plots during optimisation
 control.plotting={'correlation_order','local_each_spin',...

--- a/examples/optimal_control/features_phase_cycle.m
+++ b/examples/optimal_control/features_phase_cycle.m
@@ -69,7 +69,6 @@ control.method='lbfgs';                           % Optimisation method
 control.max_iter=100;                             % Termination condition
 control.phase_cycle=[0  0  0  0  0;
                      0  0  0  pi pi];             % Phase cycle (only 0, pi supported so far)
-control.parallel='ensemble';                      % Parallelisation
 
 % Plots during optimisation
 control.plotting={'correlation_order','local_each_spin',...

--- a/examples/optimal_control/features_trapezium.m
+++ b/examples/optimal_control/features_trapezium.m
@@ -69,7 +69,6 @@ control.p_weights=100;                            % Penalty weight
 control.integrator='trapezium';                   % Piecewise-linear
 control.method='lbfgs';                           % Optimisation method
 control.max_iter=100;                             % Termination condition
-control.parallel='ensemble';                      % Parallelisation
 
 % Plots during optimisation
 control.plotting={'correlation_order','local_each_spin',...

--- a/examples/optimal_control/features_wave_basis.m
+++ b/examples/optimal_control/features_wave_basis.m
@@ -62,7 +62,6 @@ control.method='lbfgs';                          % Optimisation method
 control.max_iter=200;                            % Termination condition
 control.penalties={'SNS'};                       % Penalty type
 control.p_weights=10;                            % Penalty weight
-control.parallel='ensemble';                     % Parallelisation 
 
 % Plotting options
 control.plotting={'xy_controls','amp_controls',...

--- a/examples/optimal_control/magic_pulse_cart.m
+++ b/examples/optimal_control/magic_pulse_cart.m
@@ -67,7 +67,6 @@ control.method='lbfgs';                            % Optimisation method
 control.penalties={'NS','SNS'};                    % Penalty types
 control.p_weights=[0.01 10.0];                     % Penalty weights
 control.max_iter=200;                              % Termination condition
-control.parallel='ensemble';                       % Parallelisation
 
 % Plotting options
 control.plotting={'xy_controls','robustness','spectrogram'};

--- a/examples/optimal_control/magic_pulse_phase.m
+++ b/examples/optimal_control/magic_pulse_phase.m
@@ -66,7 +66,6 @@ control.pwr_levels=2*pi*linspace(50e3,70e3,10); % Power levels
 control.amplitudes=ones(1,60);                  % Amplitude profile
 control.method='lbfgs';                         % Optimisation method
 control.max_iter=200;                           % Termination condition
-control.parallel='ensemble';                    % Parallelisation
 
 % Plotting options
 control.plotting={'phi_controls','xy_controls',...

--- a/examples/optimal_control/mas_powder_control.m
+++ b/examples/optimal_control/mas_powder_control.m
@@ -69,7 +69,6 @@ control.off_ops={Lz};                               % Offset operator
 control.method='lbfgs';                             % Optimisation method
 control.max_iter=100;                               % Termination condition
 control.amplitudes=ones(1,100);                     % Amplitude profile
-control.parallel='ensemble';                        % Parallelisation
 
 % Plotting options
 control.plotting={'phi_controls','robustness',...

--- a/examples/optimal_control/pattern_pulse_1.m
+++ b/examples/optimal_control/pattern_pulse_1.m
@@ -61,7 +61,6 @@ control.pwr_levels=2*pi*nutf_range;       % Power levels (B1 in rad/s)
 control.amplitudes=ones(1,250);           % Amplitude profile
 control.method='lbfgs';                   % Optimisation method
 control.max_iter=200;                     % Termination condition
-control.parallel='ensemble';              % Parallelisation
 control.ens_corrs={'rho_ens'};            % Own state pair for each B1
 
 % Plotting options

--- a/examples/optimal_control/pattern_pulse_2.m
+++ b/examples/optimal_control/pattern_pulse_2.m
@@ -64,7 +64,6 @@ control.pwr_levels=2*pi*2000;             % Power level
 control.amplitudes=ones(1,300);           % Amplitude profile
 control.method='lbfgs';                   % Optimisation method
 control.max_iter=200;                     % Termination condition
-control.parallel='ensemble';              % Parallelisation
 control.ens_corrs={'rho_ens'};            % Own state pair for each B1
 
 % Plotting options

--- a/examples/optimal_control/state_transfer_m2s.m
+++ b/examples/optimal_control/state_transfer_m2s.m
@@ -68,7 +68,6 @@ control.penalties={'NS','SNS'};                   % Penalties
 control.p_weights=[1 10];                         % Penalty weights
 control.method='lbfgs';                           % Optimisation method
 control.max_iter=3000;                            % Termination condition
-control.parallel='ensemble';                      % Parallelisation mode
 
 % Plots during optimisation
 control.plotting={'correlation_order','coherence_order',...

--- a/examples/optimal_control/state_transfer_pro.m
+++ b/examples/optimal_control/state_transfer_pro.m
@@ -88,7 +88,6 @@ control.penalties={'NS'};                         % Penalty function
 control.p_weights=0.01;                           % Penalty weight
 control.method='lbfgs';                           % Optimisation method
 control.max_iter=500;                             % Termination tolerance
-control.parallel='ensemble';                      % Parallelisation
 
 % Control trajectory analysis plots
 control.plotting={'correlation_order','local_each_spin',...

--- a/examples/optimal_control/state_transfer_s2m.m
+++ b/examples/optimal_control/state_transfer_s2m.m
@@ -68,7 +68,6 @@ control.penalties={'NS','SNS'};                   % Penalties
 control.p_weights=[0.1 10];                       % Penalty weights
 control.method='lbfgs';                           % Optimisation method
 control.max_iter=100;                             % Termination condition
-control.parallel='ensemble';                      % Parallelisation
 
 % Plots during optimisation
 control.plotting={'correlation_order','coherence_order',...

--- a/examples/optimal_control/state_transfer_wf.m
+++ b/examples/optimal_control/state_transfer_wf.m
@@ -62,7 +62,6 @@ control.penalties={'NS','SNS'};                   % Penalties
 control.p_weights=[0.1 10];                       % Penalty weights
 control.method='goodwin';                           % Optimisation method
 control.max_iter=100;                             % Termination condition
-control.parallel='ensemble';                      % Parallelisation
 
 % Plots during optimisation
 control.plotting={'xy_controls','spectrogram'};

--- a/examples/optimal_control/static_powder_control.m
+++ b/examples/optimal_control/static_powder_control.m
@@ -75,7 +75,6 @@ control.max_iter=100;                          % Maximum iterations
 control.dead_time=100e-6;                      % Dead time
 control.penalties={'NS','SNS'};                % Penalties
 control.p_weights=[0.1 10];                    % Penalty weights
-control.parallel='ensemble';                   % Parallelisation
 
 % Plotting options
 control.plotting={'xy_controls','robustness','spectrogram'};

--- a/examples/optimal_control/steady_orbit/solid_effect_chirp.m
+++ b/examples/optimal_control/steady_orbit/solid_effect_chirp.m
@@ -99,7 +99,6 @@ control.amplitudes=[ones(1,720) ...              % Pulse itself
                     zeros(1,1)];                 % Sequence delay
 control.method='rbfgs';                          % Optimisation method
 control.max_iter=10000;                          % Maximum iterations
-control.parallel='ensemble';                     % Parallelisation
 control.steady=true();                           % Steady state
 control.budget=500;                              % Increase this
 

--- a/examples/optimal_control/steady_orbit/solid_effect_dq.m
+++ b/examples/optimal_control/steady_orbit/solid_effect_dq.m
@@ -99,7 +99,6 @@ control.amplitudes=[ones(1,720) ...              % Pulse itself
                     zeros(1,1)];                 % Sequence delay
 control.method='rbfgs';                          % Optimisation method
 control.max_iter=10000;                          % Maximum iterations
-control.parallel='ensemble';                     % Parallelisation
 control.steady=true();                           % Steady state
 control.budget=500;                              % Increase this
 

--- a/examples/optimal_control/steady_orbit/solid_effect_int.m
+++ b/examples/optimal_control/steady_orbit/solid_effect_int.m
@@ -99,7 +99,6 @@ control.amplitudes=[ones(1,720) ...              % Pulse itself
                     zeros(1,1)];                 % Sequence delay
 control.method='rbfgs';                          % Optimisation method
 control.max_iter=10000;                          % Maximum iterations
-control.parallel='ensemble';                     % Parallelisation
 control.steady=true();                           % Steady state
 control.budget=500;                              % Increase this
 

--- a/examples/optimal_control/steady_orbit/solid_effect_xix.m
+++ b/examples/optimal_control/steady_orbit/solid_effect_xix.m
@@ -99,7 +99,6 @@ control.amplitudes=[ones(1,720) ...              % Pulse itself
                     zeros(1,1)];                 % Sequence delay
 control.method='rbfgs';                          % Optimisation method
 control.max_iter=10000;                          % Maximum iterations
-control.parallel='ensemble';                     % Parallelisation
 control.steady=true();                           % Steady state
 control.budget=500;                              % Increase this
 

--- a/examples/quantum_tech/circuit_qed/cavity_fock_grape_a.m
+++ b/examples/quantum_tech/circuit_qed/cavity_fock_grape_a.m
@@ -71,7 +71,6 @@ for m=1:2
     control.p_weights=0.001;
     control.method='lbfgs';
     control.max_iter=300;
-    control.parallel='ensemble';
 
     % Plots during optimisation
     control.plotting={'xy_controls'};

--- a/examples/quantum_tech/circuit_qed/cavity_fock_grape_b.m
+++ b/examples/quantum_tech/circuit_qed/cavity_fock_grape_b.m
@@ -64,7 +64,6 @@ control.penalties={'NS'};
 control.p_weights=0.001;
 control.method='lbfgs';
 control.max_iter=300;
-control.parallel='ensemble';
 
 % Plots during optimisation
 control.plotting={'xy_controls'};

--- a/examples/quantum_tech/circuit_qed/transmon_two_photon.m
+++ b/examples/quantum_tech/circuit_qed/transmon_two_photon.m
@@ -54,7 +54,6 @@ control.penalties={'NS'};
 control.p_weights=0.001;
 control.method='lbfgs';
 control.max_iter=200;
-control.parallel='ensemble';
 
 % Plots during optimisation
 control.plotting={'xy_controls'};

--- a/examples/quantum_tech/transmon_frog.m
+++ b/examples/quantum_tech/transmon_frog.m
@@ -66,7 +66,6 @@ control.penalties={'SNSA'};                          % Penalties
 control.p_weights=0.01;                              % Penalty weights
 control.method='goodwin';                            % Optimisation method
 control.max_iter=50;                                 % Termination condition
-control.parallel='ensemble';                         % Parallelisation mode
 
 % Plots during optimisation
 control.plotting={'xy_controls','spectrogram','robustness'};

--- a/examples/quantum_tech/transmon_stirap.m
+++ b/examples/quantum_tech/transmon_stirap.m
@@ -66,7 +66,6 @@ control.penalties={'SNSA'};                       % Penalties
 control.p_weights=1.0;                            % Penalty weights
 control.method='goodwin';                         % Optimisation method
 control.max_iter=50;                              % Termination condition
-control.parallel='ensemble';                      % Parallelisation mode
 
 % Plots during optimisation
 control.plotting={'xy_controls','spectrogram','robustness'};

--- a/examples/quantum_tech/transmon_transfer.m
+++ b/examples/quantum_tech/transmon_transfer.m
@@ -76,7 +76,6 @@ control.penalties={'SNSA'};                            % Penalties
 control.p_weights=1.0;                                 % Penalty weights
 control.method='rbfgs';                                % Optimisation method
 control.max_iter=200;                                  % Termination condition
-control.parallel='ensemble';                           % Parallelisation mode
 
 % Plots during optimisation
 control.plotting={'xy_controls','spectrogram','robustness'};

--- a/kernel/optimcon/ens_catalog.m
+++ b/kernel/optimcon/ens_catalog.m
@@ -1,0 +1,119 @@
+% Ensemble case catalog for optimal control problems. Enumerates the
+% Cartesian product of the state-target pairs, the drift generators,
+% the control power levels, the resonance offsets, the phase cycle
+% lines, and the distortion functions; then applies the ensemble
+% correlation filters and the ensemble budget. Each row of the cata-
+% log is one ensemble case to be simulated at each evaluation of the
+% control sequence fidelity. Syntax:
+%
+%              [catalog,ens_sizes]=ens_catalog(control)
+%
+% Parameters:
+%
+%    control    - control data structure produced by optimcon.m
+%
+% Outputs:
+%
+%    catalog    - [n_cases x 6] array of ensemble indices; the col-
+%                 umns index the state-target pair, the drift gene-
+%                 rator, the power level, the offset combination,
+%                 the phase cycle line, and the distortion function
+%
+%    ens_sizes  - [1 x 6] array of the ensemble dimension sizes the
+%                 catalog was built from, in the same column order
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=ens_catalog.m>
+
+function [catalog,ens_sizes]=ens_catalog(control)
+
+% Check consistency
+grumble(control);
+
+% Get offset ensemble size
+off_ens_sizes=cellfun(@numel,control.offsets);
+if ~isempty(off_ens_sizes)
+    n_offset_vals=prod(off_ens_sizes);
+else
+    n_offset_vals=1;
+end
+
+% Extract ensemble grid dimensions
+n_state_pairs=numel(control.rho_init);
+n_ens_systems=control.ndrifts;
+n_power_levls=numel(control.pwr_levels);
+n_phase_specs=size(control.phase_cycle,1);
+n_distortions=size(control.distortion,1);
+
+% Record the grid dimensions
+ens_sizes=[n_state_pairs n_ens_systems n_power_levls ...
+           n_offset_vals n_phase_specs n_distortions];
+
+% Create a catalog of the ensemble
+catalog=(1:n_state_pairs)';
+catalog=[kron(ones(n_ens_systems,1),catalog) kron((1:n_ens_systems)',ones(size(catalog,1),1))];
+catalog=[kron(ones(n_power_levls,1),catalog) kron((1:n_power_levls)',ones(size(catalog,1),1))];
+catalog=[kron(ones(n_offset_vals,1),catalog) kron((1:n_offset_vals)',ones(size(catalog,1),1))];
+catalog=[kron(ones(n_phase_specs,1),catalog) kron((1:n_phase_specs)',ones(size(catalog,1),1))];
+catalog=[kron(ones(n_distortions,1),catalog) kron((1:n_distortions)',ones(size(catalog,1),1))];
+
+% Ensemble correlation: own state pair for each member
+if ismember('rho_ens',control.ens_corrs)
+    catalog=catalog(:,2:end);
+    catalog=unique(catalog,'rows');
+    catalog=[(1:size(catalog,1))' catalog];
+end
+
+% Ensemble correlation: own state pair for each drift
+if ismember('rho_drift',control.ens_corrs)
+    catalog(catalog(:,1)~=catalog(:,2),:)=[];
+end
+
+% Ensemble correlation: own control power for each drift
+if ismember('power_drift',control.ens_corrs)
+    catalog(catalog(:,3)~=catalog(:,2),:)=[];
+end
+
+% Count the full ensemble size
+n_cases=size(catalog,1);
+
+% Convert fractional budget into sample count
+ens_budget=control.budget;
+if isfinite(ens_budget)&&(ens_budget<=1)
+    ens_budget=round(n_cases*ens_budget);
+    ens_budget=max(1,ens_budget);
+end
+
+% Apply ensemble budget
+if ens_budget<n_cases
+
+    % Get RNG into a reproducible state
+    rng_state=rng; rng(5318008,'twister');
+
+    % Draw a random subset of the ensemble
+    catalog=catalog(randperm(n_cases,ens_budget),:);
+
+    % Release RNG
+    rng(rng_state);
+
+end
+
+end
+
+% Consistency enforcement
+function grumble(control)
+if ~isstruct(control)
+    error('control must be a data structure produced by optimcon.m');
+end
+if ~all(isfield(control,{'rho_init','ndrifts','pwr_levels','offsets',...
+                         'phase_cycle','distortion','ens_corrs','budget'}))
+    error('control must be a data structure produced by optimcon.m');
+end
+end
+
+% The purpose of abstraction is not to be vague, but to create
+% a new semantic level in which one can be absolutely precise.
+%
+% Edsger W. Dijkstra
+

--- a/kernel/optimcon/ensemble.m
+++ b/kernel/optimcon/ensemble.m
@@ -20,15 +20,22 @@
 %                  ray separating the penalties from the simulation
 %                  fidelity.
 %
-%   gradient     - gradient of the fidelity with respect to the control 
+%   gradient     - gradient of the fidelity with respect to the control
 %                  sequence. When penalty methods are specified, gradi-
 %                  ent is returned as an array separating penalty gra-
 %                  dients from the fidelity gradient.
 %
-%   hessian      - Hessian of the fidelity with respect to the control 
+%   hessian      - Hessian of the fidelity with respect to the control
 %                  sequence. When penalty methods are specified, gradi-
 %                  ent is returned as an array separating penalty Hes-
 %                  sians from the fidelity Hessian.
+%
+% Note: the ensemble cases enumerated in spin_system.control.catalog
+%       are distributed over the parallel pool workers. Each case
+%       fetches the evaluation-invariant problem data from the pool
+%       constant published by optimcon.m, so only the waveform, the
+%       states, and the evaluation-variable settings travel at each
+%       objective evaluation.
 %
 % david.goodwin@inano.au.dk
 % ilya.kuprov@weizmann.ac.il
@@ -41,78 +48,34 @@ function [traj_data,fidelity,gradient,hessian]=ensemble(waveform,spin_system)
 % Check consistency
 grumble(spin_system,waveform);
 
+% Pull the ensemble case catalog
+catalog=spin_system.control.catalog;
+n_cases=size(catalog,1);
+
+% Pull the worker-resident problem data handle
+invariants=spin_system.control.invariants;
+
+% Collect the evaluation-variable settings
+live.rho_init=spin_system.control.rho_init;
+live.rho_targ=spin_system.control.rho_targ;
+live.pulse_dt=spin_system.control.pulse_dt;
+live.pwr_levels=spin_system.control.pwr_levels;
+live.offsets=spin_system.control.offsets;
+live.phase_cycle=spin_system.control.phase_cycle;
+live.distortion=spin_system.control.distortion;
+live.freeze=spin_system.control.freeze;
+live.fidelity=spin_system.control.fidelity;
+live.plotting=spin_system.control.plotting;
+live.keyholes=spin_system.control.keyholes;
+live.return_traj=isfield(spin_system.control,'return_traj')&&...
+                 spin_system.control.return_traj;
+if strcmp(spin_system.control.integrator,'trapezium')
+    live.cc_comm=spin_system.control.cc_comm;
+    live.cc_comm_idx=spin_system.control.cc_comm_idx;
+end
+
 % Get offset ensemble size
-off_ens_sizes=cellfun(@numel,spin_system.control.offsets);
-if ~isempty(off_ens_sizes)
-    n_offset_vals=prod(off_ens_sizes);
-else
-    n_offset_vals=1;
-end
-
-% Extract ensemble grid dimensions
-n_state_pairs=numel(spin_system.control.rho_init);     % State-target pair count
-n_ens_systems=spin_system.control.ndrifts;             % Drift ensemble size
-n_power_levls=numel(spin_system.control.pwr_levels);   % Power level count
-n_phase_specs=size(spin_system.control.phase_cycle,1); % Phase cycle line count
-n_distortions=size(spin_system.control.distortion,1);  % Distortion function ensemble size
-
-% Create a catalog of the ensemble
-catalog=(1:n_state_pairs)';
-catalog=[kron(ones(n_ens_systems,1),catalog) kron((1:n_ens_systems)',ones(size(catalog,1),1))];
-catalog=[kron(ones(n_power_levls,1),catalog) kron((1:n_power_levls)',ones(size(catalog,1),1))];
-catalog=[kron(ones(n_offset_vals,1),catalog) kron((1:n_offset_vals)',ones(size(catalog,1),1))];
-catalog=[kron(ones(n_phase_specs,1),catalog) kron((1:n_phase_specs)',ones(size(catalog,1),1))];
-catalog=[kron(ones(n_distortions,1),catalog) kron((1:n_distortions)',ones(size(catalog,1),1))];
-
-% Ensemble correlation: own state pair for each member
-if ismember('rho_ens',spin_system.control.ens_corrs)
-    catalog=catalog(:,2:end); 
-    catalog=unique(catalog,'rows');
-    catalog=[(1:size(catalog,1))' catalog];
-end
-
-% Ensemble correlation: own state pair for each drift
-if ismember('rho_drift',spin_system.control.ens_corrs)
-    catalog(catalog(:,1)~=catalog(:,2),:)=[];
-end
-
-% Ensemble correlation: own control power for each drift
-if ismember('power_drift',spin_system.control.ens_corrs)
-    catalog(catalog(:,3)~=catalog(:,2),:)=[];
-end
-
-% Count the full ensemble size
-n_cases=size(catalog,1);
-
-% Get ensemble budget
-if isfield(spin_system.control,'budget')
-    ens_budget=spin_system.control.budget;
-else
-    ens_budget=Inf;
-end
-
-% Convert fractional budget into sample count
-if isfinite(ens_budget)&&(ens_budget<=1)
-    ens_budget=round(n_cases*ens_budget);
-    ens_budget=max(1,ens_budget);
-end
-
-% Apply ensemble budget
-if ens_budget<n_cases
-
-    % Get RNG into a reproducible state
-    rng_state=rng; rng(5318008,'twister');
-
-    % Draw a random subset of the ensemble
-    catalog=catalog(randperm(n_cases,ens_budget),:);
-
-    % Release RNG
-    rng(rng_state);
-
-end
-
-% Count the cases
-n_cases=size(catalog,1);
+off_ens_sizes=cellfun(@numel,live.offsets);
 
 % Count the outputs
 n_outputs=nargout;
@@ -124,96 +87,89 @@ gradients=cell(1,n_cases); hessians=cell(1,n_cases);
 % Waveform dimension statistics
 ncont=size(waveform,1); nsteps=size(waveform,2);
 
-% Parallel strategy
-if strcmp(spin_system.control.parallel,'ensemble')
+% Parallelise over the ensemble
+nworkers=poolsize;
 
-    % Over ensemble
-    nworkers=poolsize;
-
-elseif strcmp(spin_system.control.parallel,'time')
-
-    % Pass down
-    nworkers=0;
-
-else
-
-    % Complain and bomb out
-    error('unknown parallelisation strategy.');
-
-end
-    
 % Run the ensemble loop
 parfor (n=1:n_cases,nworkers) %#ok<*PFBNS>
-    
+
+    % Fetch worker-resident problem data
+    ss=invariants.Value;
+
+    % Graft the evaluation-variable settings
+    ss.control.pulse_dt=live.pulse_dt;
+    ss.control.freeze=live.freeze;
+    ss.control.plotting=live.plotting;
+    ss.control.keyholes=live.keyholes;
+    ss.control.return_traj=live.return_traj;
+    if isfield(live,'cc_comm')
+        ss.control.cc_comm=live.cc_comm;
+        ss.control.cc_comm_idx=live.cc_comm_idx;
+    end
+
     % Extract ensemble indices
     n_rho=catalog(n,1); n_sys=catalog(n,2);
     n_pwr=catalog(n,3); n_off=catalog(n,4);
     n_phi=catalog(n,5); n_dis=catalog(n,6);
-    
+
     % Get initial and target state
-    rho_init=spin_system.control.rho_init{n_rho};
-    rho_targ=spin_system.control.rho_targ{n_rho};
-    
+    rho_init=live.rho_init{n_rho};
+    rho_targ=live.rho_targ{n_rho};
+
     % Localise the waveform
     local_waveform=waveform;
-    
+
     % Apply the phase cycle
-    if ~isempty(spin_system.control.phase_cycle)
-        
+    if ~isempty(live.phase_cycle)
+
         % Apply phase to the initial state
-        phi=spin_system.control.phase_cycle(n_phi,1);
+        phi=live.phase_cycle(n_phi,1);
         rho_init=exp(1i*phi)*rho_init;
-        
+
         % Apply phase to the target state
-        phi=spin_system.control.phase_cycle(n_phi,end);
+        phi=live.phase_cycle(n_phi,end);
         rho_targ=exp(1i*phi)*rho_targ;
-        
+
         % Apply phases to the waveform
         for k=1:(size(local_waveform,1)/2)
-            
+
             % Assemble complex waveform
             cplx_wave=local_waveform(2*k-1,:)+...
                    1i*local_waveform(2*k,:);
-            
+
             % Get the phase
-            phi=spin_system.control.phase_cycle(n_phi,k+1);
-            
+            phi=live.phase_cycle(n_phi,k+1);
+
             % Apply the phase
             cplx_wave=exp(1i*phi)*cplx_wave;
-            
+
             % Get back X and Y components
             local_waveform(2*k-1,:)=real(cplx_wave);
             local_waveform(2*k,:)=imag(cplx_wave);
-            
+
         end
-        
+
     end
-    
-    % Get drifts from pool ValueStore
-    if (nworkers==0)||(~isworkernode)
-        store=gcp('nocreate').ValueStore; 
-        L=store(['oc_drift_' num2str(n_sys)]);
-    else
-        store=getCurrentValueStore(); 
-        L=store(['oc_drift_' num2str(n_sys)]);
-    end
-      
+
+    % Get the drift generators
+    L=ss.control.drifts{n_sys};
+
     % Add offset terms
     if ~isempty(off_ens_sizes)
-        
+
         % Multi-index mathematics
-        cum_sizes=fliplr(cumprod(off_ens_sizes)); 
+        cum_sizes=fliplr(cumprod(off_ens_sizes));
         cum_sizes=[cum_sizes(2:end) 1]; lin_idx=n_off;
         for k=1:numel(off_ens_sizes)
-            
+
             % Current channel index
             vi=rem(lin_idx-1,cum_sizes(k))+1;
             vj=(lin_idx-vi)/cum_sizes(k)+1;
             oper_idx=numel(off_ens_sizes)-k+1;
 
             % Add to the drift (user specifies offsets in Hz)
-            L=L+sparse(2*pi*spin_system.control.offsets{oper_idx}(vj)*...
-                            spin_system.control.off_ops{oper_idx});
+            L=L+sparse(2*pi*live.offsets{oper_idx}(vj)*...
+                            ss.control.off_ops{oper_idx});
 
             % Next channel
             lin_idx=vi;
@@ -223,45 +179,38 @@ parfor (n=1:n_cases,nworkers) %#ok<*PFBNS>
     end
 
     % Move the waveform into physical units
-    power_lvl=spin_system.control.pwr_levels(n_pwr);
+    power_lvl=live.pwr_levels(n_pwr);
     local_waveform=power_lvl*local_waveform;
 
     % Call GRAPE
     if n_outputs==2
 
         % Apply waveform distortions
-        for k=1:size(spin_system.control.distortion,2)
+        for k=1:size(live.distortion,2)
 
             % Get distortion function
-            dist_function=spin_system.control.distortion{n_dis,k};
+            dist_function=live.distortion{n_dis,k};
 
             % Apply distortion function
             local_waveform=dist_function(local_waveform);
 
         end
-            
-        % Fidelity and trajectory
-        switch spin_system.bas.formalism
 
-            case {'sphten-liouv','zeeman-liouv'}
-                
+        % Fidelity and trajectory
+        switch ss.bas.formalism
+
+            case {'sphten-liouv','zeeman-liouv','zeeman-wavef'}
+
                 % Call Liouville space version of the GRAPE function
-                [traj_data{n},fidelities{n}]=grape_liouv(spin_system,L,spin_system.control.operators,...
+                [traj_data{n},fidelities{n}]=grape_liouv(ss,L,ss.control.operators,...
                                                          local_waveform,rho_init,rho_targ,...
-                                                         spin_system.control.fidelity);
+                                                         live.fidelity);
             case 'zeeman-hilb'
 
                 % Call Hilbert space version of the GRAPE function
-                [traj_data{n},fidelities{n}]=grape_hilb(spin_system,L,spin_system.control.operators,...
+                [traj_data{n},fidelities{n}]=grape_hilb(ss,L,ss.control.operators,...
                                                         local_waveform,rho_init,rho_targ,...
-                                                        spin_system.control.fidelity);
-
-            case 'zeeman-wavef'
-
-                % Call Liouville space version of the GRAPE function (homomorphism)
-                [traj_data{n},fidelities{n}]=grape_liouv(spin_system,L,spin_system.control.operators,...
-                                                         local_waveform,rho_init,rho_targ,...
-                                                         spin_system.control.fidelity);
+                                                        live.fidelity);
 
             otherwise
 
@@ -269,17 +218,17 @@ parfor (n=1:n_cases,nworkers) %#ok<*PFBNS>
                 error('unrecognised formalism specification.');
 
         end
-                                       
+
     elseif n_outputs==3
 
         % Get the Jacobian going
         J=speye(numel(local_waveform));
 
         % Apply waveform distortions
-        for k=1:size(spin_system.control.distortion,2)
+        for k=1:size(live.distortion,2)
 
             % Get distortion function
-            dist_function=spin_system.control.distortion{n_dis,k};
+            dist_function=live.distortion{n_dis,k};
 
             % Apply distortion and get its Jacobian
             [local_waveform,stage_jacobian]=dist_function(local_waveform);
@@ -288,29 +237,22 @@ parfor (n=1:n_cases,nworkers) %#ok<*PFBNS>
             J=stage_jacobian*J;
 
         end
-            
-        % Fidelity and trajectory
-        switch spin_system.bas.formalism
 
-            case {'sphten-liouv','zeeman-liouv'}
-                
+        % Fidelity and trajectory
+        switch ss.bas.formalism
+
+            case {'sphten-liouv','zeeman-liouv','zeeman-wavef'}
+
                 % Call Liouville space version of the GRAPE function
-                [traj_data{n},fidelities{n},gradients{n}]=grape_liouv(spin_system,L,spin_system.control.operators,...
+                [traj_data{n},fidelities{n},gradients{n}]=grape_liouv(ss,L,ss.control.operators,...
                                                                       local_waveform,rho_init,rho_targ,...
-                                                                      spin_system.control.fidelity);
+                                                                      live.fidelity);
             case 'zeeman-hilb'
 
                 % Call Hilbert space version of the GRAPE function
-                [traj_data{n},fidelities{n},gradients{n}]=grape_hilb(spin_system,L,spin_system.control.operators,...
+                [traj_data{n},fidelities{n},gradients{n}]=grape_hilb(ss,L,ss.control.operators,...
                                                                      local_waveform,rho_init,rho_targ,...
-                                                                     spin_system.control.fidelity);
-
-            case 'zeeman-wavef'
-
-                % Call Liouville space version of the GRAPE function (homomorphism)
-                [traj_data{n},fidelities{n},gradients{n}]=grape_liouv(spin_system,L,spin_system.control.operators,...
-                                                                      local_waveform,rho_init,rho_targ,...
-                                                                      spin_system.control.fidelity);
+                                                                     live.fidelity);
 
             otherwise
 
@@ -327,34 +269,26 @@ parfor (n=1:n_cases,nworkers) %#ok<*PFBNS>
 
         % Restore the original gradient layout
         gradients{n}=reshape(gradients{n},[n_rows n_cols]);
-                                                
+
     elseif n_outputs==4
 
         % Fidelity and trajectory
-        switch spin_system.bas.formalism
+        switch ss.bas.formalism
 
-            case {'sphten-liouv','zeeman-liouv'}
-                
+            case {'sphten-liouv','zeeman-liouv','zeeman-wavef'}
+
                 % Call Liouville space version of the GRAPE function
                 [traj_data{n},fidelities{n},...
-                 gradients{n},hessians{n}]=grape_liouv(spin_system,L,spin_system.control.operators,...
+                 gradients{n},hessians{n}]=grape_liouv(ss,L,ss.control.operators,...
                                                        local_waveform,rho_init,rho_targ,...
-                                                       spin_system.control.fidelity);
+                                                       live.fidelity);
             case 'zeeman-hilb'
 
                 % Call Hilbert space version of the GRAPE function
                 [traj_data{n},fidelities{n},...
-                 gradients{n},hessians{n}]=grape_hilb(spin_system,L,spin_system.control.operators,...
+                 gradients{n},hessians{n}]=grape_hilb(ss,L,ss.control.operators,...
                                                       local_waveform,rho_init,rho_targ,...
-                                                      spin_system.control.fidelity);
-
-            case 'zeeman-wavef'
-
-                % Call Liouville space version of the GRAPE function (homomorphism)
-                [traj_data{n},fidelities{n},...
-                 gradients{n},hessians{n}]=grape_liouv(spin_system,L,spin_system.control.operators,...
-                                                       local_waveform,rho_init,rho_targ,...
-                                                       spin_system.control.fidelity);
+                                                      live.fidelity);
 
             otherwise
 
@@ -362,74 +296,74 @@ parfor (n=1:n_cases,nworkers) %#ok<*PFBNS>
                 error('unrecognised formalism specification.');
 
         end
-                                                         
+
     end
-    
+
     % Post-process gradient
-    if (~isempty(spin_system.control.phase_cycle))&&(n_outputs>2)
-        
+    if (~isempty(live.phase_cycle))&&(n_outputs>2)
+
         % Un-apply phases to gradient
         for k=1:(size(gradients{n},1)/2)
-            
+
             % Assemble complex gradient
             cplx_grad=gradients{n}(2*k-1,:)+...
                    1i*gradients{n}(2*k,:);
-            
+
             % Get the phase
-            phi=spin_system.control.phase_cycle(n_phi,k+1);
-            
+            phi=live.phase_cycle(n_phi,k+1);
+
             % Un-apply the phase
             cplx_grad=exp(-1i*phi)*cplx_grad;
-            
+
             % Get back X and Y components
             gradients{n}(2*k-1,:)=real(cplx_grad);
             gradients{n}(2*k,:)=imag(cplx_grad);
-            
+
         end
-        
+
     end
-    
+
     % Post-process Hessian
-    if (~isempty(spin_system.control.phase_cycle))&&(n_outputs>3)
-        
+    if (~isempty(live.phase_cycle))&&(n_outputs>3)
+
         % Re-shape the Hessian as [ncont x nsteps x nsteps x ncont]
         hessians{n}=reshape(hessians{n},[ncont nsteps ncont nsteps]);
-    
+
         % Un-apply phases to Hessian
         for k=1:(size(gradients{n},1)/2)
-            
+
             % Get the phase
-            phi=spin_system.control.phase_cycle(n_phi,k+1);
-            
+            phi=live.phase_cycle(n_phi,k+1);
+
             % Assemble complex Hessian - left
             cplx_hess=hessians{n}(2*k-1,:,:,:)+...
                    1i*hessians{n}(2*k,:,:,:);
-            
+
             % Un-apply the phase
             cplx_hess=exp(-1i*phi)*cplx_hess;
-            
+
             % Get back X and Y components
             hessians{n}(2*k-1,:,:,:)=real(cplx_hess);
             hessians{n}(2*k,:,:,:)=imag(cplx_hess);
-            
+
             % Assemble complex Hessian - right
             cplx_hess=hessians{n}(:,:,2*k-1,:)+...
                    1i*hessians{n}(:,:,2*k,:);
-            
+
             % Un-apply the phase
             cplx_hess=exp(-1i*phi)*cplx_hess;
-            
+
             % Get back X and Y components
             hessians{n}(:,:,2*k-1,:)=real(cplx_hess);
             hessians{n}(:,:,2*k,:)=imag(cplx_hess);
-        
+
         end
-        
+
         % Reshape the Hessian back
         hessians{n}=reshape(hessians{n},[ncont*nsteps nsteps*ncont]);
-        
+
     end
-    
+
     % Apply power level
     if n_outputs>2
         gradients{n}=power_lvl*gradients{n}(:);
@@ -437,7 +371,7 @@ parfor (n=1:n_cases,nworkers) %#ok<*PFBNS>
     if n_outputs>3
         hessians{n}=power_lvl*power_lvl*hessians{n}(:);
     end
-    
+
 end
 
 % Apply trajectory options
@@ -448,12 +382,12 @@ if ismember('average',spin_system.control.traj_opts)
     for n=2:numel(traj_data)
         ave_traj=ave_traj+(1/n_cases)*traj_data{n}.forward;
     end
-    
+
     % Overwrite traj_data
     traj_data=[]; traj_data{1}.forward=ave_traj;
-    
+
 end
-    
+
 % Add up fidelities
 fidelities=cell2mat(fidelities);
 fidelity=sum(fidelities)/n_cases;
@@ -492,12 +426,12 @@ if ~isempty(spin_system.control.plotting)
         ctrl_trajan(spin_system,dist_waveform,traj_data,fidelities);
 
     else
-    
+
         % Real-life trajectory but the ideal control sequence
         ctrl_trajan(spin_system,waveform,traj_data,fidelities);
 
     end
-    
+
 end
 
 end
@@ -507,10 +441,16 @@ function grumble(spin_system,waveform)
 if ~isfield(spin_system,'control')
     error('control data missing from spin_system, run optimcon() first.');
 end
+if ~all(isfield(spin_system.control,{'catalog','ens_sizes','invariants'}))
+    error('ensemble catalog missing from spin_system, run optimcon() first.');
+end
+if any(isfield(spin_system.control,{'operators','off_ops','drifts'}))
+    error('generators and operators are frozen after optimcon(), re-run optimcon() to change them.');
+end
 if (~isnumeric(waveform))||(~isreal(waveform))
     error('waveform must be an array of real numbers.');
 end
-if size(waveform,1)~=numel(spin_system.control.operators)
+if size(waveform,1)~=spin_system.control.ncontrols
     error('the number of rows in waveform must equal to the number of controls.');
 end
 switch spin_system.control.integrator
@@ -524,6 +464,24 @@ switch spin_system.control.integrator
         end
     otherwise
         error('unknown time propagation algorithm.');
+end
+if numel(spin_system.control.pulse_dt)~=spin_system.control.pulse_nsteps
+    error('the length of control.pulse_dt has changed, re-run optimcon().');
+end
+if ~isempty(spin_system.control.offsets)
+    n_offset_vals=prod(cellfun(@numel,spin_system.control.offsets));
+else
+    n_offset_vals=1;
+end
+live_sizes=[numel(spin_system.control.rho_init) ...
+            spin_system.control.ndrifts ...
+            numel(spin_system.control.pwr_levels) ...
+            n_offset_vals ...
+            size(spin_system.control.phase_cycle,1) ...
+            size(spin_system.control.distortion,1)];
+if (numel(spin_system.control.rho_targ)~=numel(spin_system.control.rho_init))||...
+   any(live_sizes~=spin_system.control.ens_sizes)
+    error('ensemble composition changed after optimcon(), re-run optimcon().');
 end
 end
 

--- a/kernel/optimcon/ensemble.m
+++ b/kernel/optimcon/ensemble.m
@@ -97,8 +97,15 @@ parfor (n=1:n_cases,nworkers) %#ok<*PFBNS>
     ss=invariants.Value;
 
     % Graft the evaluation-variable settings
+    ss.control.rho_init=live.rho_init;
+    ss.control.rho_targ=live.rho_targ;
     ss.control.pulse_dt=live.pulse_dt;
+    ss.control.pwr_levels=live.pwr_levels;
+    ss.control.offsets=live.offsets;
+    ss.control.phase_cycle=live.phase_cycle;
+    ss.control.distortion=live.distortion;
     ss.control.freeze=live.freeze;
+    ss.control.fidelity=live.fidelity;
     ss.control.plotting=live.plotting;
     ss.control.keyholes=live.keyholes;
     ss.control.return_traj=live.return_traj;
@@ -468,19 +475,10 @@ end
 if numel(spin_system.control.pulse_dt)~=spin_system.control.pulse_nsteps
     error('the length of control.pulse_dt has changed, re-run optimcon().');
 end
-if ~isempty(spin_system.control.offsets)
-    n_offset_vals=prod(cellfun(@numel,spin_system.control.offsets));
-else
-    n_offset_vals=1;
-end
-live_sizes=[numel(spin_system.control.rho_init) ...
-            spin_system.control.ndrifts ...
-            numel(spin_system.control.pwr_levels) ...
-            n_offset_vals ...
-            size(spin_system.control.phase_cycle,1) ...
-            size(spin_system.control.distortion,1)];
+[catalog_now,ens_sizes_now]=ens_catalog(spin_system.control);
 if (numel(spin_system.control.rho_targ)~=numel(spin_system.control.rho_init))||...
-   any(live_sizes~=spin_system.control.ens_sizes)
+   (~isequal(ens_sizes_now,spin_system.control.ens_sizes))||...
+   (~isequal(catalog_now,spin_system.control.catalog))
     error('ensemble composition changed after optimcon(), re-run optimcon().');
 end
 end

--- a/kernel/optimcon/grape_hilb.m
+++ b/kernel/optimcon/grape_hilb.m
@@ -58,7 +58,7 @@
 
 function [traj_data,fidelity,grad,hess]=grape_hilb(spin_system,drifts,controls,...
                                                    waveform,rho_init,rho_targ,...
-                                                   fidelity_type) %#ok<*PFBNS>
+                                                   fidelity_type)
 
 % Check consistency
 grumble(spin_system,drifts,controls,waveform,rho_init,rho_targ,fidelity_type);
@@ -92,9 +92,7 @@ switch spin_system.control.integrator
 end
 
 % Hush up the output
-ss_parfor.sys=spin_system.sys; ss_parfor.tols=spin_system.tols;
-ss_parfor.bas.formalism=spin_system.bas.formalism;
-ss_parfor.sys.output='hush';
+spin_system.sys.output='hush';
 
 % Pull the target back through the dead time using
 % the last drift generator in the drift array
@@ -139,7 +137,7 @@ switch spin_system.control.integrator
         H=cell(1,nsteps); P=cell(1,nsteps);
 
         % Precompute evolution generators and propagators
-        parfor n=1:nsteps
+        for n=1:nsteps
 
             % Cycle through the drifts array
             H{n}=drifts{mod(n-1,ndrifts)+1};
@@ -153,7 +151,7 @@ switch spin_system.control.integrator
             end
 
             % Compute the interval propagator
-            P{n}=propagator(ss_parfor,H{n},dt(n));
+            P{n}=propagator(spin_system,H{n},dt(n));
 
         end
 
@@ -164,7 +162,7 @@ switch spin_system.control.integrator
         H=cell(1,nsteps); P=cell(1,nsteps);
 
         % Precompute edge generators and propagators
-        parfor n=1:nsteps
+        for n=1:nsteps
 
             % Cycle through the drifts array
             left_ham=drifts{mod(n-1,ndrifts)+1};
@@ -182,7 +180,7 @@ switch spin_system.control.integrator
                                    right_ham*left_ham);
 
             % Compute the interval propagator
-            P{n}=propagator(ss_parfor,H{n},dt(n));
+            P{n}=propagator(spin_system,H{n},dt(n));
 
         end
 
@@ -246,7 +244,7 @@ if n_outputs>2
         case 'rectangle'
 
             % Loop over control sequence
-            parfor n=1:nsteps
+            for n=1:nsteps
 
                 % Allocate local gradient column
                 grad_col=zeros(nctrls,1,'like',1i);
@@ -255,7 +253,7 @@ if n_outputs>2
                 for k=1:nctrls
 
                     % Compute directional derivative of the propagator
-                    auxmat=dirdiff(ss_parfor,H{n},controls{k},dt(n),2);
+                    auxmat=dirdiff(spin_system,H{n},controls{k},dt(n),2);
 
                     % Apply the derivative to the density matrix
                     rho_deriv=auxmat{2}*fwd_traj{n}*auxmat{1}'+...
@@ -282,7 +280,7 @@ if n_outputs>2
             dim=size(drifts{1},1);
 
             % Loop over control sequence
-            parfor n=1:(nsteps+1)
+            for n=1:(nsteps+1)
 
                 % Allocate local gradient column
                 grad_col=zeros(nctrls,1,'like',1i);
@@ -303,7 +301,7 @@ if n_outputs>2
                                              waveform(:,2),k);
 
                         % Exponentiate the auxiliary matrix
-                        auxmat=propagator(ss_parfor,DL_first,dt(n));
+                        auxmat=propagator(spin_system,DL_first,dt(n));
 
                         % Extract propagator and derivative
                         P_aux=auxmat(1:dim,1:dim);
@@ -335,7 +333,7 @@ if n_outputs>2
                                             waveform(:,end),k);
 
                         % Exponentiate the auxiliary matrix
-                        auxmat=propagator(ss_parfor,DR_last,dt(n-1));
+                        auxmat=propagator(spin_system,DR_last,dt(n-1));
 
                         % Extract propagator and derivative
                         P_aux=auxmat(1:dim,1:dim);
@@ -366,7 +364,7 @@ if n_outputs>2
                                              waveform(:,n+1),k);
 
                         % Exponentiate the auxiliary matrix
-                        auxmat=propagator(ss_parfor,Right_DL,dt(n));
+                        auxmat=propagator(spin_system,Right_DL,dt(n));
 
                         % Extract propagator and derivative
                         P_aux=auxmat(1:dim,1:dim);
@@ -390,7 +388,7 @@ if n_outputs>2
                                             waveform(:,n),k);
 
                         % Exponentiate the auxiliary matrix
-                        auxmat=propagator(ss_parfor,Left_DR,dt(n-1));
+                        auxmat=propagator(spin_system,Left_DR,dt(n-1));
 
                         % Extract propagator and derivative
                         P_aux=auxmat(1:dim,1:dim);
@@ -434,7 +432,7 @@ if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
     d2P=cell(nctrls,nctrls,nsteps);
 
     % Compute derivative propagators
-    parfor n=1:nsteps
+    for n=1:nsteps
 
         % Preallocate local derivative arrays
         dP_col=cell(nctrls,1);
@@ -444,12 +442,12 @@ if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
         for k=1:nctrls
 
             % First derivative of the propagator
-            auxmat=dirdiff(ss_parfor,H{n},controls{k},dt(n),2);
+            auxmat=dirdiff(spin_system,H{n},controls{k},dt(n),2);
             dP_col{k}=auxmat{2};
 
             % Second derivative of the propagator
             for j=1:nctrls
-                auxmat=dirdiff(ss_parfor,H{n},{controls{k},controls{j}},dt(n),3);
+                auxmat=dirdiff(spin_system,H{n},{controls{k},controls{j}},dt(n),3);
                 d2P_block{k,j}=auxmat{3};
             end
 

--- a/kernel/optimcon/grape_liouv.m
+++ b/kernel/optimcon/grape_liouv.m
@@ -69,7 +69,7 @@
 
 function [traj_data,fidelity,grad,hess]=grape_liouv(spin_system,drifts,controls,...
                                                     waveform,rho_init,rho_targ,...
-                                                    fidelity_type) %#ok<*PFBNS>
+                                                    fidelity_type)
 % Check consistency
 grumble(spin_system,drifts,controls,waveform,...
         rho_init,rho_targ,fidelity_type);
@@ -116,7 +116,7 @@ switch spin_system.control.integrator
 
         else
 
-            % Parfor needs these empty declarations
+            % Empty declarations tested downstream
             fwd_dP={}; bwd_dP={}; fwd_d2P={}; P_cum={};
 
         end
@@ -125,7 +125,7 @@ switch spin_system.control.integrator
         if spin_system.control.steady
             P=cell(1,nsteps);
         else
-            P={}; % Needed by parfor
+            P={};
         end
 
     % Piecewise-linear
@@ -173,10 +173,6 @@ if ~isempty(spin_system.control.suffix)
     rho_targ=suffix(spin_system,drifts{end},rho_targ);
 end
 
-% Strip the spin system object for communication efficiency
-ss_parfor.sys=spin_system.sys; ss_parfor.tols=spin_system.tols;
-ss_parfor.bas.formalism=spin_system.bas.formalism;
-
 % Define a vector and a matrix of zeroes for auxiliary systems
 zero_state=complex(spalloc(size(rho_init,1),size(rho_init,2),0));
 zero_drift=complex(spalloc(size(drifts{1},1),size(drifts{1},2),0));
@@ -195,10 +191,9 @@ switch spin_system.control.integrator
 
         % Preallocate evolution generators
         L_forw=cell(1,nsteps); L_back=cell(1,nsteps);
-        
+
         % Precompute evolution generators
-        % (this is surprisingly expensive)
-        parfor n=1:nsteps
+        for n=1:nsteps
 
             % Cycle through the drifts array
             L_forw{n}=drifts{mod(n-1,ndrifts)+1};
@@ -227,7 +222,7 @@ switch spin_system.control.integrator
             for n=1:nsteps
 
                 % Get the step propagator
-                P{n}=propagator(ss_parfor,L_forw{n},dt(n));
+                P{n}=propagator(spin_system,L_forw{n},dt(n));
 
                 % Merge into the total (physical: no keyholes)
                 P_tot=clean_up(spin_system,P{n}*P_tot,...
@@ -275,7 +270,7 @@ switch spin_system.control.integrator
 
             % Goodwin's optimiser needs cumulative propagators
             if strcmp(spin_system.control.method,'goodwin')&&(n_outputs>3)
-                P_cum{n}=propagator(ss_parfor,L_forw{n},dt(n));
+                P_cum{n}=propagator(spin_system,L_forw{n},dt(n));
                 if n>1
                     P_cum{n}=P_cum{n}*P_cum{n-1};
                     P_cum{n}=clean_up(spin_system,P_cum{n},...
@@ -313,7 +308,7 @@ switch spin_system.control.integrator
         L_back_left=cell(1,nsteps); L_back_right=cell(1,nsteps);
 
         % Precompute evolution generators
-        parfor n=1:nsteps
+        for n=1:nsteps
 
             % Cycle through the drifts array
             L_forw_left{n}=drifts{mod(n-1,ndrifts)+1};           
@@ -386,8 +381,8 @@ if n_outputs>2
         case 'rectangle'
 
             % Over time steps
-            parfor n=1:nsteps
-                
+            for n=1:nsteps
+
                 % Preallocate local gradient column
                 grad_col=zeros(nctrls,1,'like',1i);
 
@@ -405,7 +400,7 @@ if n_outputs>2
                         aux_vec=[zero_state; fwd_traj(:,n)];
             
                         % Propagate the auxiliary vector
-                        aux_vec=step(ss_parfor,aux_matrix,aux_vec,dt(n));
+                        aux_vec=step(spin_system,aux_matrix,aux_vec,dt(n));
                 
                         % Compute the derivative
                         grad_col(k)=bwd_traj(:,n+1)'*aux_vec(1:(end/2));
@@ -432,7 +427,7 @@ if n_outputs>2
             cc_comm=spin_system.control.cc_comm;
 
             % Loop over control sequence
-            parfor n=1:(nsteps+1)
+            for n=1:(nsteps+1)
 
                 % Allocate local gradient column
                 grad_col=zeros(nctrls,1,'like',1i);
@@ -454,7 +449,7 @@ if n_outputs>2
                         aux_vec=[zero_state; fwd_traj(:,n)];
 
                         % Propagate the auxiliary vector
-                        aux_vec=step(ss_parfor,DL_first,aux_vec,dt(n));
+                        aux_vec=step(spin_system,DL_first,aux_vec,dt(n));
 
                         % Compute the derivative
                         grad_col(k)=bwd_traj(:,n+1)'*aux_vec(1:(end/2));
@@ -478,7 +473,7 @@ if n_outputs>2
                         aux_vec=[zero_state; fwd_traj(:,n-1)];
 
                         % Propagate the auxiliary vector
-                        aux_vec=step(ss_parfor,DR_last,aux_vec,dt(n-1));
+                        aux_vec=step(spin_system,DR_last,aux_vec,dt(n-1));
 
                         % Compute the derivative
                         grad_col(k)=bwd_traj(:,end)'*aux_vec(1:(end/2));
@@ -502,7 +497,7 @@ if n_outputs>2
                         aux_vec_a=[zero_state; fwd_traj(:,n)];
 
                         % Propagate and extract derivative action
-                        aux_vec_a=step(ss_parfor,Right_DL,aux_vec_a,dt(n)); 
+                        aux_vec_a=step(spin_system,Right_DL,aux_vec_a,dt(n)); 
 
                         % Product rule: [dP2]*[P1]*rho part
                         grad_col(k)=grad_col(k)+bwd_traj(:,n+1)'*aux_vec_a(1:(end/2));
@@ -518,7 +513,7 @@ if n_outputs>2
                         aux_vec_b=[zero_state; fwd_traj(:,n-1)];
                         
                         % Propagate and extract derivative action
-                        aux_vec_b=step(ss_parfor,Left_DR,aux_vec_b,dt(n-1));
+                        aux_vec_b=step(spin_system,Left_DR,aux_vec_b,dt(n-1));
 
                         % Product rule: [P2]*[dP1]*rho part
                         grad_col(k)=grad_col(k)+bwd_traj(:,n)'*aux_vec_b(1:(end/2));
@@ -544,11 +539,11 @@ end
 % Compute Hessian
 if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
 
-    % Flip the backward trajectory for ease of paralellisation
+    % Flip the backward trajectory to match forward indexing
     bwd_traj=fliplr(bwd_traj);
 
     % Compute derivative trajectories
-    parfor n=1:nsteps
+    for n=1:nsteps
 
         % Preallocate local arrays
         fwd_dP_col=cell(nctrls,1);
@@ -635,7 +630,7 @@ if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
             bwd_dP=fliplr(bwd_dP);
 
             % Loop over timesteps
-            parfor n=1:nsteps
+            for n=1:nsteps
 
                 % Loop over controls
                 for k=1:nctrls
@@ -661,7 +656,7 @@ if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
             bwd_traj=fliplr(bwd_traj);
 
             % Loop over timesteps
-            parfor n=1:nsteps
+            for n=1:nsteps
 
                 % Preallocate local Hessian column
                 hess_col=zeros(nctrls,nsteps,nctrls,1,'like',1i);
@@ -708,7 +703,7 @@ if strcmp(spin_system.control.integrator,'rectangle')&&(n_outputs>3)
             bwd_traj=fliplr(bwd_traj); bwd_dP=fliplr(bwd_dP);
 
             % Loop over timesteps
-            parfor n=1:nsteps
+            for n=1:nsteps
 
                 % Allocate local Hessian column
                 hess_col=zeros(nctrls,nsteps,nctrls,1,'like',1i);

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -1,6 +1,6 @@
 % Validates optimal control options and updates the spin system
 % object. Syntax:
-% 
+%
 %          spin_system=optimcon(spin_system,control)
 %
 % Parameters:
@@ -9,12 +9,23 @@
 %                    created by create.m and updated
 %                    by basis.m functions
 %
-%     control      - control data structure described 
+%     control      - control data structure described
 %                    in detail in the online manual
 %
 % Outputs:
 %
 %     spin_system  - updated Spinach data structure
+%
+% Note: this function freezes the optimisation problem. The ensemble
+%       case catalog is built here, and the evaluation-invariant data
+%       (drift generators, control operators, and offset operators)
+%       is published to the parallel pool workers exactly once, as a
+%       parallel.pool.Constant held in spin_system.control.invariants;
+%       those three fields are then removed from the returned struc-
+%       ture. Numerical values of timings, powers, offsets, phases,
+%       states, and penalties may be overwritten between optimisati-
+%       ons; changes to the ensemble composition, the operators, or
+%       the generators require a fresh optimcon() call.
 %
 % david.goodwin@inano.au.dk
 % u.rasulov@soton.ac.uk
@@ -728,16 +739,9 @@ if isfield(control,'drifts')
         report(spin_system,[pad('Time-dependent drift generator',60) 'yes']);
     end
 
-    % Put drift generators on pool ValueStore
-    vs_labels=cell([numel(control.drifts) 1]);
-    for n=1:numel(control.drifts)
-        vs_labels{n}=['oc_drift_' num2str(n)];
-    end
-    store=gcp('nocreate').ValueStore;
-    put(store,vs_labels,control.drifts);
-
-    % Only keep the overall drift count
-    spin_system.control.ndrifts=numel(control.drifts); 
+    % Absorb drift generators and their count
+    spin_system.control.drifts=control.drifts;
+    spin_system.control.ndrifts=numel(control.drifts);
     control=rmfield(control,'drifts');
 
 else
@@ -1164,31 +1168,6 @@ else
     report(spin_system,[pad('Ensemble budget',60) 'all']);
 end
 
-% Parallelisation strategy
-if isfield(control,'parallel')
-
-    % Input validation
-    if ~ischar(control.parallel)
-        error('control.parallel must be a character string.');
-    end
-    if ~ismember(control.parallel,{'ensemble','time'})
-        error('control.parallel must be ''ensemble'' or ''time''.');
-    end
-
-    % Absorb the specification
-    spin_system.control.parallel=control.parallel;
-    control=rmfield(control,'parallel');
-
-else
-
-    % Default is over time steps
-    spin_system.control.parallel='time';
-
-end
-
-% Inform the user
-report(spin_system,[pad('Parallelisation strategy',60) spin_system.control.parallel]);
-                     
 % Plotting options
 if isfield(control,'plotting')
 
@@ -1335,6 +1314,45 @@ if ~isempty(unparsed)
     end
     error('there are problems with the control structure.');
 end
+
+% Build the ensemble case catalog
+[spin_system.control.catalog,...
+ spin_system.control.ens_sizes]=ens_catalog(spin_system.control);
+n_cases=size(spin_system.control.catalog,1);
+
+% Inform the user
+report(spin_system,[pad('Ensemble cases per objective evaluation',60) ...
+                    int2str(n_cases)]);
+
+% Report the parallel load balance ceiling
+nworkers=poolsize;
+if nworkers>0
+    balance=n_cases/(nworkers*ceil(n_cases/nworkers));
+    report(spin_system,[pad('Parallel pool size, workers',60) ...
+                        int2str(nworkers)]);
+    report(spin_system,[pad('Ensemble parallel efficiency ceiling',60) ...
+                        num2str(balance,'%.3f')]);
+end
+
+% Pack the evaluation-invariant problem data
+worker_data=spin_system; worker_data.control=struct();
+worker_data.control.integrator=spin_system.control.integrator;
+worker_data.control.method=spin_system.control.method;
+worker_data.control.steady=spin_system.control.steady;
+worker_data.control.dead_time=spin_system.control.dead_time;
+worker_data.control.prefix=spin_system.control.prefix;
+worker_data.control.suffix=spin_system.control.suffix;
+worker_data.control.pulse_nsteps=spin_system.control.pulse_nsteps;
+worker_data.control.pulse_ntpts=spin_system.control.pulse_ntpts;
+worker_data.control.operators=spin_system.control.operators;
+worker_data.control.off_ops=spin_system.control.off_ops;
+worker_data.control.drifts=spin_system.control.drifts;
+
+% Publish the invariants to the parallel pool, once per problem
+spin_system.control.invariants=parallel.pool.Constant(worker_data);
+
+% Keep heavy invariants off the per-evaluation communication path
+spin_system.control=rmfield(spin_system.control,{'operators','off_ops','drifts'});
 
 end
 

--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -17,15 +17,16 @@
 %     spin_system  - updated Spinach data structure
 %
 % Note: this function freezes the optimisation problem. The ensemble
-%       case catalog is built here, and the evaluation-invariant data
-%       (drift generators, control operators, and offset operators)
-%       is published to the parallel pool workers exactly once, as a
-%       parallel.pool.Constant held in spin_system.control.invariants;
-%       those three fields are then removed from the returned struc-
-%       ture. Numerical values of timings, powers, offsets, phases,
-%       states, and penalties may be overwritten between optimisati-
-%       ons; changes to the ensemble composition, the operators, or
-%       the generators require a fresh optimcon() call.
+%       case catalog is built here, and the complete frozen problem,
+%       including the drift generators, the control operators, and
+%       the offset operators, is published to the parallel pool wor-
+%       kers exactly once, as a parallel.pool.Constant held in
+%       spin_system.control.invariants; those three heavy fields are
+%       then removed from the returned structure. Numerical values
+%       of timings, powers, offsets, phases, states, and penalties
+%       may be overwritten between optimisations; changes to the en-
+%       semble composition, the operators, or the generators require
+%       a fresh optimcon() call.
 %
 % david.goodwin@inano.au.dk
 % u.rasulov@soton.ac.uk
@@ -1334,22 +1335,8 @@ if nworkers>0
                         num2str(balance,'%.3f')]);
 end
 
-% Pack the evaluation-invariant problem data
-worker_data=spin_system; worker_data.control=struct();
-worker_data.control.integrator=spin_system.control.integrator;
-worker_data.control.method=spin_system.control.method;
-worker_data.control.steady=spin_system.control.steady;
-worker_data.control.dead_time=spin_system.control.dead_time;
-worker_data.control.prefix=spin_system.control.prefix;
-worker_data.control.suffix=spin_system.control.suffix;
-worker_data.control.pulse_nsteps=spin_system.control.pulse_nsteps;
-worker_data.control.pulse_ntpts=spin_system.control.pulse_ntpts;
-worker_data.control.operators=spin_system.control.operators;
-worker_data.control.off_ops=spin_system.control.off_ops;
-worker_data.control.drifts=spin_system.control.drifts;
-
-% Publish the invariants to the parallel pool, once per problem
-spin_system.control.invariants=parallel.pool.Constant(worker_data);
+% Publish the complete frozen problem to the pool, once per problem
+spin_system.control.invariants=parallel.pool.Constant(spin_system);
 
 % Keep heavy invariants off the per-evaluation communication path
 spin_system.control=rmfield(spin_system.control,{'operators','off_ops','drifts'});

--- a/kernel/optimcon/tgrape.m
+++ b/kernel/optimcon/tgrape.m
@@ -93,7 +93,7 @@ if nargout>1
     grad=zeros(size(dt_grid));
 
     % Loop over control sequence
-    parfor n=1:nsteps
+    for n=1:nsteps
 
         % Make evolution generator
         L=drift;

--- a/kernel/optimcon/wrappers/grape_coop.m
+++ b/kernel/optimcon/wrappers/grape_coop.m
@@ -88,6 +88,8 @@ spin_system.control.rho_init(:)={rho};
 
 % Impurity cancellation gradients
 spin_system.control.ens_corrs={'rho_ens'};
+[spin_system.control.catalog,...
+ spin_system.control.ens_sizes]=ens_catalog(spin_system.control);
 [~,~,gradient_c]=grape_phase(profile_a,spin_system);
 [~,~,gradient_d]=grape_phase(profile_b,spin_system);
 

--- a/kernel/optimcon/wrappers/grape_curv.m
+++ b/kernel/optimcon/wrappers/grape_curv.m
@@ -50,7 +50,7 @@ function [traj_data,fidelity,df_du]=grape_curv(waveform_u,u2x,...
 grumble(waveform_u,u2x,dx_du,spin_system);
 
 % Count rectilinear and curvilinear coordinates
-size_x=numel(spin_system.control.operators); 
+size_x=spin_system.control.ncontrols; 
 n_time_pts=size(waveform_u,2);
 size_u=size(waveform_u,1); 
 

--- a/kernel/optimcon/wrappers/grape_phase.m
+++ b/kernel/optimcon/wrappers/grape_phase.m
@@ -108,7 +108,7 @@ elseif nargout==4
 
     % Transform Hessian from n^2 kxk block matrices to k^2 nxn matrices
     for n=1:size(hess_xy,3)
-        hess_xy(:,:,n)=hess_reorder(hess_xy(:,:,n),numel(spin_system.control.operators),...
+        hess_xy(:,:,n)=hess_reorder(hess_xy(:,:,n),spin_system.control.ncontrols,...
                                                    spin_system.control.pulse_nsteps);
     end
 
@@ -173,7 +173,7 @@ if ~isfield(spin_system.control,'amplitudes')
     error('control amplitude profile missing from spin_system.control.amplitudes.');
 end
 amp_profile=spin_system.control.amplitudes;
-if mod(numel(spin_system.control.operators),2)~=0
+if mod(spin_system.control.ncontrols,2)~=0
     error('phase-amplitude optimisations must have an even number of controls.');
 end
 if (~isnumeric(amp_profile))||(~isreal(amp_profile))
@@ -188,10 +188,10 @@ end
 if numel(amp_profile)~=numel(phi_profile)
     error('amp_profile and phi_profile must have the same number of elements.');
 end
-if size(amp_profile,1)~=numel(spin_system.control.operators)/2
+if size(amp_profile,1)~=spin_system.control.ncontrols/2
     error('the number of rows in amp_profile must be half the number of controls.');
 end
-if size(phi_profile,1)~=numel(spin_system.control.operators)/2
+if size(phi_profile,1)~=spin_system.control.ncontrols/2
     error('the number of rows in phi_profile must be half the number of controls.');
 end
 switch spin_system.control.integrator

--- a/kernel/optimcon/wrappers/grape_xy.m
+++ b/kernel/optimcon/wrappers/grape_xy.m
@@ -131,22 +131,22 @@ elseif nargout==4
         grad=permute(grad,[2 1 3]);
         
         % Preallocate transformed Hessians
-        hess_in_basis=zeros([nwaves*numel(spin_system.control.operators) ...
-                             nwaves*numel(spin_system.control.operators) ...
+        hess_in_basis=zeros([nwaves*spin_system.control.ncontrols ...
+                             nwaves*spin_system.control.ncontrols ...
                              npenterms+1]);
 
         % Transform Hessians
         for n=1:size(hess,3)
 
             % Reorder Hessian
-            hess_re=hess_reorder(hess(:,:,n),numel(spin_system.control.operators),...
+            hess_re=hess_reorder(hess(:,:,n),spin_system.control.ncontrols,...
                                              spin_system.control.pulse_nsteps);
 
             % Fold up the block matrix into a 4D tensor
             hess_re=reshape(hess_re,[spin_system.control.pulse_nsteps ...
-                                     numel(spin_system.control.operators) ...
+                                     spin_system.control.ncontrols ...
                                      spin_system.control.pulse_nsteps ...
-                                     numel(spin_system.control.operators)]);
+                                     spin_system.control.ncontrols]);
 
             % Transform the Hessian
             hess_re=tensorprod(spin_system.control.basis,hess_re,2,1);
@@ -154,12 +154,12 @@ elseif nargout==4
             hess_re=permute(hess_re,[2 3 1 4]);
 
             % Unfold the 4D tensor into block matrix
-            hess_re=reshape(hess_re,[nwaves*numel(spin_system.control.operators) ...
-                                     nwaves*numel(spin_system.control.operators)]);
+            hess_re=reshape(hess_re,[nwaves*spin_system.control.ncontrols ...
+                                     nwaves*spin_system.control.ncontrols]);
 
             % Reorder transformed Hessian
             hess_in_basis(:,:,n)=hess_reorder(hess_re,nwaves,...
-                                              numel(spin_system.control.operators));
+                                              spin_system.control.ncontrols);
 
         end
 
@@ -180,7 +180,7 @@ end
 if (~isnumeric(waveform))||(~isreal(waveform))
     error('waveform must be an array of real numbers.');
 end
-if size(waveform,1)~=numel(spin_system.control.operators)
+if size(waveform,1)~=spin_system.control.ncontrols
     error('the number of rows in waveform must be equal to the number of controls.');
 end
 if ~isempty(spin_system.control.basis)

--- a/tests/kernel/test_dynamic_optimcon_remaining.m
+++ b/tests/kernel/test_dynamic_optimcon_remaining.m
@@ -25,7 +25,7 @@ result=new_test_result('kernel/dynamic_optimcon_remaining',...
                        ['Remaining optimcon helper functions must pass '...
                         'small deterministic regression checks.']);
 
-% Ensure that optimcon and ensemble can use a process-pool ValueStore
+% Ensure that a parallel pool is available for the ensemble loop
 local_ensure_pool();
 
 % Run independent groups of small checks
@@ -607,7 +607,6 @@ control.p_weights=0;
 control.l_bound=-100;
 control.u_bound=100;
 control.plotting={};
-control.parallel='time';
 control.amplitudes=[5 6 7];
 spin_system=optimcon(spin_system,control);
 
@@ -628,7 +627,6 @@ spin_system.control.suffix=[];
 spin_system.control.keyholes=cell(1,2);
 spin_system.control.method='newton';
 spin_system.control.plotting={};
-spin_system.control.parallel='time';
 spin_system.control.freeze=[];
 spin_system.control.steady=false();
 drift=[0.20 0.10; -0.05 -0.10];
@@ -657,7 +655,6 @@ control.p_weights=0;
 control.l_bound=-100;
 control.u_bound=100;
 control.plotting={'correlation_order'};
-control.parallel='time';
 control.amplitudes=[4 5];
 spin_system=optimcon(spin_system,control);
 

--- a/tests/kernel/test_optimcon_grape_one_spin.m
+++ b/tests/kernel/test_optimcon_grape_one_spin.m
@@ -22,7 +22,7 @@ result=new_test_result('optimcon/grape_one_spin',...
                        'One-spin optimal-control setup and GRAPE gradient',...
                        'optimcon() and grape_hilb() must handle a tiny Hilbert-space control problem.');
 
-% Ensure that optimcon() has a process-pool ValueStore available
+% Ensure that a parallel pool is available for the ensemble loop
 current_pool=gcp('nocreate');
 if isempty(current_pool)
     parpool('Processes',1);


### PR DESCRIPTION
## What this does

Rebuilds the parallel architecture of the optimal control module around one principle: the ensemble is the only parallel dimension, and evaluation-invariant data crosses the process boundary exactly once per optimisation.

**optimcon()** now freezes the problem. It builds the ensemble case catalog once (new kernel function `ens_catalog.m`, also used by `grape_coop`), publishes the drift generators, control operators, and offset operators to the pool workers as a `parallel.pool.Constant` held in `control.invariants`, and removes those three fields from the returned structure. It also reports the ensemble size and the parallel load balance ceiling.

**ensemble()** runs one parfor over the catalog cases. Each case fetches the worker-resident invariants (measured 6.7 ms per dereference at a 3.9 MB payload) and grafts the evaluation-variable settings, so each objective evaluation ships only the waveform, the states, and small numerics. Client-side summation order is unchanged, which keeps results deterministic and independent of the worker count.

**grape_liouv() / grape_hilb() / tgrape()** lose all eleven internal `parfor` statements and become pure serial functions: under ensemble parallelism those loops always ran serially anyway, and outside it they shipped the evolution generator arrays to the client and back (4.7 GB per evaluation at Liouville dimension 21067). The time-parallel strategy, `control.parallel`, and every ValueStore use are gone; `create()` clearing the ValueStore can no longer destroy a live optimisation.

**Contract.** Post-optimcon overwrites of `pulse_dt`, `pwr_levels`, offset values, phases, states, penalties, and bounds remain supported (sweep drivers keep working). Changing the ensemble composition, the operators, or the generators now raises a clear error instead of going silently stale; supplying `control.parallel` fails loudly as an unrecognised option. Direct low-level calls of `grape_liouv`/`grape_hilb` with the client structure keep working.

## Measured results

Back-to-back runs, same host, 12 process workers, one fidelity+gradient evaluation:

| case | traffic/eval before | after | wall before | after |
|---|---|---|---|---|
| dim 1909, 135 cases | 8.12 MB | 0.24 MB | 32.4 s | 33.1 s |
| dim 21067, 36 cases | 96.97 MB | 0.20 MB | 79.9 s | 60.8 s |

At dimension 21067 the ranges do not overlap (new max 62.4 s vs old min 75.0 s): removing the per-evaluation broadcast serialisation is worth 24% of wall clock at scale. At dimension 1909 wall time is parity within this host's run-to-run drift.

## Validation

- 11-case equivalence battery (rectangle and trapezium integrators, Liouville and Hilbert formalisms, phase cycling, a two-member distortion ensemble with Jacobians, six-member drift ensemble, `rho_drift` correlation, ensemble budget, Newton Hessian, cooperative pulses via `grape_coop`, and post-optimcon sweep overwrites): fidelities, gradients, and Hessians **bitwise identical** to current main in every case.
- All three shipped optimcon test suites pass (`optimcon/support_paths`, `optimcon/grape_one_spin`, `kernel/dynamic_optimcon_remaining`; the latter two updated for the new architecture).
- All 11 shipped derivative tests pass (`auxmat_test`, `dirdiff_1`...`dirdiff_8`), plus a five-seed determinised version of `dirdiff_4_trap` with gradients bitwise identical across trees.
- 13 optimal control examples run on the new tree covering Newton, trapezium, phase cycles, freeze masks, `zeeman-wavef`, keyholes, waveform bases, `tgrape` time-optimal control, cooperative pulses, variable `dt`, and RLC distortions: five to completion, the rest deep into healthy optimisation under a smoke-test time cap, zero errors.
- `checkcode` clean on all touched kernel files; house-style violation count reduced from 32 to 25 with none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)