### PR TITLE
b2spinach: parse multi-column Bruker sampling schedules

### DIFF
--- a/interfaces/b2spinach.m
+++ b/interfaces/b2spinach.m
@@ -86,8 +86,10 @@
 %     bdata.vc_list     - variable counter list, present when
 %                         the vclist file exists
 %
-%     bdata.nus_list    - non-uniform sampling schedule, pre-
-%                         sent when the nuslist file exists
+%     bdata.nus_list    - non-uniform sampling schedule, one
+%                         row per sampled fid and one column
+%                         per indirect dimension, present
+%                         when the nuslist file exists
 %
 % Adapted from the brukerimport() function of the GNAT package by:
 %
@@ -412,35 +414,51 @@ all_lines=regexp(fileread(file_path),'\r?\n','split');
 all_lines=strtrim(all_lines);
 all_lines=all_lines(~cellfun(@isempty,all_lines));
 
+% Refuse empty list files
+if isempty(all_lines)
+    error(['list file is empty: ' file_path]);
+end
+
+% Split the lines into whitespace-separated entries
+all_lines=cellfun(@strsplit,all_lines,'UniformOutput',false);
+
+% Require a consistent entry count per line
+n_cols=numel(all_lines{1});
+if any(cellfun(@numel,all_lines)~=n_cols)
+    error(['inconsistent number of columns in ' file_path]);
+end
+
 % Preallocate the values
-vals=zeros(numel(all_lines),1);
+vals=zeros(numel(all_lines),n_cols);
 
-% Loop over the lines
+% Loop over the entries
 for n=1:numel(all_lines)
+    for k=1:n_cols
 
-    % Convert time unit suffixes into multipliers
-    text_line=all_lines{n};
-    switch text_line(end)
-        case 'n'
-            multiplier=1e-9; text_line=text_line(1:(end-1));
-        case 'u'
-            multiplier=1e-6; text_line=text_line(1:(end-1));
-        case 'm'
-            multiplier=1e-3; text_line=text_line(1:(end-1));
-        case 's'
-            multiplier=1;    text_line=text_line(1:(end-1));
-        otherwise
-            multiplier=1;
+        % Convert time unit suffixes into multipliers
+        entry=all_lines{n}{k};
+        switch entry(end)
+            case 'n'
+                multiplier=1e-9; entry=entry(1:(end-1));
+            case 'u'
+                multiplier=1e-6; entry=entry(1:(end-1));
+            case 'm'
+                multiplier=1e-3; entry=entry(1:(end-1));
+            case 's'
+                multiplier=1;    entry=entry(1:(end-1));
+            otherwise
+                multiplier=1;
+        end
+
+        % Convert the value into a number
+        vals(n,k)=multiplier*str2double(entry);
+
+        % Make sure the conversion succeeded
+        if isnan(vals(n,k))
+            error(['cannot interpret list file entry: ' all_lines{n}{k}]);
+        end
+
     end
-
-    % Convert the value into a number
-    vals(n)=multiplier*str2double(text_line);
-
-    % Make sure the conversion succeeded
-    if isnan(vals(n))
-        error(['cannot interpret list file entry: ' all_lines{n}]);
-    end
-
 end
 
 end


### PR DESCRIPTION
`read_list` converted one `str2double` per line, and `str2double('0 5')` is `NaN`, so any 3D/4D `nuslist` (one row per sampled fid, one column per indirect dimension — the format TopSpin writes for multidimensional NUS) failed with `cannot interpret list file entry`. Multidimensional NUS import therefore could not work at all, while the importer otherwise supports data sets up to 4D.

**Fix**: `read_list` now splits each line into whitespace-separated entries, keeps the per-entry time-unit-suffix logic, requires a consistent column count, and returns an N×M matrix; single-column files produce bit-identical output to the old code (`multiplier*str2double(entry)` per entry, column vector). Empty and ragged list files now get clean one-line errors instead of a silent empty return or a NaN error. Header documents the `nus_list` shape.

**Validation** (probe `d19.log`): full `b2spinach()` call on a synthetic 3D NUS data set (acqus/acqu2s/acqu3s, 12 of 48 declared fids in `ser`, two-column `nuslist`) returns the exact 12×2 schedule as written; `vdlist` with `10m/50u/1` suffixes, `vclist`, and `difflist` parse bit-identically to the old arithmetic; ragged and empty schedules rejected with the new messages; `checkcode` and house-style gates clean. (Probe terminated with the known R2026a shutdown allocator failure after the success marker; all assertions had passed.)

Found during the 2026-08-29 whole-range review (finding I02-F2).