### PR TITLE
redor: restore the pulse-free reference echo

### DIFF
--- a/experiments/nmr_solids/redor.m
+++ b/experiments/nmr_solids/redor.m
@@ -1,10 +1,8 @@
 % Rotational-echo double-resonance (REDOR) experiment with ideal
-% hard pi pulses. The observed channel is refocused once per rotor
-% period, and the dephasing channel is pulsed at rotor-period
-% boundaries. The sequence reports the full rotational echo, the
-% dephased echo, and their difference as a function of the number of
-% rotor cycles. To be called from singlerot context. Further
-% information in:
+% hard pi pulses on the dephasing channel. The sequence reports the
+% full rotational echo, the dephased echo, and their difference as a
+% function of the number of rotor cycles. To be called from singlerot
+% context. Further information in:
 %
 %           https://doi.org/10.1016/0022-2364(89)90280-1
 %             https://doi.org/10.1006/jmre.2000.2128
@@ -35,10 +33,6 @@
 %                              during REDOR evolution, supplied as
 %                              a cell array of isotope strings
 %
-%    parameters.refocus_phase - phase of the observed-channel pi
-%                              refocusing pulses, radians; defaults
-%                              to 0
-%
 %    parameters.pulse_phase  - phases of the dephasing-channel pi
 %                              pulses, radians; the vector is cycled
 %                              through the pulse train, and defaults
@@ -52,12 +46,12 @@
 %
 % Outputs:
 %
-%    redor_curve(1,:)        - full echo S0, with observed-channel
-%                              refocusing pulses only
-%
-%    redor_curve(2,:)        - dephased echo S, with observed-channel
-%                              refocusing and dephasing-channel pi
+%    redor_curve(1,:)        - full echo S0, without dephasing
 %                              pulses
+%
+%    redor_curve(2,:)        - dephased echo S, with pi pulses every
+%                              half rotor period on the dephasing
+%                              channel
 %
 %    redor_curve(3,:)        - REDOR difference, S0-S
 %
@@ -72,12 +66,7 @@ if ~isfield(parameters,'decouple')
     parameters.decouple={};
 end
 
-% Set default refocusing phase
-if ~isfield(parameters,'refocus_phase')
-    parameters.refocus_phase=0;
-end
-
-% Set default dephasing pulse phases
+% Set default pulse phases
 if ~isfield(parameters,'pulse_phase')
     parameters.pulse_phase=[0 pi/2];
 end
@@ -90,13 +79,6 @@ L=H+1i*R+1i*K;
 
 % Apply analytical decoupling if requested
 [L,rho0]=decouple(spin_system,L,parameters.rho0,parameters.decouple);
-
-% Get observed-channel refocusing operator
-Ip=operator(spin_system,'L+',parameters.spins{1});
-Ix=(Ip+Ip')/2; Iy=(Ip-Ip')/2i;
-ref_oper=cos(parameters.refocus_phase)*Ix+...
-         sin(parameters.refocus_phase)*Iy;
-ref_oper=kron(speye(parameters.spc_dim),ref_oper);
 
 % Get dephasing-channel pulse operators
 Ip=operator(spin_system,'L+',parameters.spins{2});
@@ -129,19 +111,21 @@ rho_s0=rho0; rho_s=rho0; pulse_count=0;
 % Step through the requested REDOR evolution window
 for n=1:max(parameters.ncycles)
 
-    % Propagate both echoes over the first half-period
-    rho_s0=step(spin_system,L,rho_s0,half_period);
+    % Propagate the full rotational echo over one rotor period
+    rho_s0=step(spin_system,L,rho_s0,rotor_period);
+
+    % Propagate the dephased echo over the first half-period
     rho_s=step(spin_system,L,rho_s,half_period);
 
-    % Refocus the observed channel
-    rho_s0=step(spin_system,ref_oper,rho_s0,pi);
-    rho_s=step(spin_system,ref_oper,rho_s,pi);
+    % Apply the first dephasing-channel pi pulse
+    pulse_count=pulse_count+1;
+    pulse_idx=mod(pulse_count-1,numel(deph_opers))+1;
+    rho_s=step(spin_system,deph_opers{pulse_idx},rho_s,pi);
 
-    % Propagate both echoes over the second half-period
-    rho_s0=step(spin_system,L,rho_s0,half_period);
+    % Propagate the dephased echo over the second half-period
     rho_s=step(spin_system,L,rho_s,half_period);
 
-    % Apply the dephasing-channel pi pulse to the S echo
+    % Apply the second dephasing-channel pi pulse
     pulse_count=pulse_count+1;
     pulse_idx=mod(pulse_count-1,numel(deph_opers))+1;
     rho_s=step(spin_system,deph_opers{pulse_idx},rho_s,pi);
@@ -234,10 +218,6 @@ if any(~ismember(parameters.decouple,spin_system.comp.isotopes))
 end
 if any(ismember(parameters.spins,parameters.decouple))
     error('parameters.decouple must not include REDOR working spins.');
-end
-if (~isnumeric(parameters.refocus_phase))||(~isreal(parameters.refocus_phase))||...
-   (~isscalar(parameters.refocus_phase))
-    error('parameters.refocus_phase must be a real scalar.');
 end
 if (~isnumeric(parameters.pulse_phase))||(~isreal(parameters.pulse_phase))||...
    (~isrow(parameters.pulse_phase))||isempty(parameters.pulse_phase)


### PR DESCRIPTION
## Defect

Commit 9da68c87 ("Refocus observed channel in REDOR") placed an observed-channel π at the middle of every rotor period and moved the dephasing π to period boundaries. For the dephased echo S this is equivalent to the published scheme, but the reference echo S0 has only the mid-period observed pulses: its dipolar sign pattern (+[0,Tr/2), −[Tr/2,3Tr/2), +[3Tr/2,5Tr/2)...) cancels pairwise over even cycle counts and survives at odd counts. Published REDOR's reference echo carries no heteronuclear dipolar dephasing at any N.

## Measurement (2-spin 13C/15N, 10 kHz MAS, rank-7/leb-11)

Before: S0 = [0.250000 0.244854 0.250000 0.244854 ...] — zigzag with S0(odd) = S(1) exactly; the normalised difference curve is biased at every odd point of the shipped `redor_curve.m` sweep (ncycles=0:48).

After: S0 = 0.250000 at every cycle count, and the dephased-echo row is unchanged to the printed digits (0.244854, 0.229868, 0.206351, 0.176324, 0.142307, 0.107051) — only the defective reference arm changes.

## Change

Restores the original a322bedb structure (both commits mine): free evolution for S0, two dephasing-channel π pulses per rotor period at the half-period points (Gullion–Schaefer), with the later DOI-indentation cosmetics kept. Net −20 lines; the `refocus_phase` parameter (introduced with the defective scheme, unused in-tree) is removed with it.

House style: 0 violations; checkcode clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)