### PR TITLE
experiments: documentation and header corrections

### DIFF
--- a/experiments/bruker/hsqcedetgp.m
+++ b/experiments/bruker/hsqcedetgp.m
@@ -26,7 +26,8 @@
 %
 %     parameters.decouple_f1        nuclei that receive midpoint
 %                                   180-degree refocusing pulses in
-%                                   F1, e.g. {'1H','13C'}
+%                                   F1, e.g. {'1H','15N'}; must not
+%                                   contain the F1 active isotope
 %
 %     parameters.J                  working scalar coupling, Hz
 %

--- a/experiments/bruker/hsqcetgp.m
+++ b/experiments/bruker/hsqcetgp.m
@@ -24,7 +24,8 @@
 %
 %     parameters.decouple_f1        nuclei that receive midpoint
 %                                   180-degree refocusing pulses in
-%                                   F1, e.g. {'1H','13C'}
+%                                   F1, e.g. {'1H','15N'}; must not
+%                                   contain the F1 active isotope
 %
 %     parameters.J                  working scalar coupling, Hz
 %

--- a/experiments/bruker/hsqcetgpsi.m
+++ b/experiments/bruker/hsqcetgpsi.m
@@ -28,7 +28,8 @@
 %
 %     parameters.decouple_f1        nuclei that receive midpoint
 %                                   180-degree refocusing pulses in
-%                                   F1, e.g. {'1H','13C'}
+%                                   F1, e.g. {'1H','15N'}; must not
+%                                   contain the F1 active isotope
 %
 %     parameters.J                  working scalar coupling, Hz
 %

--- a/experiments/fieldsweep.m
+++ b/experiments/fieldsweep.m
@@ -2,7 +2,7 @@
 % pensive eigenfields algorithm, an explicit spherical grid, and
 % a hard-coded Lorentzian line shape. Syntax:
 %
-%        [b_axis,spec]=fieldsweep(spin_system,parameters)
+%        [spec,parameters]=fieldsweep(spin_system,parameters)
 %
 % Parameters:
 %
@@ -40,9 +40,11 @@
 %
 % Outputs:
 %
-%     b_axis   - magnetic field axis for plotting
+%     spec       - field-swept EPR spectrum
 %
-%     spec     - field-swept EPR spectrum
+%     parameters - updated parameters structure with the mag-
+%                  netic field axis for plotting returned in
+%                  parameters.b_axis
 %
 % Note: irrespective of the actual sweep extents, the magnetic field
 %       in sys.magnet should be set to 1 Tesla.

--- a/experiments/hyperpol/topdnp_steady.m
+++ b/experiments/hyperpol/topdnp_steady.m
@@ -27,8 +27,9 @@
 %
 %     parameters.delay_dur    - delay duration, seconds
 %
-%     parameters.nloops       - number of XiX/TPPM DNP blocks,
-%                               must be an integer power of 2
+%     parameters.nloops       - number of TOP DNP blocks, a
+%                               positive integer; powers of 2
+%                               are marginally faster
 %
 %     parameters.shot_spacing - delay between microwave irradiation
 %                               periods, seconds

--- a/experiments/imaging/epi_3d.m
+++ b/experiments/imaging/epi_3d.m
@@ -19,9 +19,10 @@
 %
 %  parameters.ro_grad_dur   -  readout gradient duration, s
 %
-%  parameters.diff_g_amp    -  [optional] a vector of diffusion gra-
-%                              dient pair amplitudes in X,Y (T/m) to
-%                              be active during the echo time
+%  parameters.diff_g_amp    -  [optional] a three-element vector of
+%                              diffusion gradient pair amplitudes in
+%                              X,Y,Z (T/m) to be active during the
+%                              echo time
 %
 %  parameters.t_echo        -  echo time after slice selection, seconds
 %

--- a/experiments/imaging/phase_enc_3d.m
+++ b/experiments/imaging/phase_enc_3d.m
@@ -15,10 +15,18 @@
 % 
 %  parameters.ro_grad_amp   -  readout gradient amplitude, T/m
 %
-%  parameters.ss_grad_dur   -  the duration of the slice selection 
-%                              gradient, seconds 
+%  parameters.rf_frq_list   -  a vector of RF frequencies at each
+%                              pulse slice, Hz
 %
-%  parameters.pe_grad_dur   -  the duration of the phase encoding 
+%  parameters.rf_amp_list   -  a vector of RF amplitudes at each
+%                              pulse slice, rad/s
+%
+%  parameters.rf_dur_list   -  a vector of pulse slice durations,
+%                              seconds
+%
+%  parameters.rf_phi        -  pulse phase at time zero, radians
+%
+%  parameters.pe_grad_dur   -  the duration of the phase encoding
 %                              gradient, seconds 
 %
 %  parameters.ro_grad_dur   -  the duration of the readout gradient,

--- a/experiments/nmr_liquids/tocsy.m
+++ b/experiments/nmr_liquids/tocsy.m
@@ -39,6 +39,10 @@
 %       explicit MLEV, DIPSI, WALTZ, or clean-TOCSY composite
 %       pulse-train simulation.
 %
+% Note: the mixing time evolution runs under the full Liouvillian
+%       L=H+1i*R+1i*K, meaning that relaxation and kinetics are
+%       active during the spin lock.
+%
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=tocsy.m>
@@ -67,7 +71,7 @@ rho=step(spin_system,Lx,parameters.rho0,pi/2);
 % F1 evolution
 rho_stack=evolution(spin_system,L,[],rho,timestep(1),parameters.npoints(1)-1,'trajectory');
 
-% Mixing time under spin-lock
+% Mixing time under spin-lock and the full Liouvillian
 rho_stack_cos=evolution(spin_system,L+2*pi*parameters.lamp*Lx,[],rho_stack,parameters.tmix,1,'final');
 rho_stack_sin=evolution(spin_system,L+2*pi*parameters.lamp*Ly,[],rho_stack,parameters.tmix,1,'final');
 

--- a/experiments/nmr_solids/fslghetcor.m
+++ b/experiments/nmr_solids/fslghetcor.m
@@ -34,7 +34,11 @@
 %
 %     parameters.coil         - detection state
 %
-%     parameters.sweep        - sweep width, Hz for F1, F2
+%     parameters.sweep        - [F1 F2] sweep widths, Hz; the
+%                               F1 element is not used (the F1
+%                               dwell time is set by the FSLG
+%                               block duration) and may be set
+%                               to NaN
 %
 %     parameters.npoints      - number of points in F1, F2
 %
@@ -208,7 +212,7 @@ if ~isfield(parameters,'sweep')
     error('sweep width should be specified in parameters.sweep variable.');
 elseif (~isnumeric(parameters.sweep))||(~isreal(parameters.sweep))||...
        (numel(parameters.sweep)~=2)||any(parameters.sweep<=0)
-    error('parameters.sweep must be a two-element vector of positive real numbers.');
+    error('parameters.sweep must be a two-element real vector with positive elements; the unused F1 element may be NaN.');
 end
 if ~isfield(parameters,'spins')
     error('working spins should be specified in parameters.spins variable.');

--- a/experiments/nmr_solids/mqmas.m
+++ b/experiments/nmr_solids/mqmas.m
@@ -28,10 +28,11 @@
 %
 % Notes:
 %
-%     parameters.sweep should be a two-element vector
-%     with both elements set equal to parameters.rate,
-%     this is because this pulse sequence is strobo-
-%     scopic with respect to the rotor period
+%     parameters.sweep should be a real scalar set
+%     equal to parameters.rate, this is because this
+%     pulse sequence is stroboscopic with respect to
+%     the rotor period; both dimensions are sampled
+%     at that sweep width
 %
 % ilya.kuprov@weizmann.ac.il
 % m.carravetta@soton.ac.uk

--- a/experiments/pseudocon/hfc2pcs.m
+++ b/experiments/pseudocon/hfc2pcs.m
@@ -21,6 +21,10 @@
 % Note: Gauss units are used for hyperfine couplings because they do
 %       not depend on the electron g-tensor.
 %
+% Note: the hyperfine tensor must be normalised per unpaired electron,
+%       i.e. supplied in the convention where it enters the spin Hamil-
+%       tonian as S*A*I; this is the convention returned by gparse.m
+%
 % ilya.kuprov@weizmann.ac.il
 % e.suturina@bath.ac.uk
 %

--- a/experiments/pseudocon/hfc2pms.m
+++ b/experiments/pseudocon/hfc2pms.m
@@ -21,6 +21,10 @@
 % Note: Gauss units are used for hyperfine couplings because they do
 %       not depend on the electron g-tensor.
 %
+% Note: the hyperfine tensor must be normalised per unpaired electron,
+%       i.e. supplied in the convention where it enters the spin Hamil-
+%       tonian as S*A*I; this is the convention returned by gparse.m
+%
 % ilya.kuprov@weizmann.ac.il
 % e.suturina@bath.ac.uk
 %

--- a/experiments/pseudocon/pcs2chi.m
+++ b/experiments/pseudocon/pcs2chi.m
@@ -24,8 +24,12 @@
 %
 %         err   - least squares error
 %
-% Note: Gauss units are used for hyperfine couplings because they 
+% Note: Gauss units are used for hyperfine couplings because they
 %       do not depend on the electron g-tensor.
+%
+% Note: hyperfine tensors must be normalised per unpaired electron,
+%       i.e. supplied in the convention where they enter the spin
+%       Hamiltonian as S*A*I; this is what gparse.m returns
 %
 % ilya.kuprov@weizmann.ac.il
 % e.suturina@bath.ac.uk

--- a/experiments/pseudocon/pms2chi.m
+++ b/experiments/pseudocon/pms2chi.m
@@ -27,6 +27,10 @@
 % Note: Gauss units are used for hyperfine couplings because they do
 %       not depend on the electron g-tensor.
 %
+% Note: hyperfine tensors must be normalised per unpaired electron,
+%       i.e. supplied in the convention where they enter the spin
+%       Hamiltonian as S*A*I; this is what gparse.m returns
+%
 % ilya.kuprov@weizmann.ac.il
 % e.suturina@bath.ac.uk
 %


### PR DESCRIPTION
Nine header/comment corrections in the experiments tree found during the whole-range review; none change executable behaviour except one error-message string:

- `nmr_liquids/tocsy.m`: the mixing-time evolution generator was changed from the coherent Hamiltonian to the full Liouvillian without a documentation flag; the header now carries a note that relaxation and kinetics are active during the spin lock, and the code comment says the same (E01-F4).
- `imaging/epi_3d.m`: header said diffusion gradient pair amplitudes are "a vector ... in X,Y", while the grumbler enforces exactly three elements and the body applies them to `G{1..3}`; now documented as a three-element vector in X,Y,Z (E02-F4).
- `imaging/phase_enc_3d.m`: header still advertised `parameters.ss_grad_dur` after its grumbler requirement was removed (the body never used it); that entry is deleted and the actually required `rf_frq_list`/`rf_amp_list`/`rf_dur_list`/`rf_phi` fields are now documented (E02-F5).
- `pseudocon/hfc2pcs.m`, `hfc2pms.m`, `pcs2chi.m`, `pms2chi.m`: after the `nel` argument removal, headers did not state which normalisation the hyperfine tensors must be in; all four now state the per-unpaired-electron convention where the tensor enters the spin Hamiltonian as `S*A*I`, as returned by `gparse.m` (E03-F2).
- `nmr_solids/mqmas.m`: header note demanded a two-element sweep vector that the grumbler rejects ("must be a non-zero real scalar"); the note now asks for a scalar equal to `parameters.rate`, at which both dimensions are sampled (E04-F2).
- `bruker/hsqcetgp.m`, `hsqcetgpsi.m`, `hsqcedetgp.m`: the printed `decouple_f1` example `{'1H','13C'}` combined with the printed `spins` example puts the F1 active isotope in `decouple_f1`, which the grumbler forbids; the example is now `{'1H','15N'}` with the restriction stated (E04-F4).
- `nmr_solids/fslghetcor.m`: the sweep grumbler admits the shipped `[NaN 1/dwell]` sweep only because `NaN<=0` is false, while its message claimed "positive real numbers"; the header now documents that the F1 element is unused (F1 dwell comes from the FSLG block duration) and may be NaN, and the error message says the same (Ex04-F2). This is the one error-message string change.
- `hyperpol/topdnp_steady.m`: header demanded power-of-2 `nloops` and called them XiX/TPPM blocks; the grumbler accepts any positive integer, the sequence is TOP DNP, and shipped examples use `nloops=300`; now documented as a positive integer count of TOP DNP blocks, with a note that powers of 2 are marginally faster under the binary-powering `ppower.m` (Ex06a-F1).
- `fieldsweep.m`: header syntax line and outputs section still documented the old `[b_axis,spec]` output convention; now aligned with the actual `[spec,parameters]` signature, with the field axis returned in `parameters.b_axis` (K06-F4).

No items were skipped; all nine findings verified against the head files before editing.

**Validation**: house-style checker clean on all fourteen changed files; every corrected statement verified against the grumbler and body lines quoted in the review findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)