### PR TITLE
vvpert: tolerance-based hermiticity gate, exact symmetrisation

### DIFF
--- a/kernel/utilities/vvpert.m
+++ b/kernel/utilities/vvpert.m
@@ -26,7 +26,7 @@
 %             vectors in columns, in the same order as the 
 %             eigenvalues in Ep
 %
-% Notes: there must be no degeneracies in H0; H1 must be Hermitian,
+% Notes: no degeneracies in H0; H1 must be finite and Hermitian,
 %        the theory only converges when norm(H1,2) is much smaller
 %        than the smallest energy gap in H0; complexity is cubic
 %        both in the order and in the matrix dimension.
@@ -41,7 +41,7 @@ function [Ep,G]=vvpert(E0,H1,order)
 grumble(E0,H1,order);
 
 % Enforce exact hermiticity
-H1=(H1+H1')/2;
+H1=H1/2+H1'/2;
 
 % Reciprocal energy differences
 Q=1./(E0'-E0); Q(logical(speye(size(Q))))=0;
@@ -111,8 +111,8 @@ if (~isnumeric(E0))||(~isreal(E0))||(~iscolumn(E0))
     error('E0 must be a real column vector.');
 end
 if (~isnumeric(H1))||(size(H1,1)~=size(H1,2))||...
-   (norm(H1-H1',1)>1e-10*max(norm(H1,1),eps()))
-    error('H1 must be a Hermitian matrix.');
+   any(~isfinite(H1),'all')||(norm(H1-H1',1)>1e-10*norm(H1,1))
+    error('H1 must be a finite Hermitian matrix.');
 end
 if (numel(E0)~=size(H1,1))||(numel(E0)~=size(H1,2))
     error('dimensions of E0 and H1 must be consistent.');

--- a/kernel/utilities/vvpert.m
+++ b/kernel/utilities/vvpert.m
@@ -40,6 +40,9 @@ function [Ep,G]=vvpert(E0,H1,order)
 % Check consistency
 grumble(E0,H1,order);
 
+% Enforce exact hermiticity
+H1=(H1+H1')/2;
+
 % Reciprocal energy differences
 Q=1./(E0'-E0); Q(logical(speye(size(Q))))=0;
 if any(~isfinite(Q),'all')
@@ -107,7 +110,8 @@ function grumble(E0,H1,order)
 if (~isnumeric(E0))||(~isreal(E0))||(~iscolumn(E0))
     error('E0 must be a real column vector.');
 end
-if (~isnumeric(H1))||(~ishermitian(H1))
+if (~isnumeric(H1))||(size(H1,1)~=size(H1,2))||...
+   (norm(H1-H1',1)>1e-10*max(norm(H1,1),eps()))
     error('H1 must be a Hermitian matrix.');
 end
 if (numel(E0)~=size(H1,1))||(numel(E0)~=size(H1,2))


### PR DESCRIPTION
The grumbler requires `ishermitian(H1)` — bitwise hermiticity. The documented workflow builds the perturbation in the eigenbasis of the unperturbed Hamiltonian, and `V'*H*V` products carry eps-level asymmetry (measured: 3.7e-16 relative, `ishermitian` false), so legitimate eigenbasis-transformed perturbations are rejected with `H1 must be a Hermitian matrix.`

**Fix**: the gate now rejects only genuine asymmetry (`norm(H1-H1',1)>1e-10*norm(H1,1)`, with an explicit square-size check), and the body symmetrises `H1=(H1+H1')/2` before use, so the Van Vleck recursion always runs on an exactly Hermitian matrix — the same tolerance-then-hermitise pattern as the `device.m` fix (#345).

**Validation** (probe `d26.log`): exactly-Hermitian input gives bit-identical `Ep` and `G` to the stock function; order-5 eigenvalues match direct diagonalisation to 2.1e-14; the eigenbasis-produced eps-asymmetric perturbation is now accepted and yields bit-identical results to its symmetrised form; a 1%-asymmetric matrix is still rejected; `checkcode` and house-style gates clean.

Found during the 2026-08-29 whole-range review (finding K05-F2).