### PR TITLE
plot_3d: orientation-independent zerofill value comparison

### DIFF
--- a/kernel/plotting/plot_3d.m
+++ b/kernel/plotting/plot_3d.m
@@ -190,7 +190,7 @@ if (~isnumeric(parameters.zerofill))||(~isreal(parameters.zerofill))||...
    any(mod(parameters.zerofill,1)~=0)||any(parameters.zerofill<1)
     error('parameters.zerofill must be a three-element vector of finite positive real integers.');
 end
-if ~isequal(size(spectrum),parameters.zerofill)
+if ~isequal(size(spectrum),reshape(parameters.zerofill,1,[]))
     error('spectrum dimensions must match parameters.zerofill.');
 end
 if ~isfield(parameters,'axis_units')


### PR DESCRIPTION
## Defect

`plot_3d.m:193` did `~isequal(size(spectrum),parameters.zerofill)`. `size()` returns a 1×3 row, so a column three-vector zerofill — which passes the preceding `numel==3` validation — failed with a misleading "spectrum dimensions must match parameters.zerofill." even when the values match exactly (measured with an 8×8×8 cube and `zerofill=[8;8;8]`).

## Change and validation

The comparison flattens zerofill to a row: `reshape(parameters.zerofill,1,[])`. Measured: `[8;8;8]` and `[8 8 8]` both accepted through a full `plot_3d` call on an 8×8×8 cube; `[16;16;16]` still rejected with the same message.

House style: 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)