### PR TITLE
frob_chop: relative round-off cleanup, raw-input validation

### DIFF
--- a/kernel/utilities/frob_chop.m
+++ b/kernel/utilities/frob_chop.m
@@ -21,14 +21,12 @@
 
 function r=frob_chop(s,tol)
 
-% Remove tiny negative round-off artefacts
-s=real(s(:));
-s(abs(s)<1e-12)=0;
-
 % Check consistency
 grumble(s,tol);
 
-% Project any remaining tiny negative round-off to zero
+% Remove round-off artefacts relative to the largest singular value
+s=real(s(:));
+s(abs(s)<1e-12*max(abs(s)))=0;
 s=max(s,0);
 
 % Find the cutting point
@@ -52,7 +50,8 @@ end
 if (~isnumeric(s))||(~isvector(s))
     error('s must be a vector of non-negative real numbers.');
 end
-if any(~isfinite(s(:)))||any(abs(imag(s(:)))>1e-10)||any(real(s(:))<-1e-10)
+if any(~isfinite(s(:)))||any(abs(imag(s(:)))>1e-10*max(abs(s(:))))||...
+   any(real(s(:))<-1e-10*max(abs(s(:))))
     error('s must be a vector of non-negative real numbers.');
 end
 end

--- a/kernel/utilities/frob_chop.m
+++ b/kernel/utilities/frob_chop.m
@@ -14,6 +14,11 @@
 %
 %    r   - the number of singular values to keep
 %
+% Note: singular values below numel(s)*eps*max(s), the standard
+%       numerical rank threshold, are set to zero because the
+%       SVD that produced them does not resolve them; above that
+%       threshold the requested tolerance is honoured exactly.
+%
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
 %
@@ -24,9 +29,9 @@ function r=frob_chop(s,tol)
 % Check consistency
 grumble(s,tol);
 
-% Remove round-off artefacts relative to the largest singular value
+% Remove round-off artefacts below the numerical rank threshold
 s=real(s(:));
-s(abs(s)<1e-12*max(abs(s)))=0;
+s(abs(s)<numel(s)*eps*max(abs(s)))=0;
 s=max(s,0);
 
 % Find the cutting point
@@ -47,7 +52,7 @@ function grumble(s,tol)
 if (~isnumeric(tol))||(~isreal(tol))||(~isscalar(tol))||(tol<0)
     error('tol must be a non-negative real scalar.');
 end
-if (~isnumeric(s))||(~isvector(s))
+if (~isnumeric(s))||((~isvector(s))&&(~isempty(s)))
     error('s must be a vector of non-negative real numbers.');
 end
 if any(~isfinite(s(:)))||any(abs(imag(s(:)))>1e-10*max(abs(s(:))))||...


### PR DESCRIPTION
## Defects (two, same function)

1. `s(abs(s)<1e-12)=0` used an absolute floor in a utility whose callers pass tolerances relative to `norm(s)` (`@ttclass/truncate.m:43`: `frob_chop(S,eps*norm(S,'fro'))`; `amensum.m` likewise). Any input with all singular values below 1e-12 — a small-norm matrix or TT core, e.g. the difference of two nearly equal tensor trains — was zeroed wholesale and the function returned rank 0, silently annihilating content. Measured: `frob_chop(1e-13*[3 2 1],eps*norm(...))` returns 0 at head, 3 at base 23984e1d.
2. `s=real(s(:))` ran before `grumble(s,tol)`, so the grumbler's imaginary-part rejection could never fire: significantly complex input was silently realified. Measured: `frob_chop([3+2i 2 1],0.1)` returns 3 at head where base errored.

## Change

The grumble now validates the raw input, with imaginary and negative round-off gates relative to `max(abs(s))`; the cleanup floor is relative the same way. Empty-input behaviour (rank 0) unchanged.

## Validation

Ranks scale-invariant at 1e−13 and 1e+13 (both 3); `[3+2i 2 1]` rejected again; `[3+1e-14i 2 1]` (round-off) accepted; 2000 random ordinary-scale (s,tol) cases agree with the previous implementation with zero disagreements.

House style: 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)