### PR TITLE
hamiltonian: honour declared mode carriers in the offset frame

### DIFF
--- a/kernel/hamiltonian.m
+++ b/kernel/hamiltonian.m
@@ -931,9 +931,10 @@ if isfield(spin_system.inter,'modes')
                 omega_ref=abs(carrier_frqs(1));
             end
 
-            % Assign the reference to the member modes
+            % Assign the reference to member modes without declared carriers
             sub_modes=reshape(intersect(members,mode_list),1,[]);
-            mode_refs(sub_modes)=omega_ref;
+            no_carr=sub_modes(modes.carriers(sub_modes)==0);
+            mode_refs(no_carr)=omega_ref;
 
             % Declared carriers must agree with the connected spin carrier
             for k=sub_modes
@@ -978,7 +979,7 @@ if isfield(spin_system.inter,'modes')
                     % Add to the invariant part
                     I=I+omega*operator(spin_system,{'N'},{k},operator_type);
 
-                elseif mode_refs(k)~=0
+                elseif (mode_refs(k)~=0)||(modes.carriers(k)>0)
 
                     % Inform the user
                     report(spin_system,['bosonic mode ' num2str(k) ' is on resonance with its carrier.']);


### PR DESCRIPTION
## Defect

`kernel/create.m` documents and implements `inter.modes.frqs` as a detuning whenever `inter.modes.carriers` is declared (thermal occupations and validation use carrier+frqs as the physical frequency). The 'offset' branch of `kernel/hamiltonian.m`, however, assigned `mode_refs(sub_modes)=omega_ref` (the connected-spin carrier) to every mode in the subgraph — including carrier-declared ones — and then computed `omega=modes.frqs(k)-mode_refs(k)`. Its own consistency check admits a declared carrier equal to the spin carrier, so the legal input {carrier=w_c, frqs=detuning} produced a mode energy of detuning−w_c: wrong by the full carrier, silently. No shipped example declares mode carriers, which is why it went unnoticed.

## Measurement (E + C5 Jaynes-Cummings system, 0.33 T)

Before: carrier-declared on-resonance mode vs the equivalent stock declaration differ by exactly `c*N` with c/(2π) = −9.248234 GHz = −e_frq (fit residual 6.5e-05 against a 4.5e11 norm).

After: on-resonance difference exactly 0; +5 MHz-detuned difference 4.6e-05 absolute (~1e-12 relative, carrier-addition rounding); `jaynes_cummings_a` runs unchanged.

## Change

Two lines in the offset branch: the reference assignment now excludes modes with declared carriers (their frqs are already detunings), and the on-resonance console message also covers carrier-declared modes. The stray-mode warning already excluded declared carriers and is untouched.

House style: no new violations; `checkcode` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)