### PR TITLE
karplus_fit: error bars from the plain-residual Jacobian

### DIFF
--- a/interfaces/gaussian/karplus_fit.m
+++ b/interfaces/gaussian/karplus_fit.m
@@ -77,14 +77,14 @@ cosine_0=ones(size(phi));
 result=[cosine_2' cosine_1' cosine_0']\J';
 A=result(1); B=result(2); C=result(3);
 
-% Vector of squared residuals
-vec_res_sq=@(x)(J'-x(1)*cosine_2'-x(2)*cosine_1'-x(3)*cosine_0').^2;
+% Vector of residuals
+vec_res=@(x)(J'-x(1)*cosine_2'-x(2)*cosine_1'-x(3)*cosine_0');
 
-% Sum of squared residuals 
-sum_res_sq=@(x)sum(vec_res_sq(x));
+% Sum of squared residuals
+sum_res_sq=@(x)sum(vec_res(x).^2);
 
 % Compute the Jacobian at the optimal point
-jac=jacobianest(vec_res_sq,result);
+jac=jacobianest(vec_res,result);
 
 % Get the Studentized residual
 sdr=sqrt(sum_res_sq(result)/(numel(J)-3));


### PR DESCRIPTION
The reported standard deviations are computed as `sqrt(diag(sdr^2*inv(jac'*jac)))` — the standard nonlinear-regression covariance, which requires `jac` to be the Jacobian of the **plain** residual vector. The shipped code hands `jacobianest` the **squared** residuals, whose Jacobian is `2*r_i*∂r_i/∂x` — an extra factor proportional to each residual — so the quoted A/B/C error bars carry no statistical meaning and come out inflated by roughly the residual scale.

**Measured on synthetic scan data** (Karplus A=7.0, B=−1.0, C=0.7, σ=0.15 Hz, 36 points; Phase C probe v67): shipped stdevs **[0.236 0.124 0.150]** vs correct plain-residual formula **[0.072 0.036 0.044]** vs 200-draw Monte-Carlo ground truth **[0.068 0.035 0.045]** — the Monte-Carlo arbitrates for the plain-residual formula; shipped bars are ~3.3× too large on this data set, and the inflation varies with the residuals, so it cannot be calibrated away.

**Fix**: `vec_res_sq` → `vec_res` (no square), `sum_res_sq=@(x)sum(vec_res(x).^2)` unchanged in value, `jacobianest(vec_res,result)`. Fit parameters A, B, C are untouched — only the error bars change.

**Validation** (probe `d20.log`): the patched function was run end-to-end (a byte-identical copy resolved against a mock `gparse` that encodes dihedral angles in file names — same-folder shadowing is the only way to substitute the parser; geometry goes through the real `dihedral()`). Its error bars now equal the analytic linear-regression covariance `sdr*sqrt(diag(inv(X'X)))` to 1e-6 and sit within a few percent of a fresh 500-draw Monte-Carlo: function [0.0693 0.0347 0.0425], analytic [0.0693 0.0347 0.0425], MC [0.0675 0.0370 0.0413]; fitted A/B/C bracket the ground truth within errors. `checkcode` and house-style gates clean.

Found during the 2026-08-29 whole-range review (finding I02-F1).