### PR TITLE
device: hermitise the Hamiltonian before rotating-frame transforms

### DIFF
--- a/kernel/contexts/device.m
+++ b/kernel/contexts/device.m
@@ -86,6 +86,7 @@ spin_system=assume(spin_system,assumptions);
 % Get the Hamiltonian at the spin subsystem orientation
 [I,Q]=hamiltonian(spin_system);
 H=I+orientation(Q,parameters.orientation);
+H=(H+H')/2;
 
 % Get relaxation and kinetics superoperators
 R=relaxation(spin_system,parameters.orientation);


### PR DESCRIPTION
## Defect

`device.m` built `H=I+orientation(Q,parameters.orientation)` and passed it straight into `rotframe()` when `parameters.rframes` is non-empty. The Wigner reconstruction leaves a ~1e-16-relative anti-Hermitian summation residue (measured 1-norm 7.5e-9 on a 0.33 T cavity system at orientation [0.3 0.7 1.1]), and `rotframe`'s grumbler is an exact `ishermitian` test, so every such call died with "both H and C must be Hermitian". All sibling contexts hermitise before their rframes loops (`crystal.m:111`, `singlerot.m:295`, `doublerot.m:326`); no shipped example exercises device with rframes, which is why this was invisible to the suite.

## Change and validation

One line after Hamiltonian assembly: `H=(H+H')/2;`, exactly as in `crystal.m`.

Measured: the pre-fix crash point (rotframe hermiticity grumble) is now cleared — execution proceeds into `intrep`, where the synthetic probe system is then stopped by the independent, pre-existing H1-vs-H0 perturbation-order gate (my probe couples a cavity-assumption system to an 'E' rank-2 frame, which is not a physical rframes use; the hermiticity fix is orthogonal to that gate). The rframes-free production path is regression-checked: `spin_cavity_vacuum_rabi` runs clean with its internal assertions.

House style: 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)