### PR TITLE
validate_sym: explain why componentwise invariance is required

### DIFF
--- a/kernel/utilities/validate_sym.m
+++ b/kernel/utilities/validate_sym.m
@@ -3,11 +3,14 @@
 % spin system object are strictly invariant under every operation of
 % each declared permutation group, so that the irreducible representa-
 % tion projectors built by symmetry.m correspond to a symmetry that
-% the interactions actually possess. The declared symmetry is a permu-
-% tation of spin labels, not a spatial rotation; interaction tensors
-% related by a rotation rather than being identical are not accepted.
-% When no symmetry is declared, the function returns without perfor-
-% ming any checks. Syntax:
+% the interactions actually possess. Zeeman and giant-spin interacti-
+% ons must be identical between permuted spins. Coupling tensors bet-
+% ween permuted spin pairs must have identical eigenvalues; tensors
+% that match only up to a rotation, such as dipolar couplings computed
+% from symmetric coordinates, are accepted with a report that their
+% anisotropic parts are not permutation-invariant. When no symmetry
+% is declared, the function returns without performing any checks.
+% Syntax:
 %
 %                    validate_sym(spin_system,bas)
 %
@@ -70,6 +73,9 @@ for m=1:numel(bas.sym_group)
     % Permutation elements of the declared group
     group=perm_group(bas.sym_group{m});
 
+    % Rotation-related coupling flag
+    rot_related=false();
+
     % Loop over symmetry operations
     for n=1:group.order
 
@@ -100,19 +106,29 @@ for m=1:numel(bas.sym_group)
                        'giant-spin interactions are not identical.']);
             end
 
-            % Check coupling tensor invariance against every spin
+            % Check coupling eigenvalue invariance against every spin
             for q=1:nspins
-                if norm(get_coupling(spin_system,perm(spins(k)),perm(q))-...
-                        get_coupling(spin_system,spins(k),q),2)>tol
+                coup_a=get_coupling(spin_system,spins(k),q);
+                coup_b=get_coupling(spin_system,perm(spins(k)),perm(q));
+                if norm(sort(eig(coup_b))-sort(eig(coup_a)),2)>tol
                     error(['the interaction between spins ' num2str(spins(k)) ' and ' ...
                            num2str(q) ' is not preserved by the ' bas.sym_group{m} ...
                            ' symmetry; it differs from the interaction between spins ' ...
                            num2str(perm(spins(k))) ' and ' num2str(perm(q)) '.']);
+                elseif norm(coup_b-coup_a,2)>tol
+                    rot_related=true();
                 end
             end
 
         end
 
+    end
+
+    % Report rotation-related coupling anisotropies
+    if rot_related
+        report(spin_system,['couplings in the ' bas.sym_group{m} ' group match their '...
+                            'permutation images only up to a rotation; anisotropic '...
+                            'parts are not permutation-invariant.']);
     end
 
 end

--- a/kernel/utilities/validate_sym.m
+++ b/kernel/utilities/validate_sym.m
@@ -3,14 +3,11 @@
 % spin system object are strictly invariant under every operation of
 % each declared permutation group, so that the irreducible representa-
 % tion projectors built by symmetry.m correspond to a symmetry that
-% the interactions actually possess. Zeeman and giant-spin interacti-
-% ons must be identical between permuted spins. Coupling tensors bet-
-% ween permuted spin pairs must have identical eigenvalues; tensors
-% that match only up to a rotation, such as dipolar couplings computed
-% from symmetric coordinates, are accepted with a report that their
-% anisotropic parts are not permutation-invariant. When no symmetry
-% is declared, the function returns without performing any checks.
-% Syntax:
+% the interactions actually possess. The declared symmetry is a permu-
+% tation of spin labels, not a spatial rotation; interaction tensors
+% related by a rotation rather than being identical are not accepted.
+% When no symmetry is declared, the function returns without perfor-
+% ming any checks. Syntax:
 %
 %                    validate_sym(spin_system,bas)
 %
@@ -73,9 +70,6 @@ for m=1:numel(bas.sym_group)
     % Permutation elements of the declared group
     group=perm_group(bas.sym_group{m});
 
-    % Rotation-related coupling flag
-    rot_related=false();
-
     % Loop over symmetry operations
     for n=1:group.order
 
@@ -106,29 +100,21 @@ for m=1:numel(bas.sym_group)
                        'giant-spin interactions are not identical.']);
             end
 
-            % Check coupling eigenvalue invariance against every spin
+            % Check coupling tensor invariance against every spin
             for q=1:nspins
-                coup_a=get_coupling(spin_system,spins(k),q);
-                coup_b=get_coupling(spin_system,perm(spins(k)),perm(q));
-                if norm(sort(eig(coup_b))-sort(eig(coup_a)),2)>tol
+                if norm(get_coupling(spin_system,perm(spins(k)),perm(q))-...
+                        get_coupling(spin_system,spins(k),q),2)>tol
                     error(['the interaction between spins ' num2str(spins(k)) ' and ' ...
                            num2str(q) ' is not preserved by the ' bas.sym_group{m} ...
                            ' symmetry; it differs from the interaction between spins ' ...
-                           num2str(perm(spins(k))) ' and ' num2str(perm(q)) '.']);
-                elseif norm(coup_b-coup_a,2)>tol
-                    rot_related=true();
+                           num2str(perm(spins(k))) ' and ' num2str(perm(q)) '; the condition '...
+                           'enforced is componentwise identity in the laboratory frame, '...
+                           'because symmetry.m permutes spin labels without rotating it.']);
                 end
             end
 
         end
 
-    end
-
-    % Report rotation-related coupling anisotropies
-    if rot_related
-        report(spin_system,['couplings in the ' bas.sym_group{m} ' group match their '...
-                            'permutation images only up to a rotation; anisotropic '...
-                            'parts are not permutation-invariant.']);
     end
 
 end


### PR DESCRIPTION
Originally this PR relaxed the coupling-invariance test in `validate_sym` to accept rotation-related anisotropies, comparing eigenvalue spectra instead of components and emitting a report. Codex review flagged that as unsafe, and the objection reproduced:

- `symmetry.m:139-150` builds projectors from spin-label permutations only, with no rotation, so a rotation-related pair does not satisfy the invariance the factorisation assumes.
- Exact C3 methyl at fixed orientation under `assume('labframe')`: A1g leakage `norm(H*P-P*(P'*H*P))/norm(H*P)` = 2.64e-05, and the pulse-acquire FID with vs without the S3 declaration differs by 1.48 relative. The permuted dipolar pair differs componentwise by 1.73e+05 rad/s while its eigenvalue spectra agree to 4.37e-11 against a 6.28e-10 tolerance, which is exactly what the eigenvalue gate was letting through.
- The motivating liquid-state case is genuinely sound (`assume('nmr')` plus Redfield: leakage 3.21e-06, FID discrepancy 1.77e-14), but that validity comes from an assumption applied after `basis()`, which `validate_sym` cannot see; `spin_system` carries no regime information at basis-construction time.

The relaxation is therefore reverted and the executable logic is identical to `main`. What remains is a longer error message naming the condition that is actually enforced and why.

Validation: `checkcode` empty on the edited file, house-style checker clean; coordinate methyl plus S3 rejected with the new message, a J12=J23=5 / J13=2 Hz chain declared S3 still rejected, scalar-equivalent methyl still accepted; shipped `symmetry_1`, `symmetry_2`, `symmetry_3`, `symmetry_4` and `endor_methyl` all run to completion.