### PR TITLE
floquet: fire the truncation warning on present interaction ranks only

### DIFF
--- a/kernel/contexts/floquet.m
+++ b/kernel/contexts/floquet.m
@@ -114,7 +114,7 @@ report(spin_system,['non-empty spherical ranks in Q: ' num2str(int_ranks)]);
 max_int=max([int_ranks 2]);
 
 % Warn about truncated rotor harmonics
-if max_int>parameters.max_rank
+if any(int_ranks>parameters.max_rank)
     report(spin_system,'WARNING - max_rank is below an interaction rank, its harmonics are truncated.');
 end
 


### PR DESCRIPTION
## Defect

The truncation warning in `kernel/contexts/floquet.m` tested `max_int>parameters.max_rank`, where `max_int=max([int_ranks 2])` is floored at 2 because it also sizes the Fourier block. For systems whose Q has no anisotropic content at all (or rank-1 only), any run with `parameters.max_rank<2` (the grumbler allows `>=0`) printed "WARNING - max_rank is below an interaction rank, its harmonics are truncated." although the non-empty rank list is empty and nothing is truncated. `gridfree.m` implements the same check correctly (`any(int_ranks>parameters.max_rank)`), and commit 376461e0's message states the intended semantics ("a console warning fires when max_rank is below a present interaction rank").

## Measurement

Before: isotropic 13C system, max_rank=1 → warning fires while the console shows "non-empty spherical ranks in Q:" (empty). After: the same run is silent; a rank-2 CSA system at max_rank=1 still warns; `mas_powder_gly_floquet` runs clean. `max_int` and the assembled Floquet matrix are untouched (warning predicate only).

House style: no new violations (1 pre-existing, unchanged); checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)