### PR TITLE
diamond_ni, diamond_siv0: distinct 13C bond axes per site

### DIFF
--- a/etc/diamond_defects/diamond_ni.m
+++ b/etc/diamond_defects/diamond_ni.m
@@ -22,7 +22,18 @@
 %      .nickel       - '61Ni', 'none', or another nickel isotope;
 %                      required when .centre is 'w8'
 %      .n_13c        - number of reported 13C hyperfine couplings
-%                      to include, from 0 to 4; applies only to W8
+%                      to include, from 0 to 4; applies only to
+%                      W8. Carbons are placed, in the order given,
+%                      on the [111], [1-1-1], [-11-1], and [-1-11]
+%                      nearest-neighbour bonds, so a count below
+%                      four selects one specific isotopomer rather
+%                      than an average over them. That choice is
+%                      observable: with .orientation='111' the
+%                      [111] carbon splits by 1.339 mT and each of
+%                      the other three by 0.451 mT. For other
+%                      isotopomers, or for a mixture, request all
+%                      four carbons and drop or weight them in the
+%                      calling script
 %
 % Outputs:
 %
@@ -76,15 +87,16 @@ switch centre
             % Nearest-neighbour bond directions of the Td centre
             bond_dirs=[+1 +1 +1; +1 -1 -1; -1 +1 -1; -1 -1 +1]/sqrt(3);
 
-            % Axial hyperfine tensor about each bond direction
+            % Preallocate the requested carbon records
             nuc_idx=numel(nuclei);
             nuclei(nuc_idx+1:nuc_idx+parameters.n_13c)={[]};
-            for n=1:parameters.n_13c
-                Rmat=rotmat_align([0 0 1],bond_dirs(n,:));
-                Cmat=Rmat*diag([0.340 0.340 1.339]*hz_per_mt)*Rmat';
-                nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat);
-            end
 
+            % Build an axial hyperfine tensor about each bond direction
+            for n=1:parameters.n_13c
+                rot_mat=rotmat_align([0 0 1],bond_dirs(n,:));
+                hfc_mat=rot_mat*diag([0.340 0.340 1.339]*hz_per_mt)*rot_mat';
+                nuclei{nuc_idx+n}=struct('iso','13C','A',hfc_mat);
+            end
         end
     case {'ne1','ne2','ne3','ne5','ne8'}
         electron='E';

--- a/etc/diamond_defects/diamond_ni.m
+++ b/etc/diamond_defects/diamond_ni.m
@@ -72,12 +72,19 @@ switch centre
             nuclei{end+1}=struct('iso',nickel);
         end
         if parameters.n_13c>0
-            Cmat=((frame_111)*diag([0.340 0.340 1.339]*hz_per_mt)*(frame_111)');
+
+            % Nearest-neighbour bond directions of the Td centre
+            bond_dirs=[+1 +1 +1; +1 -1 -1; -1 +1 -1; -1 -1 +1]/sqrt(3);
+
+            % Axial hyperfine tensor about each bond direction
             nuc_idx=numel(nuclei);
             nuclei(nuc_idx+1:nuc_idx+parameters.n_13c)={[]};
             for n=1:parameters.n_13c
+                Rmat=rotmat_align([0 0 1],bond_dirs(n,:));
+                Cmat=Rmat*diag([0.340 0.340 1.339]*hz_per_mt)*Rmat';
                 nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat);
             end
+
         end
     case {'ne1','ne2','ne3','ne5','ne8'}
         electron='E';

--- a/etc/diamond_defects/diamond_siv0.m
+++ b/etc/diamond_defects/diamond_siv0.m
@@ -54,12 +54,19 @@ end
 
 % Add reported nearest-neighbour carbons
 if parameters.n_13c>0
-    Cmat=((frame)*diag([30.2e6 30.2e6 66.2e6])*(frame)');
+
+    % Dangling-bond lines of the split-vacancy carbons, two sites each
+    bond_dirs=[+1 -1 -1; -1 +1 -1; -1 -1 +1]/sqrt(3);
+
+    % Axial hyperfine tensor about each dangling-bond line
     nuc_idx=numel(nuclei);
     nuclei(nuc_idx+1:nuc_idx+parameters.n_13c)={[]};
     for n=1:parameters.n_13c
+        Rmat=rotmat_align([0 0 1],bond_dirs(mod(n-1,3)+1,:));
+        Cmat=Rmat*diag([30.2e6 30.2e6 66.2e6])*Rmat';
         nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat);
     end
+
 end
 
 % Build the Spinach structures

--- a/etc/diamond_defects/diamond_siv0.m
+++ b/etc/diamond_defects/diamond_siv0.m
@@ -12,8 +12,20 @@
 %      .silicon      - '29Si', 'none', or another silicon isotope
 %      .orientation  - '111', '110', or '100' crystal plane normal
 %                      aligned with the magnetic field
-%      .n_13c       - number of reported nearest-neighbour 13C
-%                     hyperfine couplings, between 0 and 6
+%      .n_13c        - number of reported nearest-neighbour 13C
+%                      hyperfine couplings, between 0 and 6.
+%                      Carbons are added by cycling through the
+%                      three dangling-bond lines [1-1-1], [-11-1],
+%                      and [-1-11], which carry two carbons each,
+%                      so a count below six selects one specific
+%                      isotopomer rather than an average over
+%                      them. With .orientation='111' the three
+%                      lines are equivalent and the choice is
+%                      immaterial, but with '110' one of them
+%                      splits by 54.2 MHz against 30.2 MHz for
+%                      the other two. For other isotopomers, or
+%                      for a mixture, request all six carbons and
+%                      drop or weight them in the calling script
 %
 % Outputs:
 %
@@ -58,15 +70,16 @@ if parameters.n_13c>0
     % Dangling-bond lines of the split-vacancy carbons, two sites each
     bond_dirs=[+1 -1 -1; -1 +1 -1; -1 -1 +1]/sqrt(3);
 
-    % Axial hyperfine tensor about each dangling-bond line
+    % Preallocate the requested carbon records
     nuc_idx=numel(nuclei);
     nuclei(nuc_idx+1:nuc_idx+parameters.n_13c)={[]};
-    for n=1:parameters.n_13c
-        Rmat=rotmat_align([0 0 1],bond_dirs(mod(n-1,3)+1,:));
-        Cmat=Rmat*diag([30.2e6 30.2e6 66.2e6])*Rmat';
-        nuclei{nuc_idx+n}=struct('iso','13C','A',Cmat);
-    end
 
+    % Build an axial hyperfine tensor about each dangling-bond line
+    for n=1:parameters.n_13c
+        rot_mat=rotmat_align([0 0 1],bond_dirs(mod(n-1,3)+1,:));
+        hfc_mat=rot_mat*diag([30.2e6 30.2e6 66.2e6])*rot_mat';
+        nuclei{nuc_idx+n}=struct('iso','13C','A',hfc_mat);
+    end
 end
 
 % Build the Spinach structures


### PR DESCRIPTION
Both builders construct one ¹³C hyperfine tensor axial about the defect [111] axis and replicate it `n_13c` times, making all requested carbons magnetically equivalent at every field orientation. No physical configuration of either centre produces that: W8 is substitutional Ni⁻ (Td) whose four nearest carbons sit on the four **distinct** ⟨111⟩ bond axes, and SiV⁰ is a D3d split-vacancy whose six carbons have dangling bonds along their own ⟨111⟩ lines at 70.5°/109.5° to the trigonal axis — for SiV⁰ **no** carbon axis coincides with the defect axis at all. Measured at head: `diamond_ni` with `n_13c=2` returns two bitwise-identical carbon tensors (difference norm 0 of 3.99e7). Sibling routines already do this correctly (`diamond_ti` uses two distinct ⟨111⟩ frames; `diamond_n2vm` rotates its second carbon; `diamond_ov0` documents its one-carbon simplification explicitly). Shipped examples use `n_13c=0`, so the defect was latent.

**Fix**: each requested carbon now gets an axial tensor about its own bond line — W8: `[1 1 1], [1 -1 -1], [-1 1 -1], [-1 -1 1]`; SiV⁰: the three non-defect ⟨111⟩ lines with inversion partners sharing a line (an axial tensor is invariant under axis sign flip, so the six sites form three magnetically distinct pairs, as D3d symmetry requires). Tabulated principal values are untouched.

**Validation** (probe `d22.log`): W8 `n_13c=4` — all four sites share the eigenvalue set and every pairwise unique-axis line angle measures the tetrahedral 70.529°, preserved under a change of crystal orientation; the first site reproduces the old `frame_111` tensor to 2.8e-16 (axial tensors are azimuth-gauge-free), so `n_13c=1` W8 workflows are bit-compatible. SiV⁰ `n_13c=6` — every axis at 70.529° to the defect axis (old code: 0°), three distinct lines with inversion partners coinciding. Carbon-count grumblers still enforce their limits; `checkcode` and house-style gates clean on both files.

Found during the 2026-08-29 whole-range review (finding X01-F2).