### PR TITLE
Add dhofun.m, a normalised damped harmonic oscillator lineshape

### DIFF
--- a/kernel/line_shapes/dhofun.m
+++ b/kernel/line_shapes/dhofun.m
@@ -1,0 +1,63 @@
+% Normalised damped harmonic oscillator response function in mag-
+% netic resonance notation. This is the standard shape of a phonon
+% band: a resonance at the natural frequency of the oscillator, br-
+% oadened by damping, and vanishing quadratically at zero frequen-
+% cy, which a Lorentzian centred at the same place does not do. In
+% the weak damping limit the function tends to a Lorentzian of the
+% same width. Syntax:
+%
+%                    y=dhofun(x,nat_freq,fwhm)
+%
+% Parameters:
+%
+%            x - argument values, a real array of any dimension;
+%                the function is zero at non-positive arguments
+%
+%     nat_freq - natural frequency of the undamped oscillator, a
+%                positive real scalar, in the same units as x; the
+%                maximum of the function sits exactly here
+%
+%         fwhm - damping rate of the oscillator, a positive real
+%                scalar, in the same units as x; for this respon-
+%                se function it is exactly the full width at half-
+%                maximum, at any damping
+%
+% Outputs:
+%
+%            y - function values at the points specified in x, an
+%                array of the same dimension as x, normalised to
+%                unit integral over positive arguments
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=dhofun.m>
+
+function y=dhofun(x,nat_freq,fwhm)
+
+% Check consistency
+grumble(x,nat_freq,fwhm);
+
+% The response function only lives at positive frequencies
+y=zeros(size(x)); pos_args=(x>0); arg=x(pos_args);
+
+% Compute the normalised damped oscillator response
+y(pos_args)=(2*fwhm/pi)*(arg.^2)./...
+            ((arg.^2-nat_freq^2).^2+(fwhm*arg).^2);
+
+end
+
+% Consistency enforcement
+function grumble(x,nat_freq,fwhm)
+if (~isnumeric(x))||(~isreal(x))
+    error('x must be an array of real numbers.');
+end
+if (~isnumeric(nat_freq))||(~isreal(nat_freq))||...
+   (numel(nat_freq)~=1)||(nat_freq<=0)
+    error('nat_freq must be a positive real scalar.');
+end
+if (~isnumeric(fwhm))||(~isreal(fwhm))||...
+   (numel(fwhm)~=1)||(fwhm<=0)
+    error('fwhm must be a positive real scalar.');
+end
+end
+

--- a/kernel/line_shapes/dhofun.m
+++ b/kernel/line_shapes/dhofun.m
@@ -4,7 +4,8 @@
 % oadened by damping, and vanishing quadratically at zero frequen-
 % cy, which a Lorentzian centred at the same place does not do. In
 % the weak damping limit the function tends to a Lorentzian of the
-% same width. Syntax:
+% same width. Evaluation uses frequencies scaled by nat_freq to
+% avoid intermediate overflow in single precision. Syntax:
 %
 %                    y=dhofun(x,nat_freq,fwhm)
 %
@@ -25,8 +26,8 @@
 % Outputs:
 %
 %            y - function values at the points specified in x, an
-%                array of the same dimension as x, normalised to
-%                unit integral over positive arguments
+%                array of the same size and type as x, normalised
+%                to unit integral over positive arguments
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -38,11 +39,12 @@ function y=dhofun(x,nat_freq,fwhm)
 grumble(x,nat_freq,fwhm);
 
 % The response function only lives at positive frequencies
-y=zeros(size(x)); pos_args=(x>0); arg=x(pos_args);
+y=zeros(size(x),'like',x); pos_args=(x>0); arg=x(pos_args);
 
-% Compute the normalised damped oscillator response
-y(pos_args)=(2*fwhm/pi)*(arg.^2)./...
-            ((arg.^2-nat_freq^2).^2+(fwhm*arg).^2);
+% Compute the response in reduced frequency units
+rel_freq=arg/nat_freq; rel_fwhm=fwhm/nat_freq;
+y(pos_args)=(2*rel_fwhm/(pi*nat_freq))*(rel_freq.^2)./...
+            ((rel_freq.^2-1).^2+(rel_fwhm*rel_freq).^2);
 
 end
 
@@ -52,12 +54,12 @@ if (~isnumeric(x))||(~isreal(x))
     error('x must be an array of real numbers.');
 end
 if (~isnumeric(nat_freq))||(~isreal(nat_freq))||...
-   (numel(nat_freq)~=1)||(nat_freq<=0)
-    error('nat_freq must be a positive real scalar.');
+   (numel(nat_freq)~=1)||(~isfinite(nat_freq))||(nat_freq<=0)
+    error('nat_freq must be a finite positive real scalar.');
 end
 if (~isnumeric(fwhm))||(~isreal(fwhm))||...
-   (numel(fwhm)~=1)||(fwhm<=0)
-    error('fwhm must be a positive real scalar.');
+   (numel(fwhm)~=1)||(~isfinite(fwhm))||(fwhm<=0)
+    error('fwhm must be a finite positive real scalar.');
 end
 end
 


### PR DESCRIPTION
## Summary

Adds `kernel/line_shapes/dhofun.m`, a normalised damped harmonic oscillator
response function, alongside the existing `gaussfun.m` and `lorentzfun.m`.

This is the standard shape of a phonon band, and it is what the spin-phonon
side of the package currently lacks: a Lorentzian centred at the mode frequency
does not vanish at zero frequency and therefore misbehaves as a spectral
density weight for soft modes, whereas the damped oscillator response goes as
the square of the frequency at the bottom of the band.

```
                    y=dhofun(x,nat_freq,fwhm)
```

The function is zero at non-positive arguments and normalised to unit integral
over positive arguments. Two exact properties, which hold at any damping and
are stated in the header:

* the maximum sits exactly at `nat_freq`;
* the full width at half-maximum is exactly `fwhm`.

No existing file is touched and nothing calls the new function, so the change
cannot affect any current result.

## Validation

Headless MATLAB probe, all assertions passed, log clean, no warnings:

* `checkcode` empty, house-style checker clean;
* unit integral over positive frequencies at `fwhm` = 1e-3, 0.01, 0.1, 1, 5,
  and 20, with `nat_freq` = 3; worst error 5.9e-14;
* weak damping limit agrees with `lorentzfun(nat_freq,2,fwhm,x,0)` to a
  relative deviation of 1.9e-4 at `fwhm/nat_freq` = 5e-4;
* maximum over a fine grid never exceeds `dhofun(nat_freq,nat_freq,fwhm)` at
  `fwhm` = 0.05, 1, 2, and 8;
* full width at half-maximum recovered by `fzero` equals `fwhm` to 1e-15 at
  `fwhm` = 0.05, 1, 2, and 8;
* exact zeros at non-positive arguments, output shape follows input shape for
  a 4x5x3 array, and values are non-negative;
* low-frequency power-law exponent measured as 2.000000009;
* grumbler rejects complex `x`, non-positive `nat_freq`, non-positive `fwhm`,
  and non-scalar `nat_freq` or `fwhm`.
