### PR TITLE
grape_hilb.m: match the overlap conjugation to the gradient

### DIFF
--- a/kernel/optimcon/grape_hilb.m
+++ b/kernel/optimcon/grape_hilb.m
@@ -242,7 +242,7 @@ if n_outputs>2
 end
 
 % Calculate the state overlap
-overlap=hdot(fwd_traj{end},rho_targ);
+overlap=hdot(rho_targ,fwd_traj{end});
 
 % Compute gradient
 if n_outputs>2


### PR DESCRIPTION
Fixes finding 1 of today's optimal control module audit.

`grape_hilb.m` computed the state overlap as `hdot(fwd_traj{end},rho_targ)` — the complex conjugate of the `<target|rho(T)>` convention that `grape_liouv.m` uses and that the adjoint-state gradient chain differentiates. Consequences, measured before the fix on a one-spin problem with a non-Hermitian target (`L+`): the `'imag'` fidelity gradient was exactly opposite in sign to central differences of the engine's own returned fidelity (+2.194931e-7 vs −2.194931e-7), the `'imag'` fidelity value was sign-flipped relative to `grape_liouv` on identical physics, and the `'square'` gradient and Hessian were wrong whenever the overlap is complex. `'real'` fidelities and Hermitian targets were unaffected, which is why every shipped test and example passed.

The fix is the one-line conjugation swap: `overlap=hdot(rho_targ,fwd_traj{end})`. The downstream `'square'` product rules are correct once the overlap carries the right convention, so nothing else changes.

Validation (MATLAB R2026a, this branch): gradients of all three fidelity types match central differences of the returned fidelity in both engines (rel. err. 9.4e-8 to 3.8e-9); the two engines now agree on all three fidelity values for the same physics to ten digits; the `'square'` Hessian matches directional finite-difference curvature (9.4e-4 at h=5e-2); `dirdiff_3_rect` and `dirdiff_5_rect` (Hilbert-space gradients and both Hessian types) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
