### PR TITLE
optimcon.m: stroboscopic steady states require sphten-liouv

### DIFF
--- a/kernel/optimcon/optimcon.m
+++ b/kernel/optimcon/optimcon.m
@@ -406,9 +406,12 @@ if isfield(control,'steady')
     if ~islogical(control.steady) || ~isscalar(control.steady)
         error('control.steady must be true() or false()');
     end
+    if control.steady&&(~strcmp(spin_system.bas.formalism,'sphten-liouv'))
+        error('stroboscopic steady states require sphten-liouv formalism.');
+    end
 
     % Absorb stroboscopic steady state switch
-    spin_system.control.steady=control.steady; 
+    spin_system.control.steady=control.steady;
     control=rmfield(control,'steady');
 
     % Inform the user


### PR DESCRIPTION
Fixes finding 3 of today's optimal control module audit.

`control.steady=true()` with the `zeeman-hilb` formalism was silently ignored: the steady-state machinery lives in `grape_liouv.m`, whose grumble refuses non-sphten Liouville formalisms, but the Hilbert-space route dispatches to `grape_hilb.m`, which has no steady-state branch and no guard. Measured before the fix: the run proceeded without error and the returned fidelity depended on the `rho_init` that `optimcon()` had just told the user would be ignored (0.697942008 vs 0.112830789 for two different initial states) — an ordinary transfer, not the steady-state functional. The manual already states the sphten-liouv requirement; the parser now enforces it.

Validation (MATLAB R2026a, this branch): `control.steady=true()` is refused at parse time in `zeeman-hilb` and `zeeman-liouv` with the formalism named in the error; it is accepted in `sphten-liouv`; `control.steady=false()` remains accepted in any formalism. `checkcode` clean; no new house-style violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
