### PR TITLE
imaging: restore multi-channel spin lists in fourteen sequence grumblers

### DIFF
--- a/experiments/imaging/basic_1d_hard.m
+++ b/experiments/imaging/basic_1d_hard.m
@@ -78,8 +78,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/cpmg_dec.m
+++ b/experiments/imaging/cpmg_dec.m
@@ -98,8 +98,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/epi_2d.m
+++ b/experiments/imaging/epi_2d.m
@@ -142,8 +142,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'rho0')
     error('parameters.rho0 field must be present.');

--- a/experiments/imaging/fse.m
+++ b/experiments/imaging/fse.m
@@ -110,8 +110,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/grad_echo.m
+++ b/experiments/imaging/grad_echo.m
@@ -69,8 +69,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/phase_enc_2d.m
+++ b/experiments/imaging/phase_enc_2d.m
@@ -144,8 +144,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'rho0')
     error('parameters.rho0 field must be present.');

--- a/experiments/imaging/press_1d.m
+++ b/experiments/imaging/press_1d.m
@@ -81,8 +81,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/press_2d.m
+++ b/experiments/imaging/press_2d.m
@@ -100,8 +100,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/press_voxel_1d.m
+++ b/experiments/imaging/press_voxel_1d.m
@@ -87,8 +87,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/press_voxel_2d.m
+++ b/experiments/imaging/press_voxel_2d.m
@@ -106,8 +106,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/press_voxel_3d.m
+++ b/experiments/imaging/press_voxel_3d.m
@@ -121,8 +121,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/slice_select_1d.m
+++ b/experiments/imaging/slice_select_1d.m
@@ -82,8 +82,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/spin_echo.m
+++ b/experiments/imaging/spin_echo.m
@@ -70,8 +70,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');

--- a/experiments/imaging/spiral.m
+++ b/experiments/imaging/spiral.m
@@ -141,8 +141,9 @@ end
 if ~isfield(parameters,'spins')
     error('parameters.spins field must be present.');
 end
-if (~iscell(parameters.spins))||(numel(parameters.spins)~=1)||(~ischar(parameters.spins{1}))
-    error('parameters.spins must be a cell array containing one spin name.');
+if (~iscell(parameters.spins))||isempty(parameters.spins)||...
+   any(~cellfun(@ischar,parameters.spins(:)))
+    error('parameters.spins must be a nonempty cell array of character strings.');
 end
 if ~isfield(parameters,'npts')
     error('parameters.npts field must be present.');


### PR DESCRIPTION
The 2026-06-15 grumbler hardening added `numel(parameters.spins)~=1` checks to fourteen imaging sequences (`basic_1d_hard`, `cpmg_dec`, `epi_2d`, `fse`, `grad_echo`, `spin_echo`, `phase_enc_2d`, `press_1d/2d`, `press_voxel_1d/2d/3d`, `slice_select_1d`, `spiral`). That removed a real capability: through the `imaging()` context, `frqoffset.m` explicitly supports per-channel `parameters.spins`/`parameters.offset`, and multi-channel calls (offsets applied per channel, pulses on `spins{1}`) ran correctly before the hardening. Measured at head: a two-channel `basic_1d_hard` call dies with `parameters.spins must be a cell array containing one spin name.`

**Fix**: the fourteen checks now require a nonempty cell array of character strings — the multi-channel calls run again, and empty or non-character spin lists are still rejected. No sequence body indexes beyond `spins{1}` (verified by grep), so no other change is needed.

**Validation** (probe `d29.log`): `gradient_image_1d`-style single-channel reference vs the same phantom with an uncoupled ¹⁹F spectator channel and a per-channel offset `[0 200]` — the two-channel run completes and the ¹H image agrees with the reference to 2.9e-8 relative (evolution-propagator tolerance level); empty `{}` and non-character `{1 2}` spin lists still rejected; `checkcode` and house-style gates clean on all fourteen files.

Found during the 2026-08-29 whole-range review (finding E02-F1).