### PR TITLE
Skip ValueStore caching when no parallel pool exists

### DIFF
--- a/kernel/hamiltonian.m
+++ b/kernel/hamiltonian.m
@@ -609,22 +609,28 @@ if ismember('ham_cache',spin_system.sys.enable)
                            spin_system.bas.basis_hash});
     end
 
-    % Get ValueStore
+    % Get ValueStore, unless the client has no parallel pool
     if ~isworkernode
-        store=gcp('nocreate').ValueStore; 
+        pool=gcp('nocreate');
+        if isempty(pool)
+            report(spin_system,'no parallel pool, Hamiltonian cache skipped.');
+            store=[];
+        else
+            store=pool.ValueStore;
+        end
     else
         store=getCurrentValueStore(); 
     end
 
     % Try to retrieve the operator from the ValueStore
-    if build_aniso&&isKey(store,[ham_hash ':I'])...
+    if (~isempty(store))&&build_aniso&&isKey(store,[ham_hash ':I'])...
                   &&isKey(store,[ham_hash ':Q'])
 
         % Load I and Q, report success, and return
         I=store([ham_hash ':I']); Q=store([ham_hash ':Q']);
         report(spin_system,'cache record used.'); return;
 
-    elseif (~build_aniso)&&isKey(store,[ham_hash ':I'])
+    elseif (~isempty(store))&&(~build_aniso)&&isKey(store,[ham_hash ':I'])
 
         % Load I, report success, and return
         I=store([ham_hash ':I']); 
@@ -1367,12 +1373,12 @@ end
 if ismember('ham_cache',spin_system.sys.enable)
 
     % Update the cache: isotropic part
-    if ~isKey(store,[ham_hash ':I'])
+    if (~isempty(store))&&(~isKey(store,[ham_hash ':I']))
         put(store,{[ham_hash ':I']},{I});
     end
 
     % Update the cache: anisotropic part
-    if build_aniso&&(~isKey(store,[ham_hash ':Q']))
+    if (~isempty(store))&&build_aniso&&(~isKey(store,[ham_hash ':Q']))
         put(store,{[ham_hash ':Q']},{Q});
     end
 

--- a/kernel/operator.m
+++ b/kernel/operator.m
@@ -88,15 +88,21 @@ if ismember('op_cache',spin_system.sys.enable)
                       spin_system.bas.basis_hash});
     op_hash=[op_hash ':O']; % Mark as operator
 
-    % Get ValueStore
+    % Get ValueStore, unless the client has no parallel pool
     if ~isworkernode
-        store=gcp('nocreate').ValueStore; 
+        pool=gcp('nocreate');
+        if isempty(pool)
+            report(spin_system,'no parallel pool, operator cache skipped.');
+            store=[];
+        else
+            store=pool.ValueStore;
+        end
     else
         store=getCurrentValueStore(); 
     end
 
     % Try to retrieve the operator from the ValueStore
-    if isKey(store,op_hash), A=store(op_hash); return; end
+    if (~isempty(store))&&isKey(store,op_hash), A=store(op_hash); return; end
     
 end
 
@@ -209,7 +215,7 @@ end
 if ismember('op_cache',spin_system.sys.enable)
 
     % Update the ValueStore
-    if ~isKey(store,op_hash)
+    if (~isempty(store))&&(~isKey(store,op_hash))
         put(store,{op_hash},{A});
     end
 

--- a/kernel/propagator.m
+++ b/kernel/propagator.m
@@ -48,15 +48,21 @@ if ismember('prop_cache',spin_system.sys.enable)
     prop_hash=md5_hash({L,timestep,spin_system.tols.prop_chop});
     prop_hash=[prop_hash ':P']; % Mark as propagator
 
-    % Get ValueStore
+    % Get ValueStore, unless the client has no parallel pool
     if ~isworkernode
-        store=gcp('nocreate').ValueStore; 
+        pool=gcp('nocreate');
+        if isempty(pool)
+            report(spin_system,'no parallel pool, propagator cache skipped.');
+            store=[];
+        else
+            store=pool.ValueStore;
+        end
     else
         store=getCurrentValueStore(); 
     end
 
     % Try to retrieve the propagator from the ValueStore
-    if isKey(store,prop_hash), P=store(prop_hash); return; end
+    if (~isempty(store))&&isKey(store,prop_hash), P=store(prop_hash); return; end
     
 end
 
@@ -214,7 +220,7 @@ end
 if ismember('prop_cache',spin_system.sys.enable)
 
     % Update the ValueStore
-    if ~isKey(store,prop_hash)
+    if (~isempty(store))&&(~isKey(store,prop_hash))
         put(store,{prop_hash},{P});
     end
 


### PR DESCRIPTION
## Defect

With `op_cache`/`ham_cache`/`prop_cache` enabled, the client-side branch in `operator.m`, `hamiltonian.m`, and `propagator.m` does `store=gcp('nocreate').ValueStore`. When no pool is alive — pool crashed mid-run, deleted by the user, or a cache-enabled `spin_system` loaded into a fresh session without going through `create()` — `gcp('nocreate')` returns a 0x0 `parallel.Pool` and dot-indexing it throws "Unrecognized method, property, or field 'ValueStore' for class 'parallel.Pool'" before any computation. The old file-based cache was resilient in the same scenario (measured at 23984e1d: the operator builds fine after pool deletion).

## Measurement (R2026a, 2-spin system, all three caches enabled)

Before: after `delete(gcp('nocreate'))`, `operator(spin_system,{'Lz'},{1})` hard-crashes as above. After: the same call reports "no parallel pool, operator cache skipped." and computes; `hamiltonian` and `propagator` likewise; all three poolless results match the pooled cached references to the last bit (norm deltas 0), and pooled caching behaviour is unchanged.

## Change

At each of the three client-side store acquisitions: an `isempty(gcp('nocreate'))` check that reports and sets `store=[]`; all cache reads and writes are guarded on store presence. Worker-side `getCurrentValueStore()` path untouched.

Note: touches lines adjacent to #342 in `hamiltonian.m` — whichever merges second may need a trivial rebase; happy to do it.

House style: no new violations (7 pre-existing across the three files, unchanged); checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)