### PR TITLE
diamond_p1_13c: adopt the rectified orientation convention of diamond_p1

### DIFF
--- a/etc/diamond_defects/diamond_p1_13c.m
+++ b/etc/diamond_defects/diamond_p1_13c.m
@@ -66,15 +66,15 @@ switch parameters.orientation
 
     case '100'
 
-        R=rotmat_align([1 1 1],[1 0 0]);
+        R=rotmat_align([1 0 0],[0 0 1])*crys2def';
 
     case '110'
 
-        R=rotmat_align([1 1 1],[1 1 0]);
+        R=rotmat_align([1 1 0],[0 0 1])*crys2def';
 
     case '111'
 
-        R=eye(3);
+        R=rotmat_align([1 1 1],[0 0 1])*crys2def';
 
     otherwise
 


### PR DESCRIPTION
Commit 3e7d97c8 ("rectified orientation conventions in diamond NV- and P1 defect initialisers") replaced the old `R=rotmat_align([1 1 1],<plane>)` scheme with the crystal-to-lab rotation `C=rotmat_align(<plane>,[0 0 1])` in `diamond_p1.m` and `diamond_nvm_gs.m`, but `diamond_p1_13c.m` kept the old scheme while its comment claims "Set the same orientation convention as diamond_p1.m". Measured consequence at head, `orientation='100'`, `nitrogen='14N'`: the P1 axis sits at 37.94° to the field instead of 54.74°, and first-order ¹⁴N Azz comes out 101.64 MHz where `diamond_p1.m` gives 92.20 MHz for the same input; at `'110'` the polar angle coincidentally agrees but the azimuth is wrong, so the rhombic ¹³C tensors differ (G8 Azz 36.85 vs 37.96 MHz). Only `'111'` — the case the shipped example uses — was physically unaffected.

**Fix**: the orientation switch now sets `R=rotmat_align(<plane>,[0 0 1])*crys2def'`. Since every downstream tensor is applied as `R*(crys2def*X_crystal*crys2def')*R'`, this collapses algebraically to `C*X_crystal*C'` — the exact `diamond_p1.m` convention — for all tensors and coordinates; nothing else in the file changes.

**Validation** (probe `d21.log`): nitrogen hyperfine tensors from `diamond_p1` and the patched `diamond_p1_13c` now agree to 3e-16 relative at all three orientations; the unique-axis angle to the field measures 54.7356°/35.2644°/0.0000° for '100'/'110'/'111'; G8 ¹³C Azz at '110' is 37.957 MHz; and the old-vs-new `'111'` outputs are the same physics to 1e-9 (every coupling-tensor eigenvalue set and lab zz element, every coordinate's cylindrical invariants — the two differ only by a global rotation about the field, which no observable sees). `checkcode` clean; house-style violations unchanged from stock.

Found during the 2026-08-29 whole-range review (finding X01-F1).