### PR TITLE
kernel: documentation and message corrections

### DIFF
--- a/kernel/line_shapes/lorentzfun.m
+++ b/kernel/line_shapes/lorentzfun.m
@@ -1,5 +1,8 @@
-% Normalised Lorentzian function in magnetic resonance notation
-% with a phase distortion. Syntax:
+% Lorentzian function in magnetic resonance notation with a
+% phase distortion, normalised so that the absorption mode
+% integrates to ampl/2, the one-sided FID Fourier transform
+% convention; note that lorentzcon() integrates to ampl.
+% Syntax:
 %
 %    [real_part,imag_part]=lorentzfun(offs,ampl,fwhm,x,phi)
 %
@@ -58,7 +61,7 @@ if (~isnumeric(ampl))||(~isreal(ampl))||(numel(ampl)~=1)
     error('ampl must be a real scalar.');
 end
 if (~isnumeric(phi))||(~isreal(phi))||(numel(phi)~=1)
-    error('ampl must be a real scalar.');
+    error('phi must be a real scalar.');
 end
 end
 

--- a/kernel/optimcon/hessreg.m
+++ b/kernel/optimcon/hessreg.m
@@ -74,7 +74,7 @@ H=real(H+H')/2;
 
 % Warn if the target condition number was not reached
 if cond(H,2)>=max_cond
-    warning('RFO regularisation failed to reach the target condition number, increase control.reg_max_iter.');
+    warning('RFO regularisation failed to reach the target condition number.');
 end
 
 end

--- a/kernel/overloads/@ttclass/shrink.m
+++ b/kernel/overloads/@ttclass/shrink.m
@@ -9,7 +9,7 @@
 % Outputs:
 %
 %    ttrain - compressed tensor train object with 
-%             right-to-left orthogonalisation
+%             left-to-right orthogonalisation
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il

--- a/kernel/plotting/contspacing.m
+++ b/kernel/plotting/contspacing.m
@@ -37,8 +37,8 @@
 %
 % Note: the following functions are used to get contour levels
 %
-%  pos_conts=delta(2)*smax*linspace(0,1,ncont).^k+smax*delta(1);
-%  neg_conts=delta(2)*smin*linspace(0,1,ncont).^k+smin*delta(1);
+%  pos_conts=(delta(2)-delta(1))*smax*linspace(0,1,ncont).^k+smax*delta(1);
+%  neg_conts=(delta(4)-delta(3))*smin*linspace(0,1,ncont).^k+smin*delta(3);
 %
 % ilya.kuprov@weizmann.ac.il
 %

--- a/kernel/plotting/int_2d.m
+++ b/kernel/plotting/int_2d.m
@@ -51,8 +51,8 @@
 %
 % Note: the following functions are used to compute contour levels:
 %
-%  cont_levs_pos=delta(2)*smax*linspace(0,1,ncont).^k+smax*delta(1);
-%  cont_levs_neg=delta(2)*smin*linspace(0,1,ncont).^k+smin*delta(1);
+%  cont_levs_pos=(delta(2)-delta(1))*smax*linspace(0,1,ncont).^k+smax*delta(1);
+%  cont_levs_neg=(delta(4)-delta(3))*smin*linspace(0,1,ncont).^k+smin*delta(3);
 %
 % where smin and smax are computed from the spectrum matrix. 
 %

--- a/kernel/pulses/iserstep.m
+++ b/kernel/pulses/iserstep.m
@@ -27,10 +27,10 @@
 %
 %     dt  - evolution time step, seconds
 %
-%     method - 'PWCL', 'PWCM', 'RKMK4', 'RKMK-DP5',
-%              'RKMK-DP8', or 'LG4'; the latter one
-%               has a good balance of efficiency and
-%               numerical accuracy
+%     method - 'PWCL', 'LG2', 'LG4', 'LG4A', 'RKMK4',
+%              'RKMK-DP5', 'RKMK-DP8', or 'RKMK-RKF45';
+%              'LG4' has a good balance of efficiency
+%               and numerical accuracy
 %
 % Outputs:
 %

--- a/kernel/steady.m
+++ b/kernel/steady.m
@@ -1,7 +1,7 @@
 % Steady state under the repeated action by the same dissi-
 % pative evolution propagator. Syntax:
 %
-%         rho=steady(spin_system,P,rho,tol,method)
+%           rho=steady(spin_system,P,rho,method)
 %
 % Parameters:
 %

--- a/kernel/utilities/hdot.m
+++ b/kernel/utilities/hdot.m
@@ -1,7 +1,7 @@
 % Hadamard route to Frobenius matrix product. Useful as a 
 % replacement for trace(A'*B) because 
 %
-%               trace(A'*B)=hadm(conj(A),B) 
+%             trace(A'*B)=sum(sum(conj(A).*B))
 %
 % and the latter only needs O(n^2) multiplications as com-
 % pared to O(n^3) for trace(A'*B). Syntax: 


### PR DESCRIPTION
Eight small header/message corrections found during the 2026-08-29 whole-range review, none changing behaviour except one error-message string:

- `hdot.m`: the header identity referenced a non-existent function `hadm`; now states `trace(A'*B)=sum(sum(conj(A).*B))` (K02-F3).
- `hessreg.m`: the regularisation warning told users to increase `control.reg_max_iter`, which `optimcon.m` sets internally and rejects as an unparsed control field; the non-actionable advice is dropped (K01-F10).
- `iserstep.m`: header advertised unimplemented `'PWCM'` and omitted the supported `'LG2'`, `'LG4A'`, `'RKMK-RKF45'`; the list now matches the grumbler whitelist (K08-F1).
- `@ttclass/shrink.m`: header said right-to-left orthogonalisation; the body performs `ttort(ttrain,+1)` left-to-right, on which the subsequent norm extraction relies (K11-F3).
- `contspacing.m`, `int_2d.m`: header contour-law formulas said `delta(2)*smax*...+smax*delta(1)` for both signs; the implementation (and the test suite) use `(delta(2)-delta(1))` and, for negatives, `delta(3)`/`delta(4)` (T03-F1).
- `steady.m`: header syntax line showed a `tol` argument the function does not take (Ex08a-F3).
- `lorentzfun.m`: header now states its own normalisation (absorption mode integrates to `ampl/2`, one-sided-FID FT convention) instead of sharing the identical "Normalised Lorentzian" opening with `lorentzcon`, which integrates to `ampl` — the two differ by a deliberate, test-enshrined factor of two (K06-F3); and the `phi` grumbler branch said `ampl must be a real scalar.`, now `phi`.

**Validation**: `checkcode` clean on all eight files; house-style violation count unchanged from stock (10, all pre-existing in `iserstep.m`/`contspacing.m`); every corrected formula/list verified against the implementation lines quoted in the review findings.