### PR TITLE
fapt2sfo.m: restore the co-rotating Y-row sign

### DIFF
--- a/kernel/optimcon/fapt2sfo.m
+++ b/kernel/optimcon/fapt2sfo.m
@@ -26,15 +26,18 @@
 %
 %    time_grid - row vector of time grid ticks
 %
-% Note: the rotation sense is counterclockwise - the effective RF
+% Note: the rotation sense is anticlockwise - the effective RF
 %       field of an event points at the angle 2*pi*freq*t+phi from
 %       the X axis. Spinach places a spin with a Larmor frequency
 %       offset of f Hz into a drift of 2*pi*f*Lz rad/s, under which
-%       transverse magnetisation also rotates counterclockwise; an
+%       transverse magnetisation also rotates anticlockwise; an
 %       event at frequency f is therefore on resonance with such a
 %       spin and nutates it about the axis at the angle phi from X.
-%       The opposite sign of the Y row is the counter-rotating com-
-%       ponent, which is off-resonance by 2*f and does not nutate.
+%       The opposite sign of the Y row puts the field at the angle
+%       phi-2*pi*freq*t, off-resonance by 2*f; its effect on the
+%       spin averages out to the extent that 2*f exceeds the nuta-
+%       tion frequency. At f=0 both signs give a static field, and
+%       differ only in reflecting the nutation axis into -phi.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -85,7 +88,7 @@ for n=1:numel(fapt)
     % Get the time interval mask
     time_mask=(time_grid>=start_time)&(time_grid<=end_time);
 
-    % Add event to the waveform, counterclockwise rotation sense
+    % Add event to the waveform, anticlockwise rotation sense
     wave(1,:)=wave(1,:)+ampl*cos(2*pi*freq*time_grid+phi).*time_mask;
     wave(2,:)=wave(2,:)+ampl*sin(2*pi*freq*time_grid+phi).*time_mask;
 

--- a/kernel/optimcon/fapt2sfo.m
+++ b/kernel/optimcon/fapt2sfo.m
@@ -26,6 +26,16 @@
 %
 %    time_grid - row vector of time grid ticks
 %
+% Note: the rotation sense is counterclockwise - the effective RF
+%       field of an event points at the angle 2*pi*freq*t+phi from
+%       the X axis. Spinach places a spin with a Larmor frequency
+%       offset of f Hz into a drift of 2*pi*f*Lz rad/s, under which
+%       transverse magnetisation also rotates counterclockwise; an
+%       event at frequency f is therefore on resonance with such a
+%       spin and nutates it about the axis at the angle phi from X.
+%       The opposite sign of the Y row is the counter-rotating com-
+%       ponent, which is off-resonance by 2*f and does not nutate.
+%
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=fapt2sfo.m>
@@ -75,9 +85,9 @@ for n=1:numel(fapt)
     % Get the time interval mask
     time_mask=(time_grid>=start_time)&(time_grid<=end_time);
 
-    % Add event to the waveform
+    % Add event to the waveform, counterclockwise rotation sense
     wave(1,:)=wave(1,:)+ampl*cos(2*pi*freq*time_grid+phi).*time_mask;
-    wave(2,:)=wave(2,:)-ampl*sin(2*pi*freq*time_grid+phi).*time_mask;
+    wave(2,:)=wave(2,:)+ampl*sin(2*pi*freq*time_grid+phi).*time_mask;
 
 end
 

--- a/tests/kernel/test_dynamic_optimcon_remaining.m
+++ b/tests/kernel/test_dynamic_optimcon_remaining.m
@@ -518,7 +518,7 @@ for n=1:numel(fapt)
     end_time=fapt{n}(5);
     time_mask=(time_grid>=start_time)&(time_grid<=end_time);
     wave_ref(1,:)=wave_ref(1,:)+ampl*cos(2*pi*freq*time_grid+phase).*time_mask;
-    wave_ref(2,:)=wave_ref(2,:)-ampl*sin(2*pi*freq*time_grid+phase).*time_mask;
+    wave_ref(2,:)=wave_ref(2,:)+ampl*sin(2*pi*freq*time_grid+phase).*time_mask;
 end
 
 end


### PR DESCRIPTION
## Defect

`kernel/optimcon/fapt2sfo.m` builds an X/Y control waveform from a frequency-amplitude-phase-time event list. Commit `147f026d` (2026-05-02, "improved isotope selection handing in the lactate spin system") flipped the Y row from `+sin` to `-sin` and deleted the "counterclockwise phase" comment; the commit message does not mention the change. That sign is the counter-rotating circular polarisation: it is off-resonance by `2*f` for the very spin the event is meant to address, and it disagrees with `polar2cartesian.m` and `shaped_pulse_af.m`, which both map an amplitude-phase pair to `(r*cos(p),+r*sin(p))`.

## Principle

Spinach puts a spin declared at a Larmor frequency offset of `f` Hz into a drift of `+2*pi*f*Lz` rad/s (`frqoffset.m`, and `ensemble.m` line 154 in the optimal control pathway). Under `exp(-1i*L*t)` with that drift, transverse magnetisation rotates from X towards Y, so the detected `L+` coherence carries `exp(+1i*2*pi*f*t)`; this is the physical `omega0=-gamma*B0` convention discussed by Levitt in "The signs of frequencies and phases in NMR" (*J. Magn. Reson.* **126**, 164, 1997). A drive co-rotates with such a spin only if its effective RF field direction also advances counterclockwise, that is, if the field points at the angle `2*pi*f*t+phi` from the X axis, which requires `wave=[+ampl*cos(...); +ampl*sin(...)]`. Transforming into the frame rotating at `2*pi*f` then leaves the static resonant generator `ampl*(cos(phi)*Lx+sin(phi)*Ly)`, whereas the `-sin` alternative leaves `ampl*(cos(2*w*t+phi)*Lx-sin(2*w*t+phi)*Ly)`, which averages away.

## Measurement

Single `1H`, `sphten-liouv`, drift built by production `frqoffset.m` at the declared offset, waveform from `fapt2sfo.m` at exactly that frequency, propagated by production `shaped_pulse_xy.m` (`expm-pwc`, 4000 slices, 1 ms, `ampl=pi/(2*T)`, that is a nominal pi/2 nutation), initial state `Lz`, normalised readouts.

| case | shipped `-sin` (Lx, Ly, Lz) | restored `+sin` (Lx, Ly, Lz) |
|---|---|---|
| `f=+10 kHz`, `phi=0` | 0.0000, -0.0003, **1.0000** | -0.0021, -1.0000, **0.0000** |
| `f=+10 kHz`, `phi=pi/2` | -0.0003, -0.0000, **1.0000** | 1.0000, -0.0021, **0.0000** |
| `f=-10 kHz`, `phi=0` | -0.0000, -0.0003, **1.0000** | 0.0021, -1.0000, **0.0000** |

The shipped sign does not nutate the spin at all: the magnetisation stays on `+z` to four decimals, exactly as expected for a drive off-resonance by `2*f=20 kHz` against a 250 Hz nutation rate. The restored sign gives the full pi/2 nutation, and the final direction pins the phase convention: `phi=0` sends `Lz` to `-Ly` (nutation about `+X`) and `phi=pi/2` sends `Lz` to `+Lx` (nutation about `+Y`), which is the `(cos(phi),sin(phi))` axis convention used everywhere else in Spinach. The residual 2e-3 components are the counter-rotating and piecewise-constant sampling residue.

## Change

- `kernel/optimcon/fapt2sfo.m`: Y row back to `+sin`; the deleted comment is replaced with an accurate one, and a header note states the rotation sense and the resonance criterion it satisfies.
- `tests/kernel/test_dynamic_optimcon_remaining.m`: the `local_fapt_ref` reference mirrors the implementation line for line, so it followed the sign. It provides no independent evidence about the sign, which is how the original flip passed the suite; the evidence is the propagation measurement above.

## Shipped results

`examples/optimal_control/distortions/distortions_figure_1.m` (Figure 1 of arXiv:2502.02198) uses a `phi=pi/2` event at zero frequency, so its Y row moves: min/max of the quadrature trace go from `[-1.1743, 0]` mT to `[0, +1.1743]` mT, that is, the middle block of the blue trace flips sign. The example was committed on 2025-02-16, fourteen months before `147f026d`, so the published figure was produced with `+sin` and this restores agreement with it. `test_dynamic_optimcon_remaining` passes (64 checks) and the example runs clean.

House style gate and `checkcode` are both clean on the two changed files. Note for the maintainer: `kernel/integrity/smells.mat` is not regenerated here, so `sniff` will report a changed hash for `fapt2sfo.m` until `rearm` is rerun.

Requested by Ilya on 2026-08-30: "There must have been a reason. Find out what is the correct principles-based convention there and implement that one."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
