### PR TITLE
summary_basis: format state labels for multiplicities above ten

### DIFF
--- a/kernel/summaries/summary_basis.m
+++ b/kernel/summaries/summary_basis.m
@@ -33,19 +33,8 @@ else
         current_line(1:length(spin_number))=spin_number;
         for k=1:spin_system.comp.nspins
             [L,M]=lin2lm(spin_system.bas.basis(n,k));
-            current_line(7+8*(k-1)+1)='(';
-            current_line(7+8*(k-1)+2)=num2str(L);
-            current_line(7+8*(k-1)+3)=',';
-            proj=num2str(M);
-            switch length(proj)
-                case 1
-                    current_line(7+8*(k-1)+4)=proj;
-                    current_line(7+8*(k-1)+5)=')';
-                case 2
-                    current_line(7+8*(k-1)+4)=proj(1);
-                    current_line(7+8*(k-1)+5)=proj(2);
-                    current_line(7+8*(k-1)+6)=')';
-            end
+            state_token=['(' num2str(L) ',' num2str(M) ')'];
+            current_line(7+8*(k-1)+(1:length(state_token)))=state_token;
         end
         report(spin_system,current_line);
     end

--- a/kernel/summaries/summary_basis.m
+++ b/kernel/summaries/summary_basis.m
@@ -33,6 +33,8 @@ else
         current_line(1:length(spin_number))=spin_number;
         for k=1:spin_system.comp.nspins
             [L,M]=lin2lm(spin_system.bas.basis(n,k));
+
+            % Format the state label and place it in the line
             state_token=['(' num2str(L) ',' num2str(M) ')'];
             current_line(7+8*(k-1)+(1:length(state_token)))=state_token;
         end


### PR DESCRIPTION
## Defect

The state-label formatter in `kernel/summaries/summary_basis.m` assigned `num2str(L)` into a single character slot (`current_line(...)=num2str(L)`) and its projection switch handled only 1- and 2-character `num2str(M)`. For any particle with multiplicity ≥ 11 (rank L ≥ 10), `num2str(L)` is 1×2 and the assignment throws "Unable to perform assignment because the left and right sides have a different number of elements." This was a carry-over from old `summary.m`, where it was only reachable with exotic spin ≥ 5 nuclei; this revision range makes multiplicities 11–16 ordinary (bosonic modes 'C#'/'V#'/'T#' and high-spin electrons), so the crash fires whenever a small system containing one prints its basis summary — i.e. inside `basis()`. The base commit refused such multiplicities with a clean "multiplicities above 10 are not supported by sphten-liouv formalism" error; head admits them and then crashes cryptically.

## Measurement

Before: `{'E','C12'}` and `{'E16'}` sphten-liouv systems crash in `basis()` (MATLAB:matrix:singleSubscriptNumelMismatch). After: both print their summaries; a 2-spin 1H/13C summary is byte-identical to the old formatter's output (verified line-by-line against the old per-character code).

## Change

The per-character assignments are replaced by one token write into the same 8-character field: `'(L,M)'` fits the field up to `(99,-99)`, and the layout for existing low-multiplicity labels is unchanged.

House style: 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)