### PR TITLE
hncaco examples: absorptive hypercomplex recombination

### DIFF
--- a/examples/nmr_proteins/hncaco_gb1.m
+++ b/examples/nmr_proteins/hncaco_gb1.m
@@ -62,7 +62,7 @@ f3_neg_pos=fftshift(fft(fid.neg_pos,parameters.zerofill(3),3),3);
 f3_neg_neg=fftshift(fft(fid.neg_neg,parameters.zerofill(3),3),3);
 
 % Absorption part of F3 signal
-f3_pos=f3_pos_pos+1i*conj(f3_neg_neg);
+f3_pos=f3_pos_pos-conj(f3_neg_neg);
 f3_neg=f3_neg_pos-conj(f3_pos_neg);
 
 % F2 Fourier transform
@@ -70,13 +70,13 @@ f3f2_pos=fftshift(fft(f3_pos,parameters.zerofill(2),2),2);
 f3f2_neg=fftshift(fft(f3_neg,parameters.zerofill(2),2),2);
 
 % Absorption part of F2 signal
-f3f2=f3f2_pos+1i*conj(f3f2_neg);
+f3f2=f3f2_pos-conj(f3f2_neg);
 
 % F1 Fourier transform
 spectrum=fftshift(fft(f3f2,parameters.zerofill(1),1),1);
 
 % Plotting
-kfigure(); plot_3d(spin_system,real(spectrum),parameters,...
+kfigure(); plot_3d(spin_system,imag(spectrum),parameters,...
                    10,[0.2 0.9 0.2 0.9],2,'positive');
 
 end

--- a/examples/nmr_proteins/hncaco_simple.m
+++ b/examples/nmr_proteins/hncaco_simple.m
@@ -59,7 +59,7 @@ f3_neg_pos=fftshift(fft(fid.neg_pos,parameters.zerofill(3),3),3);
 f3_neg_neg=fftshift(fft(fid.neg_neg,parameters.zerofill(3),3),3);
 
 % Absorption part of F3 signal
-f3_pos=f3_pos_pos+1i*conj(f3_neg_neg);
+f3_pos=f3_pos_pos-conj(f3_neg_neg);
 f3_neg=f3_neg_pos-conj(f3_pos_neg);
 
 % F2 Fourier transform
@@ -67,13 +67,13 @@ f3f2_pos=fftshift(fft(f3_pos,parameters.zerofill(2),2),2);
 f3f2_neg=fftshift(fft(f3_neg,parameters.zerofill(2),2),2);
 
 % Absorption part of F2 signal
-f3f2=f3f2_pos+1i*conj(f3f2_neg);
+f3f2=f3f2_pos-conj(f3f2_neg);
 
 % F1 Fourier transform
 spectrum=fftshift(fft(f3f2,parameters.zerofill(1),1),1);
 
 % Plotting
-kfigure(); plot_3d(spin_system,real(spectrum),parameters,...
+kfigure(); plot_3d(spin_system,imag(spectrum),parameters,...
                    10,[0.2 0.9 0.2 0.9],2,'positive');
 
 end


### PR DESCRIPTION
`hncaco_gb1.m` and `hncaco_simple.m` combine their four hypercomplex components as `+1i*conj` / `-conj` / `+1i*conj` under comments claiming absorption-mode processing — a pattern found nowhere else in the repository. For the bilinear stitch structure of `hncaco.m` (identical to `hnco.m`), the three absorption conditions for that recipe are mutually contradictory (they force `1=-1i`), so no branch phases whatsoever can make it absorptive; the sequence's phase structure also differs from `hnco`'s, so the sibling `+conj` recipe transplanted verbatim cancels the signal outright (measured: neg/pos weight 1.0000 at every display phase, i.e. noise).

**Measured fix** (probe `d23.log`): an exhaustive scan of the recombination constants `f3_pos=f3_pp+z1*conj(f3_nn)`, `f3_neg=f3_np+z2*conj(f3_pn)`, `f3f2=f3f2_pos+z3*conj(f3f2_neg)` over `z∈{±1,±i}³` and the four display phases, on one simulation of the `hncaco_simple` system, gives a unique decisive winner: **`z1=z2=z3=-1` displayed as `imag(spectrum)`** — negative/positive spectral weight 0.103, versus 0.864 for the shipped recipe and 0.841 for the next-best candidate; peak cross-section asymmetry falls to 0.16 (F2) and 0.04 (F3). The shipped `z2=-1` was already correct; only `z1`, `z3`, and the display phase change (an `imag` display has house precedent in `hcch_cosy`).

**Validation**: patched `hncaco_simple()` runs end-to-end including the 3D plot (`d23b.log`); `hncaco_gb1.m` carries the byte-identical processing block change (its sequence call is the same `hncaco.m`; not re-run — minutes-scale GB1 simulation). `checkcode` clean on both; house-style violations unchanged from stock.

Found during the 2026-08-29 whole-range review (finding Ex05-F1).