### PR TITLE
radiation damping: correct the z-row sign in the two benchmark generators

### DIFF
--- a/examples/benchmarks/iserstep_bench_hiord.m
+++ b/examples/benchmarks/iserstep_bench_hiord.m
@@ -1,6 +1,11 @@
 % Benchmarks iserstep higher-order methods on a chirped-frequency oscillator
 % with radiation damping, that has a state-dependent, and a time-dependent
-% evolution generator. Syntax:
+% evolution generator. The radiation damping term follows Bloembergen and
+% Pound:
+%
+%               https://doi.org/10.1103/PhysRev.95.8
+%
+% Syntax:
 %
 %               iserstep_bench_hiord()
 %
@@ -29,7 +34,7 @@ spin_system=bootstrap();
 
 % Make Bloch-Maxwell generator (Liouvillian, including -1i factors)
 G=@(t,mu)(-1i*[r2 cr*t 0; -cr*t r2 0; 0 0 r1]...
-          -1i*rrd*[mu(3) 0 0; 0 mu(3) 0; mu(1) mu(2) 0]);
+          -1i*rrd*[mu(3) 0 0; 0 mu(3) 0; -mu(1) -mu(2) 0]);
 
 % Set the initial magnetisation
 mu0=euler2dcm(0,pi*178/180,0)*[0 0 1]';

--- a/examples/fundamentals/quadratures/product_quadratures_2.m
+++ b/examples/fundamentals/quadratures/product_quadratures_2.m
@@ -1,6 +1,9 @@
 % A test of Lie-group product quadratures on a chirped frequency 
 % oscillator with radiation damping that has a state-dependent
-% and time-dependent evolution generator.
+% and time-dependent evolution generator. The radiation damping
+% term follows Bloembergen and Pound:
+%
+%          https://doi.org/10.1103/PhysRev.95.8
 %
 % a.acharya@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il 
@@ -17,7 +20,7 @@ spin_system=bootstrap();
 
 % Make Bloch-Maxwell generator
 G=@(t,mu)(-1i*[r2 cr*t 0; -cr*t r2 0; 0 0 r1]...
-          -1i*rrd*[mu(3) 0 0; 0 mu(3) 0; mu(1) mu(2) 0]);
+          -1i*rrd*[mu(3) 0 0; 0 mu(3) 0; -mu(1) -mu(2) 0]);
 
 % Set initial magnetisation
 mu0=euler2dcm(0,pi*178/180,0)*[0 0 1]';


### PR DESCRIPTION
## Defect

Both files build the same nonlinear "radiation damping" generator. `iserstep` integrates `d_mu/d_t=-i*L(t,mu)*mu`, and the handle already carries `-1i`, so the effective ODE is `dmu/dt=-M(t,mu)*mu` with

```
M = [r2 cr*t 0; -cr*t r2 0; 0 0 r1] + rrd*[mu3 0 0; 0 mu3 0; mu1 mu2 0]
```

The transverse rows are right — `dmux/dt=-rrd*muz*mux`, `dmuy/dt=-rrd*muz*muy`. The z-row is sign-inverted: it gives `dmuz/dt=-rrd*(mux^2+muy^2)`, whereas Bloembergen and Pound (https://doi.org/10.1103/PhysRev.95.8) require `dmuz/dt=+rrd*(mux^2+muy^2)`. As shipped, the term takes transverse magnetisation out *and* pushes `muz` down, so `|mu|` is pumped rather than conserved: with the relaxation switched off the trajectory diverges. Ilya asked for the physics to be corrected on 2026-08-30 ("Please update Arnab's benchmark to also have correct physics").

## Measurement (R2026a, RKMK-DP8, `np=2^12`, `dt=0.5/(np-1)`, `mu0` at 178 degrees)

Radiation damping term alone, `r1=r2=0`, which is where `|mu|` must be conserved:

| | max relative `|mu|^2` drift | `dmuz/dt` where `|mu_xy|>1e-3` | final state |
|---|---|---|---|
| shipped | diverges at `t=0.101` s, `|mu|^2=1.53e5` | min `-3.06e+06`, max `-4.87e-02` | `[+263.6 +84.1 -276.7]` |
| corrected | `2.71e-14` | min `+4.01e-05`, max `+4.00e+01` | `[+0.000000 -0.000000 +1.000000]` |

The corrected generator conserves `|mu|^2` to integrator round-off, has `dmuz/dt>0` at every point where transverse magnetisation is present, and carries the magnetisation from 178 degrees exactly onto `+z` — the textbook radiation-damping inversion recovery.

With the full generator (`r1=r2=10` Hz) `|mu|` decays by design, so it is not a conservation test; both versions run to completion there.

## Benchmark impact

Empirical convergence orders, before and after. All order conclusions survive, and most sit closer to the nominal values than before, because the corrected trajectory is bounded.

`iserstep_bench_hiord`:

| method | nominal | before | after |
|---|---|---|---|
| PWCL | 1 | 0.962 | 0.997 |
| LG2 | 2 | 1.966 | 2.000 |
| LG4 | 4 | 3.808 | 4.042 |
| LG4A | 4 | 4.196 | 4.181 |
| RKMK4 | 4 | 4.063 | 3.970 |
| RKMK-DP5 | 5 | 5.855 | 5.891 |
| RKMK-DP8 | 8 | 9.623 | 9.692 |

`product_quadratures_2`:

| method | nominal | before | after |
|---|---|---|---|
| PWCL | 1 | 0.965 | 0.999 |
| LG2 | 2 | 1.979 | 2.000 |
| LG4 | 4 | 3.782 | 4.078 |
| LG4A | 4 | 4.298 | 4.271 |
| RKMK4 | 4 | 4.100 | 3.973 |
| RKMK-DP5 | 5 | 5.919 | 5.957 |
| RKMK-DP8 | 8 | 8.790 | 7.857 |

Both scripts run end-to-end and print their tables; the RKMK-DP8 figure is error-floor limited in both versions.

## Change

One sign flip per file, `[mu(1) mu(2) 0]` to `[-mu(1) -mu(2) 0]` in the z-row of the radiation damping block, plus the Bloembergen-Pound citation in each header. The generator stays nonlinear and state-dependent, so both benchmarks exercise exactly what they exercised before.

These are Arnab Dutta's benchmark files, so tagging for visibility.

House style: no new violations (the 4 pre-existing ones are untouched); `checkcode` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
