### PR TITLE
merge_inp: declare and enforce row cell arrays for subsystem inputs

### DIFF
--- a/kernel/utilities/merge_inp.m
+++ b/kernel/utilities/merge_inp.m
@@ -42,6 +42,7 @@ grumble(sys_parts,inter_parts);
 
 % Count the spins in each subsystem
 part_sizes=cellfun(@(x)numel(x.isotopes),sys_parts);
+part_sizes=part_sizes(:).';
 
 % Create structure stubs
 sys.stub=1; inter.stub=1;

--- a/kernel/utilities/merge_inp.m
+++ b/kernel/utilities/merge_inp.m
@@ -6,10 +6,10 @@
 %
 % Parameters:
 %
-%    sys_parts   - a cell array of sys structures
+%    sys_parts   - a row cell array of sys structures
 %                  to be merged
 %
-%    inter_parts - a cell array of inter structures
+%    inter_parts - a row cell array of inter structures
 %                  to be merged
 %
 % Outputs:
@@ -42,7 +42,6 @@ grumble(sys_parts,inter_parts);
 
 % Count the spins in each subsystem
 part_sizes=cellfun(@(x)numel(x.isotopes),sys_parts);
-part_sizes=part_sizes(:).';
 
 % Create structure stubs
 sys.stub=1; inter.stub=1;
@@ -425,6 +424,9 @@ if numel(sys_parts)~=numel(inter_parts)
 end
 if isempty(sys_parts)
     error('at least one subsystem must be supplied.');
+end
+if (~isrow(sys_parts))||(~isrow(inter_parts))
+    error('sys_parts and inter_parts must be row cell arrays.');
 end
 if any(cellfun(@(x)(~isstruct(x)),sys_parts))||...
    any(cellfun(@(x)(~isstruct(x)),inter_parts))


### PR DESCRIPTION
## Defect

`part_sizes=cellfun(@(x)numel(x.isotopes),sys_parts)` inherits the orientation of `sys_parts`. With a column cell of 3+ subsystems, `offsets=cumsum([0 part_sizes(1:end-1)])` (merge_like_sources/merge_like_parts, computed unconditionally) horzcats a scalar with an (n-1)x1 column and throws the low-level "Dimensions of arrays being concatenated are not consistent". On current `main` a column-oriented call therefore fails with a cryptic internal message rather than an informative one.

## Change (revised after Codex review)

This PR originally adapted the derived variable (`part_sizes=part_sizes(:).';`) so that column input would be accepted. The reviewer's P1 was correct: silently adapting to array shape is forbidden by the house rules, and it also left the documented input convention undefined. The adaptation line is removed and replaced by a declared, enforced convention:

- the header now documents `sys_parts` and `inter_parts` as **row** cell arrays;
- `grumble` rejects any other orientation with `sys_parts and inter_parts must be row cell arrays.`

Net effect versus `main`: the cryptic concatenation error becomes an informative validation error, and the input convention is stated in the header instead of being implicit.

## Validation

`checkcode` empty; house-style checker 0 violations; `test_dynamic_spin_edit_suite` 26/26 pass, unchanged; row merge unchanged (`srsk_sources=[1 2 4]`); column input refused with the informative message. All shipped callers (`diels_alder_zmag`, `diels_alder_spec`, `dac_reaction`, the test suite) use row literals and are unaffected. No MEX involved.

## Design call

If column-oriented input should instead be supported, the policy-compliant route is to declare column the fixed orientation and flip the grumbler test, not to adapt to whatever shape arrives.
