### PR TITLE
v2fplanck: round-off tolerance in the tensor-field PSD gates

### DIFF
--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -260,9 +260,9 @@ if isscalar(parameters.npts)
         end
     end
     if isfield(parameters,'dxx')
-        if (~isnumeric(parameters.dxx))||(~isreal(parameters.dxx))||(~iscolumn(parameters.dxx))||...
+        if (~isfloat(parameters.dxx))||(~isreal(parameters.dxx))||(~iscolumn(parameters.dxx))||...
            any(~isfinite(parameters.dxx))||any(parameters.dxx<0)
-            error('parameters.dxx must be a non-negative real column vector.');
+            error('parameters.dxx must be a non-negative real floating-point column vector.');
         end
     end
 end
@@ -288,9 +288,9 @@ if numel(parameters.npts)==2
     for n={'dxx','dxy','dyx','dyy'}
         if isfield(parameters,n{1})
             d=getfield(parameters,n{1}); %#ok<GFLD>
-            if (~isnumeric(d))||(~isreal(d))||any(size(d)~=parameters.npts)||...
+            if (~isfloat(d))||(~isreal(d))||any(size(d)~=parameters.npts)||...
                 any(~isfinite(d(:)))
-                error(['parameters.' n{1} ' must be a real array of dimension ' num2str(parameters.npts)]);
+                error(['parameters.' n{1} ' must be a real floating-point array of dimension ' num2str(parameters.npts)]);
             end
         end
     end
@@ -334,9 +334,9 @@ if (numel(parameters.npts)==3)
     for n={'dxx','dxy','dxz','dyx','dyy','dyz','dzx','dzy','dzz'}
         if isfield(parameters,n{1})
             d=getfield(parameters,n{1}); %#ok<GFLD>
-            if (~isnumeric(d))||(~isreal(d))||any(size(d)~=parameters.npts)||...
+            if (~isfloat(d))||(~isreal(d))||any(size(d)~=parameters.npts)||...
                 any(~isfinite(d(:)))
-                error(['parameters.' n{1} ' must be a real array of dimension ' num2str(parameters.npts)]);
+                error(['parameters.' n{1} ' must be a real floating-point array of dimension ' num2str(parameters.npts)]);
             end
         end
     end

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -304,11 +304,13 @@ if numel(parameters.npts)==2
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
         m11=parameters.dxx(:); m22=parameters.dyy(:);
-        s12=(parameters.dxy(:)+parameters.dyx(:))/2;
-        scl=max([abs(m11) abs(m22) abs(s12)],[],2); scl(scl==0)=1;
-        m11=m11./scl; m22=m22./scl; s12=s12./scl;
-        if any(m11<-1e-10)||any(m22<-1e-10)||...
-           any(m11.*m22-s12.^2<-1e-10*(abs(m11.*m22)+s12.^2))
+        s12=parameters.dxy(:)/2+parameters.dyx(:)/2;
+        scl_x=sqrt(max(abs(m11),abs(s12))); scl_x(scl_x==0)=1;
+        scl_y=sqrt(max(abs(m22),abs(s12))); scl_y(scl_y==0)=1;
+        m11=m11./scl_x./scl_x; m22=m22./scl_y./scl_y; s12=s12./scl_x./scl_y;
+        psd_tol=20*eps(class(s12));
+        if any(m11<-psd_tol)||any(m22<-psd_tol)||...
+           any(m11.*m22-s12.^2<-psd_tol*(abs(m11.*m22)+s12.^2))
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end
@@ -354,21 +356,23 @@ if (numel(parameters.npts)==3)
         if sym_gap>1e-10*max(sym_scl,eps())
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
-        s12=(parameters.dxy(:)+parameters.dyx(:))/2; m11=parameters.dxx(:);
-        s13=(parameters.dxz(:)+parameters.dzx(:))/2; m22=parameters.dyy(:);
-        s23=(parameters.dyz(:)+parameters.dzy(:))/2; m33=parameters.dzz(:);
-        scl=max([abs(m11) abs(m22) abs(m33) abs(s12) abs(s13) abs(s23)],[],2);
-        scl(scl==0)=1;
-        m11=m11./scl; m22=m22./scl; m33=m33./scl;
-        s12=s12./scl; s13=s13./scl; s23=s23./scl;
+        s12=parameters.dxy(:)/2+parameters.dyx(:)/2; m11=parameters.dxx(:);
+        s13=parameters.dxz(:)/2+parameters.dzx(:)/2; m22=parameters.dyy(:);
+        s23=parameters.dyz(:)/2+parameters.dzy(:)/2; m33=parameters.dzz(:);
+        scl_x=sqrt(max([abs(m11) abs(s12) abs(s13)],[],2)); scl_x(scl_x==0)=1;
+        scl_y=sqrt(max([abs(s12) abs(m22) abs(s23)],[],2)); scl_y(scl_y==0)=1;
+        scl_z=sqrt(max([abs(s13) abs(s23) abs(m33)],[],2)); scl_z(scl_z==0)=1;
+        m11=m11./scl_x./scl_x; m22=m22./scl_y./scl_y; m33=m33./scl_z./scl_z;
+        s12=s12./scl_x./scl_y; s13=s13./scl_x./scl_z; s23=s23./scl_y./scl_z;
         det_top=m11.*(m22.*m33-s23.^2)-s12.*(s12.*m33-s23.*s13)+s13.*(s12.*s23-m22.*s13);
         nrm_det=abs(m11.*m22.*m33)+abs(m11.*s23.^2)+abs(m33.*s12.^2)+...
                 abs(m22.*s13.^2)+2*abs(s12.*s23.*s13);
-        if any(m11<-1e-10)||any(m22<-1e-10)||any(m33<-1e-10)||...
-           any(m11.*m22-s12.^2<-1e-10*(abs(m11.*m22)+s12.^2))||...
-           any(m11.*m33-s13.^2<-1e-10*(abs(m11.*m33)+s13.^2))||...
-           any(m22.*m33-s23.^2<-1e-10*(abs(m22.*m33)+s23.^2))||...
-           any(det_top<-1e-10*nrm_det)
+        psd_tol=20*eps(class(det_top));
+        if any(m11<-psd_tol)||any(m22<-psd_tol)||any(m33<-psd_tol)||...
+           any(m11.*m22-s12.^2<-psd_tol*(abs(m11.*m22)+s12.^2))||...
+           any(m11.*m33-s13.^2<-psd_tol*(abs(m11.*m33)+s13.^2))||...
+           any(m22.*m33-s23.^2<-psd_tol*(abs(m22.*m33)+s23.^2))||...
+           any(det_top<-psd_tol*nrm_det)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -304,9 +304,10 @@ if numel(parameters.npts)==2
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
         d_off=(parameters.dxy+parameters.dyx)/2;
-        psd_scl=max([abs(parameters.dxx(:)); abs(parameters.dyy(:)); abs(d_off(:)); eps()]);
-        if any(parameters.dxx(:)<-1e-10*psd_scl)||any(parameters.dyy(:)<-1e-10*psd_scl)||...
-           any(parameters.dxx(:).*parameters.dyy(:)-d_off(:).^2<-1e-10*psd_scl^2)
+        nrm_x=max(abs(parameters.dxx(:)),abs(d_off(:)));
+        nrm_y=max(abs(parameters.dyy(:)),abs(d_off(:)));
+        if any(parameters.dxx(:)<-1e-10*nrm_x)||any(parameters.dyy(:)<-1e-10*nrm_y)||...
+           any(parameters.dxx(:).*parameters.dyy(:)-d_off(:).^2<-1e-10*nrm_x.*nrm_y)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end
@@ -356,10 +357,15 @@ if (numel(parameters.npts)==3)
         s13=(parameters.dxz(:)+parameters.dzx(:))/2; m22=parameters.dyy(:);
         s23=(parameters.dyz(:)+parameters.dzy(:))/2; m33=parameters.dzz(:);
         det_top=m11.*(m22.*m33-s23.^2)-s12.*(s12.*m33-s23.*s13)+s13.*(s12.*s23-m22.*s13);
-        psd_scl=max([abs(m11); abs(m22); abs(m33); abs(s12); abs(s13); abs(s23); eps()]);
-        if any(m11<-1e-10*psd_scl)||any(m22<-1e-10*psd_scl)||any(m33<-1e-10*psd_scl)||...
-           any(m11.*m22-s12.^2<-1e-10*psd_scl^2)||any(m11.*m33-s13.^2<-1e-10*psd_scl^2)||...
-           any(m22.*m33-s23.^2<-1e-10*psd_scl^2)||any(det_top<-1e-10*psd_scl^3)
+        nrm_x=max([abs(m11) abs(s12) abs(s13)],[],2);
+        nrm_y=max([abs(s12) abs(m22) abs(s23)],[],2);
+        nrm_z=max([abs(s13) abs(s23) abs(m33)],[],2);
+        nrm_xy=max(abs(m11),abs(s12)).*max(abs(m22),abs(s12));
+        nrm_xz=max(abs(m11),abs(s13)).*max(abs(m33),abs(s13));
+        nrm_yz=max(abs(m22),abs(s23)).*max(abs(m33),abs(s23));
+        if any(m11<-1e-10*nrm_x)||any(m22<-1e-10*nrm_y)||any(m33<-1e-10*nrm_z)||...
+           any(m11.*m22-s12.^2<-1e-10*nrm_xy)||any(m11.*m33-s13.^2<-1e-10*nrm_xz)||...
+           any(m22.*m33-s23.^2<-1e-10*nrm_yz)||any(det_top<-1e-10*nrm_x.*nrm_y.*nrm_z)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -304,7 +304,7 @@ if numel(parameters.npts)==2
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
         m11=parameters.dxx(:); m22=parameters.dyy(:);
-        s12=parameters.dxy(:)/2+parameters.dyx(:)/2;
+        s12=parameters.dxy(:)+(parameters.dyx(:)-parameters.dxy(:))/2;
         psd_tol=20*eps(class(s12));
         if any(m11<0)||any(m22<0)||...
            any(abs(s12)>(1+psd_tol)*sqrt(m11).*sqrt(m22))
@@ -353,9 +353,9 @@ if (numel(parameters.npts)==3)
         if sym_gap>1e-10*max(sym_scl,eps())
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
-        s12=parameters.dxy(:)/2+parameters.dyx(:)/2; m11=parameters.dxx(:);
-        s13=parameters.dxz(:)/2+parameters.dzx(:)/2; m22=parameters.dyy(:);
-        s23=parameters.dyz(:)/2+parameters.dzy(:)/2; m33=parameters.dzz(:);
+        s12=parameters.dxy(:)+(parameters.dyx(:)-parameters.dxy(:))/2; m11=parameters.dxx(:);
+        s13=parameters.dxz(:)+(parameters.dzx(:)-parameters.dxz(:))/2; m22=parameters.dyy(:);
+        s23=parameters.dyz(:)+(parameters.dzy(:)-parameters.dyz(:))/2; m33=parameters.dzz(:);
         scl_x=sqrt(abs(m11)); scl_x(scl_x==0)=1;
         scl_y=sqrt(abs(m22)); scl_y(scl_y==0)=1;
         scl_z=sqrt(abs(m33)); scl_z(scl_z==0)=1;

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -305,12 +305,9 @@ if numel(parameters.npts)==2
         end
         m11=parameters.dxx(:); m22=parameters.dyy(:);
         s12=parameters.dxy(:)/2+parameters.dyx(:)/2;
-        scl_x=sqrt(max(abs(m11),abs(s12))); scl_x(scl_x==0)=1;
-        scl_y=sqrt(max(abs(m22),abs(s12))); scl_y(scl_y==0)=1;
-        m11=m11./scl_x./scl_x; m22=m22./scl_y./scl_y; s12=s12./scl_x./scl_y;
         psd_tol=20*eps(class(s12));
-        if any(m11<-psd_tol)||any(m22<-psd_tol)||...
-           any(m11.*m22-s12.^2<-psd_tol*(abs(m11.*m22)+s12.^2))
+        if any(m11<0)||any(m22<0)||...
+           any(abs(s12)>(1+psd_tol)*sqrt(m11).*sqrt(m22))
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end
@@ -359,19 +356,17 @@ if (numel(parameters.npts)==3)
         s12=parameters.dxy(:)/2+parameters.dyx(:)/2; m11=parameters.dxx(:);
         s13=parameters.dxz(:)/2+parameters.dzx(:)/2; m22=parameters.dyy(:);
         s23=parameters.dyz(:)/2+parameters.dzy(:)/2; m33=parameters.dzz(:);
-        scl_x=sqrt(max([abs(m11) abs(s12) abs(s13)],[],2)); scl_x(scl_x==0)=1;
-        scl_y=sqrt(max([abs(s12) abs(m22) abs(s23)],[],2)); scl_y(scl_y==0)=1;
-        scl_z=sqrt(max([abs(s13) abs(s23) abs(m33)],[],2)); scl_z(scl_z==0)=1;
-        m11=m11./scl_x./scl_x; m22=m22./scl_y./scl_y; m33=m33./scl_z./scl_z;
-        s12=s12./scl_x./scl_y; s13=s13./scl_x./scl_z; s23=s23./scl_y./scl_z;
-        det_top=m11.*(m22.*m33-s23.^2)-s12.*(s12.*m33-s23.*s13)+s13.*(s12.*s23-m22.*s13);
-        nrm_det=abs(m11.*m22.*m33)+abs(m11.*s23.^2)+abs(m33.*s12.^2)+...
-                abs(m22.*s13.^2)+2*abs(s12.*s23.*s13);
-        psd_tol=20*eps(class(det_top));
-        if any(m11<-psd_tol)||any(m22<-psd_tol)||any(m33<-psd_tol)||...
-           any(m11.*m22-s12.^2<-psd_tol*(abs(m11.*m22)+s12.^2))||...
-           any(m11.*m33-s13.^2<-psd_tol*(abs(m11.*m33)+s13.^2))||...
-           any(m22.*m33-s23.^2<-psd_tol*(abs(m22.*m33)+s23.^2))||...
+        scl_x=sqrt(abs(m11)); scl_x(scl_x==0)=1;
+        scl_y=sqrt(abs(m22)); scl_y(scl_y==0)=1;
+        scl_z=sqrt(abs(m33)); scl_z(scl_z==0)=1;
+        c12=s12./scl_x./scl_y; c13=s13./scl_x./scl_z; c23=s23./scl_y./scl_z;
+        det_top=1-c12.^2-c13.^2-c23.^2+2*c12.*c13.*c23;
+        nrm_det=1+c12.^2+c13.^2+c23.^2+2*abs(c12.*c13.*c23);
+        psd_tol=20*eps(class(c12));
+        if any(m11<0)||any(m22<0)||any(m33<0)||...
+           any(abs(s12)>(1+psd_tol)*sqrt(m11).*sqrt(m22))||...
+           any(abs(s13)>(1+psd_tol)*sqrt(m11).*sqrt(m33))||...
+           any(abs(s23)>(1+psd_tol)*sqrt(m22).*sqrt(m33))||...
            any(det_top<-psd_tol*nrm_det)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -304,8 +304,10 @@ if numel(parameters.npts)==2
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
         m11=parameters.dxx(:); m22=parameters.dyy(:);
-        s12=parameters.dxy(:)+(parameters.dyx(:)-parameters.dxy(:))/2;
-        psd_tol=20*eps(class(s12));
+        s12=(parameters.dxy(:)+parameters.dyx(:))/2;
+
+        % Cauchy-Schwarz bound, scale-free in the tensor magnitude
+        psd_tol=20*eps(class([m11 m22 s12]));
         if any(m11<0)||any(m22<0)||...
            any(abs(s12)>(1+psd_tol)*sqrt(m11).*sqrt(m22))
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
@@ -353,21 +355,25 @@ if (numel(parameters.npts)==3)
         if sym_gap>1e-10*max(sym_scl,eps())
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
-        s12=parameters.dxy(:)+(parameters.dyx(:)-parameters.dxy(:))/2; m11=parameters.dxx(:);
-        s13=parameters.dxz(:)+(parameters.dzx(:)-parameters.dxz(:))/2; m22=parameters.dyy(:);
-        s23=parameters.dyz(:)+(parameters.dzy(:)-parameters.dyz(:))/2; m33=parameters.dzz(:);
-        scl_x=sqrt(abs(m11)); scl_x(scl_x==0)=1;
-        scl_y=sqrt(abs(m22)); scl_y(scl_y==0)=1;
-        scl_z=sqrt(abs(m33)); scl_z(scl_z==0)=1;
-        c12=s12./scl_x./scl_y; c13=s13./scl_x./scl_z; c23=s23./scl_y./scl_z;
-        det_top=1-c12.^2-c13.^2-c23.^2+2*c12.*c13.*c23;
-        nrm_det=1+c12.^2+c13.^2+c23.^2+2*abs(c12.*c13.*c23);
-        psd_tol=20*eps(class(c12));
+        m11=parameters.dxx(:); s12=(parameters.dxy(:)+parameters.dyx(:))/2;
+        m22=parameters.dyy(:); s13=(parameters.dxz(:)+parameters.dzx(:))/2;
+        m33=parameters.dzz(:); s23=(parameters.dyz(:)+parameters.dzy(:))/2;
+
+        % Correlation scale; a zero diagonal forces its own off-diagonals to zero
+        scl=sqrt([m11 m22 m33]); scl(scl==0)=1;
+
+        % Off-diagonals in correlation form, bounded by unity when semidefinite
+        c=[s12./(scl(:,1).*scl(:,2)) ...
+           s13./(scl(:,1).*scl(:,3)) ...
+           s23./(scl(:,2).*scl(:,3))];
+
+        % Cauchy-Schwarz bounds and the determinant, both scale-free
+        psd_tol=20*eps(class(c));
         if any(m11<0)||any(m22<0)||any(m33<0)||...
            any(abs(s12)>(1+psd_tol)*sqrt(m11).*sqrt(m22))||...
            any(abs(s13)>(1+psd_tol)*sqrt(m11).*sqrt(m33))||...
            any(abs(s23)>(1+psd_tol)*sqrt(m22).*sqrt(m33))||...
-           any(det_top<-psd_tol*nrm_det)
+           any(1-sum(c.^2,2)+2*prod(c,2)<-psd_tol)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -363,9 +363,11 @@ if (numel(parameters.npts)==3)
         nrm_xy=max(abs(m11),abs(s12)).*max(abs(m22),abs(s12));
         nrm_xz=max(abs(m11),abs(s13)).*max(abs(m33),abs(s13));
         nrm_yz=max(abs(m22),abs(s23)).*max(abs(m33),abs(s23));
+        nrm_det=abs(m11.*m22.*m33)+abs(m11.*s23.^2)+abs(m33.*s12.^2)+...
+                abs(m22.*s13.^2)+2*abs(s12.*s23.*s13);
         if any(m11<-1e-10*nrm_x)||any(m22<-1e-10*nrm_y)||any(m33<-1e-10*nrm_z)||...
            any(m11.*m22-s12.^2<-1e-10*nrm_xy)||any(m11.*m33-s13.^2<-1e-10*nrm_xz)||...
-           any(m22.*m33-s23.^2<-1e-10*nrm_yz)||any(det_top<-1e-10*nrm_x.*nrm_y.*nrm_z)
+           any(m22.*m33-s23.^2<-1e-10*nrm_yz)||any(det_top<-1e-10*nrm_det)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -303,11 +303,12 @@ if numel(parameters.npts)==2
         if max(abs(parameters.dxy(:)-parameters.dyx(:)))>1e-10*max(sym_scl,eps())
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
-        d_off=(parameters.dxy+parameters.dyx)/2;
-        nrm_x=max(abs(parameters.dxx(:)),abs(d_off(:)));
-        nrm_y=max(abs(parameters.dyy(:)),abs(d_off(:)));
-        if any(parameters.dxx(:)<-1e-10*nrm_x)||any(parameters.dyy(:)<-1e-10*nrm_y)||...
-           any(parameters.dxx(:).*parameters.dyy(:)-d_off(:).^2<-1e-10*nrm_x.*nrm_y)
+        m11=parameters.dxx(:); m22=parameters.dyy(:);
+        s12=(parameters.dxy(:)+parameters.dyx(:))/2;
+        scl=max([abs(m11) abs(m22) abs(s12)],[],2); scl(scl==0)=1;
+        m11=m11./scl; m22=m22./scl; s12=s12./scl;
+        if any(m11<-1e-10)||any(m22<-1e-10)||...
+           any(m11.*m22-s12.^2<-1e-10*(abs(m11.*m22)+s12.^2))
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end
@@ -356,18 +357,18 @@ if (numel(parameters.npts)==3)
         s12=(parameters.dxy(:)+parameters.dyx(:))/2; m11=parameters.dxx(:);
         s13=(parameters.dxz(:)+parameters.dzx(:))/2; m22=parameters.dyy(:);
         s23=(parameters.dyz(:)+parameters.dzy(:))/2; m33=parameters.dzz(:);
+        scl=max([abs(m11) abs(m22) abs(m33) abs(s12) abs(s13) abs(s23)],[],2);
+        scl(scl==0)=1;
+        m11=m11./scl; m22=m22./scl; m33=m33./scl;
+        s12=s12./scl; s13=s13./scl; s23=s23./scl;
         det_top=m11.*(m22.*m33-s23.^2)-s12.*(s12.*m33-s23.*s13)+s13.*(s12.*s23-m22.*s13);
-        nrm_x=max([abs(m11) abs(s12) abs(s13)],[],2);
-        nrm_y=max([abs(s12) abs(m22) abs(s23)],[],2);
-        nrm_z=max([abs(s13) abs(s23) abs(m33)],[],2);
-        nrm_xy=max(abs(m11),abs(s12)).*max(abs(m22),abs(s12));
-        nrm_xz=max(abs(m11),abs(s13)).*max(abs(m33),abs(s13));
-        nrm_yz=max(abs(m22),abs(s23)).*max(abs(m33),abs(s23));
         nrm_det=abs(m11.*m22.*m33)+abs(m11.*s23.^2)+abs(m33.*s12.^2)+...
                 abs(m22.*s13.^2)+2*abs(s12.*s23.*s13);
-        if any(m11<-1e-10*nrm_x)||any(m22<-1e-10*nrm_y)||any(m33<-1e-10*nrm_z)||...
-           any(m11.*m22-s12.^2<-1e-10*nrm_xy)||any(m11.*m33-s13.^2<-1e-10*nrm_xz)||...
-           any(m22.*m33-s23.^2<-1e-10*nrm_yz)||any(det_top<-1e-10*nrm_det)
+        if any(m11<-1e-10)||any(m22<-1e-10)||any(m33<-1e-10)||...
+           any(m11.*m22-s12.^2<-1e-10*(abs(m11.*m22)+s12.^2))||...
+           any(m11.*m33-s13.^2<-1e-10*(abs(m11.*m33)+s13.^2))||...
+           any(m22.*m33-s23.^2<-1e-10*(abs(m22.*m33)+s23.^2))||...
+           any(det_top<-1e-10*nrm_det)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end

--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -304,8 +304,9 @@ if numel(parameters.npts)==2
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
         d_off=(parameters.dxy+parameters.dyx)/2;
-        if any(parameters.dxx(:)<0)||any(parameters.dyy(:)<0)||...
-           any(parameters.dxx(:).*parameters.dyy(:)-d_off(:).^2<0)
+        psd_scl=max([abs(parameters.dxx(:)); abs(parameters.dyy(:)); abs(d_off(:)); eps()]);
+        if any(parameters.dxx(:)<-1e-10*psd_scl)||any(parameters.dyy(:)<-1e-10*psd_scl)||...
+           any(parameters.dxx(:).*parameters.dyy(:)-d_off(:).^2<-1e-10*psd_scl^2)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end
@@ -355,9 +356,10 @@ if (numel(parameters.npts)==3)
         s13=(parameters.dxz(:)+parameters.dzx(:))/2; m22=parameters.dyy(:);
         s23=(parameters.dyz(:)+parameters.dzy(:))/2; m33=parameters.dzz(:);
         det_top=m11.*(m22.*m33-s23.^2)-s12.*(s12.*m33-s23.*s13)+s13.*(s12.*s23-m22.*s13);
-        if any(m11<0)||any(m22<0)||any(m33<0)||...
-           any(m11.*m22-s12.^2<0)||any(m11.*m33-s13.^2<0)||...
-           any(m22.*m33-s23.^2<0)||any(det_top<0)
+        psd_scl=max([abs(m11); abs(m22); abs(m33); abs(s12); abs(s13); abs(s23); eps()]);
+        if any(m11<-1e-10*psd_scl)||any(m22<-1e-10*psd_scl)||any(m33<-1e-10*psd_scl)||...
+           any(m11.*m22-s12.^2<-1e-10*psd_scl^2)||any(m11.*m33-s13.^2<-1e-10*psd_scl^2)||...
+           any(m22.*m33-s23.^2<-1e-10*psd_scl^2)||any(det_top<-1e-10*psd_scl^3)
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end


### PR DESCRIPTION
The per-voxel positive-semidefiniteness gates (2D and 3D diffusion tensor fields) test principal minors against exact zero. A physically legitimate boundary field — e.g. a rank-deficient diffusion tensor rotated to an arbitrary angle — produces minors whose exact value is zero but whose floating-point value rounds negative (measured: −1.2e-35 for a rotated 2D rank-1 field, −2.5e-44 for a 3D rank-2 determinant), and the whole field is rejected as non-PSD. The symmetry check four lines above already uses a relative 1e-10 tolerance; the PSD checks did not.

**Fix**: minors are now tested against `-1e-10*psd_scl^k` where `psd_scl` is the largest tensor-element magnitude and `k` the minor order (1 for diagonals, 2 for 2×2 minors, 3 for the 3D determinant) — the same 1e-10 relative convention as the adjacent symmetry gate, dimensionally consistent for each minor.

**Validation** (probe `d31.log`, full production calls on a real one-proton spin system): rotated rank-1 2D and rank-2 3D boundary fields with measured rounding-negative minors are now accepted and the Fokker-Planck operator builds; genuinely indefinite 2D and 3D fields (eigenvalue −5% of scale) are still rejected with the PSD message; the all-positive 45° control passes as before. `checkcode` and house-style gates clean.

Found during the 2026-08-29 whole-range review (finding K05-F4).