### PR TITLE
spinach-simulations skill: refresh stale claims against current kernel

### DIFF
--- a/interfaces/skills/spinach-simulations/SKILL.md
+++ b/interfaces/skills/spinach-simulations/SKILL.md
@@ -190,8 +190,8 @@ averaging, and calls your pulse sequence. All contexts share the signature
 
 The `assumptions` string selects which terms survive the rotating-frame
 treatment inside `hamiltonian`: `'nmr'`, `'esr'`, `'deer'`, `'deer-zz'`,
-`'labframe'`, `'qnmr'`, and the DNP variants `'se_dnp_h+'`, `'se_dnp_h-'`,
-`'se_dnp_h0'`. Using `'nmr'` for an EPR problem silently discards the physics
+`'labframe'`, `'qnmr'`, `'cavity'`, `'spin-phonon'`, and the DNP variants
+`'se_dnp_h+'`, `'se_dnp_h-'`, `'se_dnp_h0'`. Using `'nmr'` for an EPR problem silently discards the physics
 you wanted.
 
 ## Propagation

--- a/interfaces/skills/spinach-simulations/references/contexts.md
+++ b/interfaces/skills/spinach-simulations/references/contexts.md
@@ -188,8 +188,13 @@ Coherence selection is analytical rather than by phase cycling:
 
 The first three also run in `zeeman-liouv` and `zeeman-hilb` through an
 internal Liouville round trip (`homospoil` there keeps only the
-density-matrix diagonal and ignores `zqc_flag`); all three support
-Fokker-Planck direct products.
+density-matrix diagonal and ignores `zqc_flag`). `coherence` and
+`correlation` support Fokker-Planck direct products in every formalism;
+`homospoil` supports them in `sphten-liouv` only, because its
+`zeeman-liouv` branch takes `sqrt(size(rho,1))` as the density matrix
+dimension instead of factoring the spatial part out, which throws for
+most spatial dimensions and masks the wrong elements when the combined
+row count happens to be a perfect square.
 
 ## The `state` and `operator` grammar
 

--- a/interfaces/skills/spinach-simulations/references/contexts.md
+++ b/interfaces/skills/spinach-simulations/references/contexts.md
@@ -58,7 +58,7 @@ context can compute. The accepted strings differ by context:
 | `.max_rank` | maximum rotor harmonic (or Wigner D-function) rank retained; increase to convergence, a good first guess is the number of expected sidebands | `singlerot`, `floquet`, `gridfree` |
 | `.rate_outer`, `.rate_inner`, `.axis_outer`, `.axis_inner`, `.rank_outer`, `.rank_inner` | the same three quantities for each of the two rotors | `doublerot` |
 | `.tau_c` | rotational diffusion correlation times in seconds; a scalar for isotropic diffusion, a 3x3 matrix for anisotropic | `gridfree` |
-| `.serial` | true disables automatic parallelisation | `powder`, `doublerot` |
+| `.serial` | true disables automatic parallelisation | `powder`, `singlerot`, `doublerot`, `floquet` |
 | `.sum_up` | 1 (default) returns the powder average, 0 returns a cell array of per-orientation answers | `powder`, `singlerot`, `doublerot`, `floquet` |
 
 In `powder`, `parameters.rho0` may be a function handle of the three ZYZ
@@ -87,8 +87,8 @@ parameters.coil_ph={Ph1,...,PhN}; parameters.coil_st={rho1,...,rhoN};
 ```
 
 The relaxation pair is `_ph`/`_op`; the state pairs are `_ph`/`_st`, and the
-consistency checks enforce those names even though the file header writes
-`rho0_op` and `coil_op`. Each `Ph` has the dimension of the voxel grid, and
+consistency checks enforce those names, which the file header states
+correctly. Each `Ph` has the dimension of the voxel grid, and
 each `rho` comes from `state`. The direct product order is Z(x)Y(x)X(x)Spin,
 corresponding to column-wise vectorisation of a 3D array with dimensions
 ordered `[X Y Z]`. `meshflow`, the microfluidics and magnetohydrodynamics
@@ -186,8 +186,10 @@ Coherence selection is analytical rather than by phase cycling:
 - `rho=spinlock(spin_system,Lx,Ly,rho,direction)` applies an analytical
   spin lock.
 
-The first three require `sphten-liouv`; all three support Fokker-Planck
-direct products.
+The first three also run in `zeeman-liouv` and `zeeman-hilb` through an
+internal Liouville round trip (`homospoil` there keeps only the
+density-matrix diagonal and ignores `zqc_flag`); all three support
+Fokker-Planck direct products.
 
 ## The `state` and `operator` grammar
 

--- a/interfaces/skills/spinach-simulations/references/inputs.md
+++ b/interfaces/skills/spinach-simulations/references/inputs.md
@@ -409,7 +409,7 @@ with `comsol.crop` and `comsol.inactivate` controlling the retained region.
 
 Complete ready-made systems live in `etc/molecules/` (`strychnine(spins)`,
 `cyprinol()`, `lactate(spins)`, `allyl_pyruvate(spins)`,
-`fatty_acid(nprotons)`, `dac_reaction()`) and `etc/diamond_defects/` (fourteen
+`fatty_acid(nprotons)`, `dac_reaction()`) and `etc/diamond_defects/` (fifteen
 `[sys,inter]=<name>(parameters)` builders for NV, P1 and related centres).
 `guess_j_pro`, `guess_j_nuc` and `guess_csa_pro` are the estimators `protein`
 and `nuclacid` call internally; everything they return is an estimate and must

--- a/interfaces/skills/spinach-simulations/references/pitfalls.md
+++ b/interfaces/skills/spinach-simulations/references/pitfalls.md
@@ -91,7 +91,7 @@ approximations then have their own required fields and cross-rules:
 
 | Message | Meaning |
 |---|---|
-| `connectivity tracing depth must be specified in bas.level variable.` | IK-0/1/2 need `bas.level`. |
+| `connectivity tracing depth must be specified in bas.level variable.` | IK-0, IK-1, and IK-DNP need `bas.level` (IK-DNP as a 1x3 vector); IK-2 does not use it. |
 | `connectivity type must be specified in bas.connectivity variable.` | IK-1/2 need `'scalar_couplings'` or `'full_tensors'`. |
 | `proximity tracing depth must be specified in bas.space_level variable.` | IK-1/2 need `bas.space_level`. |
 | `bas.level is only applicable to IK-0,1,2,DNP basis sets.` | Do not set IK fields with `approximation='none'`; the same rule exists for `bas.space_level` and `bas.connectivity` (IK-1/2 only). |
@@ -108,7 +108,7 @@ relaxation is a frequent dead end:
 ```
 Redfield relaxation theory is only available for sphten-liouv formalism.
 extended T1,T2 relaxation theory is only available for sphten-liouv formalism.
-analytical decoupling is only available for sphten-liouv formalism.
+analytical decoupling is only available for sphten-liouv, zeeman-liouv, and zeeman-hilb formalisms.
 chemical reaction modelling is only available for sphten-liouv formalism.
 bas.projections option is only available for sphten-liouv formalism.
 ```

--- a/interfaces/skills/spinach-simulations/references/relaxation.md
+++ b/interfaces/skills/spinach-simulations/references/relaxation.md
@@ -18,8 +18,9 @@ rates have no effect there.
 
 `inter.relaxation` is a cell array of strings and more than one may be
 given. The accepted set is exactly `'damp'`, `'t1_t2'`, `'redfield'`,
-`'lindblad'`, `'nottingham'`, `'weizmann'`, `'SRFK'`, `'SRSK'`; anything
-else is refused by `create`. If the field is absent, `R` is zero.
+`'naka-zwan'`, `'lindblad'`, `'nottingham'`, `'weizmann'`, `'SRFK'`,
+`'SRSK'`; anything else is refused by `create`. If the field is absent,
+`R` is zero.
 
 | Theory | Physical model | Required inputs | Typical use |
 |---|---|---|---|
@@ -31,6 +32,7 @@ else is refused by `create`. If the field is absent, `R` is zero.
 | `nottingham` | DNP model on the four-level two-electron manifold | `inter.nott_r1e`, `nott_r2e`, `nott_r1n`, `nott_r2n` | Cross-effect DNP; exactly two electrons |
 | `SRFK` | Scalar relaxation of the first kind: stochastic modulation of a coupling | `inter.srfk_tau_c`, `inter.srfk_mdepth` | Exchange fast enough to modulate J; conformational averaging |
 | `SRSK` | Scalar relaxation of the second kind, Abragam's expressions | `inter.srsk_sources` | Quadrupolar neighbours (14N, 35Cl, 79Br) broadening their partners |
+| `naka-zwan` | Nakajima-Zwanzig evaluation of the same rotational-modulation kernel as `redfield`; the two are mutually exclusive | `inter.tau_c`, `inter.nz_shift`, `inter.nz_onshell` | Relaxation beyond the Redfield evaluation of the memory kernel |
 
 Two settings become mandatory the moment `inter.relaxation` is present:
 
@@ -39,13 +41,13 @@ inter.rlx_keep='kite';       % which terms of R survive
 inter.equilibrium='zero';    % where relaxation drives the system
 ```
 
-Formalism restrictions are enforced. `t1_t2` and `redfield` are
-`sphten-liouv` only. `lindblad`, `nottingham`, `weizmann`, `SRFK`, `SRSK`,
+Formalism restrictions are enforced. `t1_t2`, `redfield`, and
+`naka-zwan` are `sphten-liouv` only. `lindblad`, `nottingham`, `weizmann`, `SRFK`, `SRSK`,
 and IME thermalisation all require Liouville space (`sphten-liouv` or
 `zeeman-liouv`). Only `damp` works in `zeeman-hilb`.
 
-Terms accumulate in a fixed order: `t1_t2`, `redfield`, `lindblad`,
-`weizmann`, `nottingham`, `SRFK`, `SRSK`; then the dynamic frequency shift
+Terms accumulate in a fixed order: `t1_t2`, `redfield`, `naka-zwan`,
+`lindblad`, `weizmann`, `nottingham`, `SRFK`, `SRSK`; then the dynamic frequency shift
 policy applies, then `inter.rlx_keep` truncates, then `damp` is added, then
 thermalisation. Hence `SRSK` reads the superoperator accumulated so far to
 extract source spin T1 and T2 and is useless without a companion theory,


### PR DESCRIPTION
Six stale or wrong claims in the shipped AI skill, found by auditing every skill assertion against the head kernel during the 2026-08-29 whole-range review (finding I01), each verified against the quoted kernel lines:

- `contexts.md`: said `coherence`/`correlation`/`homospoil` "require sphten-liouv" — all three (and `decouple`) now also run in `zeeman-liouv`/`zeeman-hilb` via the Liouville round trip added in 737a83dc/5747f888 (`coherence.m:141`, `correlation.m:138`); text updated with the `homospoil` diagonal/`zqc_flag` caveat.
- `pitfalls.md`: verbatim-quoted a `decouple` error message that no longer exists; updated to the head three-formalism wording (`decouple.m:196`).
- `relaxation.md`: "exactly" eight theories — head `create.m` also accepts `'naka-zwan'` (mandatory `inter.tau_c`/`nz_shift`/`nz_onshell`, mutually exclusive with `redfield` — "alternative evaluations of the same kernel" per `create.m:2036`, `sphten-liouv` only, slots between `redfield` and `lindblad` in the accumulation order); list, theory table, formalism restrictions, and accumulation order updated.
- `pitfalls.md`: the `bas.level` error row said "IK-0/1/2 need bas.level" — wrong on both edges (`basis.m:673`: IK-0/IK-1/IK-DNP require it, IK-DNP as a 1x3 vector; IK-2 does not use it); now consistent with `inputs.md` and the code.
- `contexts.md`: alleged an `imaging.m` header error (`rho0_op`/`coil_op`) that was fixed in-range by 295c7757 — the skill was inviting agents to distrust a correct header.
- Bundled enumerations: `SKILL.md` assumptions list gains `'cavity'` and `'spin-phonon'` (both in head `assume.m`); `inputs.md` diamond-builder count fourteen → fifteen (`diamond_ov0.m`); `contexts.md` `.serial` row gains `singlerot` and `floquet` (`singlerot.m:219`, `floquet.m:184`).

Markdown-only change; every updated claim re-verified by grep against the head kernel before commit.