### PR TITLE
lorentzcon.m: match the MEX two-element boxcar convolution mode

### DIFF
--- a/kernel/line_shapes/lorentzcon.m
+++ b/kernel/line_shapes/lorentzcon.m
@@ -7,6 +7,8 @@
 %
 %     offs - peak offset from zero - when this is a scalar,
 %            a Lorentzian is returned; when this is a vector
+%            with two elements, a convolution with a boxcar
+%            function is returned; when this is a vector
 %            with three elements, a convolution with a tri-
 %            angular function is returned.
 %
@@ -38,12 +40,18 @@ offs=sort(offs(:),1,'ascend');
 % Similarity tolerance
 sim_tol=sqrt(eps)*norm(offs,2);
 
-% Single offset or three identical vertices
-if isscalar(offs)||(offs(3)-offs(1)<=sim_tol)
-    
+% Single offset or all vertices identical
+if isscalar(offs)||(offs(end)-offs(1)<=sim_tol)
+
     % Just a Lorentzian curve
     y=(ampl/(pi*gam))./(1+((x-mean(offs))/gam).^2);
-    
+
+% Two distinct vertices
+elseif numel(offs)==2
+
+    % Lorentzian convolution with a boxcar function
+    y=(ampl/(pi*(offs(2)-offs(1))))*(atan2(offs(2)-x,gam)-atan2(offs(1)-x,gam));
+
 % Vertices 1 and 2 identical
 elseif (offs(2)-offs(1)<=sim_tol)
     
@@ -82,8 +90,8 @@ end
 % Consistency enforcement
 function grumble(offs,ampl,fwhm,x)
 if (~isnumeric(offs))||(~isreal(offs))||...
-   (~ismember(numel(offs),[1 3]))||any(~isfinite(offs(:)))
-    error('offs must be a finite real scalar or a three-element vector.');
+   (~ismember(numel(offs),[1 2 3]))||any(~isfinite(offs(:)))
+    error('offs must be a finite real vector with one, two, or three elements.');
 end
 if (~isnumeric(ampl))||(~isreal(ampl))||...
    (numel(ampl)~=1)||(~isfinite(ampl))

--- a/kernel/line_shapes/lorentzcon.m
+++ b/kernel/line_shapes/lorentzcon.m
@@ -31,6 +31,10 @@ function y=lorentzcon(offs,ampl,fwhm,x)
 % Check consistency
 grumble(offs,ampl,fwhm,x);
 
+% Match the MEX numeric conversions
+offs=double(offs); ampl=double(ampl); fwhm=double(fwhm);
+if isinteger(x), x=double(x); end
+
 % Width parameter
 gam=fwhm/2;
 


### PR DESCRIPTION
`lorentzcon.cpp` implements a two-element `offs` mode — convolution of the Lorentzian with a unit-area boxcar on `[offs(1),offs(2)]` — and the test suite exercises it (`test_dynamic_remaining_core_suite.m:146`). The `.m` fallback rejected the same call (`offs must be a finite real scalar or a three-element vector`), so the one function accepted different inputs depending on whether the compiled MEX is on the path; on any platform without a shipped binary (e.g. Apple Silicon before `compile_mex` is run) two-element callers error out.

**Fix**: the fallback gains the same branch, `y=(ampl/(pi*(b-a)))*(atan2(b-x,gam)-atan2(a-x,gam))`, with the MEX's degenerate-case rule (two vertices closer than `sqrt(eps)*norm(offs)` collapse to a plain Lorentzian at their mean); grumbler and header updated to document one, two, or three elements.

**Validation** (probe `d17b.log`): shipped MEX vs patched fallback agree to machine precision on seven cases covering every mode (worst rel diff 2.6e-15); the boxcar branch matches direct adaptive quadrature of the defining convolution integral to 4.5e-16; unit-area invariant `∫y dx = ampl` holds in all modes; the shipped test-suite call runs on the fallback; four-element input still rejected; `checkcode` and house-style gates clean.

Found during the 2026-08-29 whole-range review (finding K06-F2).