### PR TITLE
Suppress the GPU deprecation warning and propagate warning switches to pool workers

### DIFF
--- a/kernel/create.m
+++ b/kernel/create.m
@@ -369,6 +369,10 @@ if ~isworkernode
     
     end
     
+    % Propagate manual warning switches to the workers
+    warn_state=warning();
+    wait(parfevalOnAll(current_pool,@warning,0,warn_state));
+    
 else
 
     % Workers do not need setting up

--- a/kernel/includes/autoexec.m
+++ b/kernel/includes/autoexec.m
@@ -7,6 +7,9 @@
 %
 % <https://spindynamics.org/wiki/index.php?title=autoexec.m>
 
+% Kill the pointless GPU deprecation warning
+warning('off','parallel:gpu:device:DeviceDeprecated');
+
 % Kill stupid ass figure defaults in R2025a and later 
 set(groot,'defaultFigurePosition',[680 458 560 420]); 
 set(groot,'defaultFigureWindowStyle','normal'); 


### PR DESCRIPTION
Two commits.

**`autoexec.m`: suppress the GPU device deprecation warning**

```matlab
% Kill the pointless GPU deprecation warning
warning('off','parallel:gpu:device:DeviceDeprecated');
```

Because `autoexec.m` is executed at the start of `create.m`, the suppression is Spinach-wide from the first `create()` call onwards. The identifier is the real Matlab one (`resources/parallel/en/gpu/device.xml`, key `DeviceDeprecated`, context `warning`); a grep over the tree confirms nothing turns it back on (the only whole-state restores, `ilpcs.m`, `ippcs.m` and `test_dynamic_integrity_includes_mex_suite.m`, each save and restore one unrelated identifier). Probe: the warning is forced on, then `create()` is called, and `warning('query',...)` returns `off`.

**`create.m`: propagate manual warning switches to pool workers**

Fresh pool workers start with the factory warning state, so client-side disable statements did not hold inside `parfor`/`spmd`. After the pool is created or adopted, the client's warning settings are now replayed on every worker:

```matlab
% Propagate manual warning switches to the workers
warn_state=warning();
wait(parfevalOnAll(current_pool,@warning,0,warn_state));
```

The paragraph sits after the pool if/else, so it covers both a freshly started pool and a re-used one. Probe on a two-worker process pool: `MATLAB:nearlySingularMatrix` (on by default) is switched off on the client before `create()`; both workers then report `off` for it and for the GPU deprecation warning — a default-on identifier reading `off` on a fresh worker can only come from the propagation. `checkcode` and the house-style gate report nothing new on either file.
