### PR TITLE
summary_rlx_t1_t2: handle cell-stored per-spin rates

### DIFF
--- a/kernel/summaries/summary_rlx_t1_t2.m
+++ b/kernel/summaries/summary_rlx_t1_t2.m
@@ -30,12 +30,23 @@ report(spin_system,'----------------------------------------');
 for n=1:spin_system.comp.nspins
     report(spin_system,[strjust([num2str(n) blanks(3-length(num2str(n)))],'left') ' '...
                         strjust([spin_system.comp.isotopes{n} blanks(5-length(spin_system.comp.isotopes{n}))],'center') '  '...
-                        num2str(spin_system.rlx.r1_rates(n),'%+0.5e   ') '  '...
-                        num2str(spin_system.rlx.r2_rates(n),'%+0.5e   ') '  '...
+                        rate_text(spin_system.rlx.r1_rates{n}) '  '...
+                        rate_text(spin_system.rlx.r2_rates{n}) '  '...
                         spin_system.comp.labels{n}]);
 end
 report(spin_system,'========================================');
 
+end
+
+% Formats a scalar, tensor, or function-handle relaxation rate
+function rate_str=rate_text(rate)
+if isnumeric(rate)&&isscalar(rate)
+    rate_str=num2str(rate,'%+0.5e   ');
+elseif isnumeric(rate)
+    rate_str='anisotropic    ';
+else
+    rate_str='orientation    ';
+end
 end
 
 % Consistency enforcement


### PR DESCRIPTION
## Defect

`kernel/summaries/summary_rlx_t1_t2.m` indexed `spin_system.rlx.r1_rates(n)`/`r2_rates(n)` as numeric arrays, but under the extended T1/T2 model `create.m` stores them as cell arrays of per-spin scalars, 3×3 tensors, or function handles (`create.m:1262,1272-1273`). `num2str` of a 1×1 cell throws "Input to num2str must be numeric" on the first table row, so the function crashed for every legal input. It has no in-tree caller, but presents itself as public API with its own wiki link.

## Measurement

Before: `summary_rlx_t1_t2(spin_system,'test')` under the documented `inter.relaxation={'t1_t2'}` setup crashes as above. After: scalar rates print in the original `%+0.5e` format (both values verified in the captured table), and a system mixing a 3×3 tensor R1 with an orientation-dependent function-handle R1 prints 'anisotropic'/'orientation' placeholders in the same columns.

## Change

The two `num2str(...(n),...)` calls become `rate_text(...{n})` with a small helper that dispatches on scalar/numeric/handle, mirroring create.m's own type dispatch.

House style: 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)