### PR TITLE
ipcs.m: document the GPU flag as the logical the grumbler requires

### DIFF
--- a/experiments/pseudocon/ipcs.m
+++ b/experiments/pseudocon/ipcs.m
@@ -40,7 +40,8 @@
 %                   Poisson's equation, 'kuprov' to recover the
 %                   unpaired electron probability density
 %
-%     gpu        - set to 1 to enable GPU processing (much faster)
+%     gpu        - set to true to enable GPU processing
+%                  (much faster), false to run on CPU
 %
 % Outputs:
 % 


### PR DESCRIPTION
The `ipcs.m` header says `gpu - set to 1 to enable GPU processing`, but the grumbler (added in the 2026-05-21 validation hardening) requires a logical scalar, so the documented call errors out: measured `ipcs(parameters,[16 16 16],1e-3)` with `parameters.gpu=1` → `parameters.gpu must be a logical scalar.` (finding E03-F1, probe v5c). All ten in-tree callers already pass `parameters.gpu=true()`.

**Fix**: header aligned with the enforced interface (documentation-only; no behaviour change).

**Note on the alternative**: out-of-tree scripts written against the old header will still hit the clear one-line error above until they switch `1` → `true`. If restoring numeric `0`/`1` acceptance is preferred over strictness here, say so and I will relax the grumbler instead.

**Validation**: house-style gate and `checkcode` clean; no executable line changed.

Found during the 2026-08-29 whole-range review (finding E03-F1).