### PR TITLE
etc, interfaces: documentation corrections

### DIFF
--- a/etc/diamond_defects/diamond_ni.m
+++ b/etc/diamond_defects/diamond_ni.m
@@ -2,8 +2,8 @@
 %
 %          [sys,inter]=diamond_ni(parameters)
 %
-% W8 magnetic parameters from Ludwig and Woodbury, Phys. Rev. B 41,
-% 3905 (1990), https://doi.org/10.1103/PhysRevB.41.3905
+% W8 magnetic parameters from Isoya, Kanda, Norris, Tang, and Bowman,
+% Phys. Rev. B 41, 3905 (1990), https://doi.org/10.1103/PhysRevB.41.3905
 % The W8 quartet entry assumes zero ZFS: no ZFS parameters were
 % reported in the cited data, and off-central transitions are treated
 % as unresolved rather than explicitly modelled.
@@ -20,7 +20,8 @@
 %      .orientation  - '111', '110', or '100' crystal plane normal
 %                      aligned with the magnetic field
 %      .nickel       - '61Ni', 'none', or another nickel isotope;
-%                      required when .centre is 'w8'
+%                      required when .centre is 'w8', and ignored
+%                      without warning for all other centres
 %      .n_13c        - number of reported 13C hyperfine couplings
 %                      to include, from 0 to 4; applies only to W8
 %

--- a/etc/molecules/lactate.m
+++ b/etc/molecules/lactate.m
@@ -1,7 +1,7 @@
 % Spin system of 13C-labelled lactate with the OH protons
 % assumed to be in rapid exchange with water. Syntax:
 %
-%             [sys,inter,bas]=lactate(spins)
+%             [sys,inter]=lactate(spins)
 %
 % Parameters:
 %

--- a/interfaces/gaussian/karplus_fit.m
+++ b/interfaces/gaussian/karplus_fit.m
@@ -8,14 +8,14 @@
 %               Gaussian logs
 %
 %    atoms    - a cell array of 4-element vectors
-%               specifying atmos making up the dihe-
+%               specifying atoms making up the dihe-
 %               dral angles of interest
 %
 % Outputs:
 %
-%    A,B,C    - coefficients for A+B*cos(phi)+C*cos(phi)^2
+%    A,B,C    - coefficients for A*cos(phi)^2+B*cos(phi)+C
 %
-%    As,Bs,Vs - standard deviations of those coefficients
+%    sA,sB,sC - standard deviations of those coefficients
 %
 % The directory specified in the first argument should contain 
 % a series of Gaussian J-coupling calculation logs that differ 


### PR DESCRIPTION
Documentation-only corrections from the big-revision review findings (X01, X02, I02). No behaviour changes.

- **X01-F3** — `etc/diamond_defects/diamond_ni.m`: the header attributed the W8 source paper to "Ludwig and Woodbury, Phys. Rev. B 41, 3905 (1990)"; PRB 41, 3905 (1990) is Isoya, Kanda, Norris, Tang, and Bowman, "Fourier-transform and continuous-wave EPR studies of nickel in synthetic diamond" (verified against the APS landing page for the cited DOI). Attribution corrected; DOI, volume, and page were already right.
- **X01-F6** — `etc/diamond_defects/diamond_ni.m`: `parameters.nickel` is read only in the W8 branch and silently discarded for NE/AB/NOL/NIRIM centres; the header now states that it is ignored without warning for all centres other than W8. Behaviour unchanged, as prescribed by the finding.
- **X02-F2** — `etc/molecules/lactate.m`: the header syntax line advertised `[sys,inter,bas]=lactate(spins)` but the function is declared `[sys,inter]=lactate(spins)` (the header's own Outputs section lists only sys and inter); the syntax line now matches the real signature.
- **I02-F4** — `interfaces/gaussian/karplus_fit.m`: the header documented the model as `A+B*cos(phi)+C*cos(phi)^2` while the code fits and plots `A*cos(phi)^2+B*cos(phi)+C`, and misnamed the standard-deviation outputs as "As,Bs,Vs" (code returns sA,sB,sC); both corrected, plus the "atmos" typo. Header lines only — no overlap with the Jacobian code hunk touched by PR #363 (lines 77-93).

MATLAB validation: not run for this PR — all edits are comment-header lines only, with no executable code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)