### PR TITLE
existentials: skip the Windows volume check on UNC paths

### DIFF
--- a/kernel/integrity/existentials.m
+++ b/kernel/integrity/existentials.m
@@ -106,15 +106,22 @@ end
 % Windows
 if ispc
 
-    % Find out which file system Spinach volume has
+    % Get the volume specifier of the Spinach path
     own_disk=mfilename('fullpath'); own_disk=own_disk(1:3);
-    own_disk=System.IO.DriveInfo(own_disk);
 
-    % Warn about non-NTFS volumes
-    if ~strcmp(char(own_disk.DriveFormat),'NTFS')
-        warning('Spinach:NonNTFSVolume',['Spinach is running from a ' ...
-                char(own_disk.DriveFormat) ' volume; NTFS is recommended ' ...
-                'on Windows for reliable file locking and performance.']);
+    % UNC paths have no drive letter and no volume to interrogate
+    if own_disk(2)==':'
+
+        % Find out which file system Spinach volume has
+        own_disk=System.IO.DriveInfo(own_disk);
+
+        % Warn about non-NTFS volumes
+        if ~strcmp(char(own_disk.DriveFormat),'NTFS')
+            warning('Spinach:NonNTFSVolume',['Spinach is running from a ' ...
+                    char(own_disk.DriveFormat) ' volume; NTFS is recommended ' ...
+                    'on Windows for reliable file locking and performance.']);
+        end
+
     end
 
 end


### PR DESCRIPTION
## Defect

`kernel/integrity/existentials.m` takes the first three characters of its own
path and hands them to `System.IO.DriveInfo`. On a Windows installation rooted
at a UNC path those three characters are `\\l` (of `\\server\share\...`), which
`DriveInfo` rejects, so `existentials` — and therefore `fix_path` — throws
before Spinach can be used at all. UNC-rooted installs are ordinary on
Windows domains where the group share is not mapped to a drive letter.

## Measurement (Elminster, Windows Server 2025, MATLAB R2026a, `-nojvm`)

Same clone (`f053e432`) reached two ways: `C:\a4probe\Spinach` and
`\\localhost\C$\a4probe\Spinach`. Driver is `addpath(root); fix_path('add')`.

| root | before | after |
|---|---|---|
| `C:\a4probe\Spinach` (NTFS) | clean, no warning | clean, no warning |
| `\\localhost\C$\a4probe\Spinach` (UNC) | **error** | clean, no warning |
| `V:\Spinach` (FAT32 VHD) | not run | clean, `Spinach:NonNTFSVolume` fires |

The error before the fix, verbatim:

```
MATLAB:NET:CLRException:CreateObject
Message: Object must be a root directory ("C:\") or a drive letter ("C").
Source: mscorlib
  existentials (line 111)
  fix_path (line 65)
```

The FAT32 row is the check-not-weakened control: a 1.2 GB FAT32 VHD mounted as
`V:`, Spinach copied onto it, patched `existentials` still raises
`Spinach:NonNTFSVolume` with the same message text. `System.IO.DriveInfo('C:\')`
still reports `NTFS` under the patch.

## Change

One guard around the existing block: the volume specifier is extracted as
before, and the `DriveInfo` interrogation plus the non-NTFS warning now run only
when the second character is a colon. Lettered-drive behaviour is unchanged;
UNC roots skip a check that has no volume to interrogate.

House style: no new violations (the file's 2 pre-existing ones — the banner and
the closing quote — are untouched); `checkcode` returns 0 messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
