### PR TITLE
grape_phase: keep the freeze mask logical through the kron translation

### DIFF
--- a/kernel/optimcon/wrappers/grape_phase.m
+++ b/kernel/optimcon/wrappers/grape_phase.m
@@ -51,7 +51,7 @@ for n=1:size(phi_profile,1)
 end
 
 % Translate the freeze mask to Cartesians
-spin_system.control.freeze=kron(spin_system.control.freeze,[1; 1]);
+spin_system.control.freeze=logical(kron(spin_system.control.freeze,[1; 1]));
 
 % Just fidelity
 if nargout==2


### PR DESCRIPTION
## Defect

`grape_phase.m` translates the user's phase-space freeze mask to Cartesians with `kron(spin_system.control.freeze,[1;1])`. `kron` of a logical returns a double 0/1 array; `grape_liouv.m`'s Hessian masking then does `hess(frozen(:),:)=0; ...` — subscript indexing with a double — and any 0 entry (guaranteed, since all-frozen masks are refused by optimcon) throws "Array indices must be positive integers or logical values". Phase-modulated Newton/Goodwin optimisation with `control.freeze` therefore crashed; the gradient path (`~frozen(k,n)`) tolerated the double mask, so LBFGS hid the defect. optimcon itself stores the mask as logical (`optimcon.m:844`) — only this translation dropped the type.

## Measurement

Before: `[~,fid,grad,hess]=grape_phase(phi,ss)` with `method='newton'` and `freeze=[true false(1,49)]` crashes as above (production path, one-spin system). After: the call returns fid 0.968, a 50×50 Hessian, zero gradient on the frozen entry, and 49 nonzero gradient entries.

## Change

One line: `logical(...)` around the kron.

House style: 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)