### PR TITLE
fid2pipe: write the indirect dimension in hypercomplex form

### DIFF
--- a/interfaces/nmrpipe/fid2pipe.m
+++ b/interfaces/nmrpipe/fid2pipe.m
@@ -29,6 +29,10 @@
 %       components; recombination is done in the accompanying NMRPipe
 %       processing script after the direct-dimension Fourier transform
 %
+% Note: the indirect dimension is written in the NMRPipe hypercomplex
+%       convention, two records per increment, and therefore declared
+%       with yN equal to twice yT
+%
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=fid2pipe.m>
@@ -73,10 +77,14 @@ npts_f1=size(fid.pos,2);
 
 % Export echo and anti-echo components separately
 branches={'pos','neg'};
+quad_rots=[-1i +1i];
 for n=1:numel(branches)
 
     % Select the current component
     data=fid.(branches{n});
+
+    % Interleave the quadrature partner records NMRPipe expects in F1
+    data=reshape([data; quad_rots(n)*data],npts_f2,2*npts_f1);
 
     % Write the text input for txt2pipe
     txt_file=[file_root '_' branches{n} '.txt'];
@@ -84,7 +92,7 @@ for n=1:numel(branches)
     if file_id<0
         error('could not open the temporary text file.');
     end
-    for k=1:npts_f1
+    for k=1:2*npts_f1
         for m=1:npts_f2
             fprintf(file_id,'%d %d %24.16E %24.16E\n',m,k,real(data(m,k)),imag(data(m,k)));
         end
@@ -100,7 +108,7 @@ for n=1:numel(branches)
              ' -xOBS ' num2str(obs_f2,16) ...
              ' -xCAR ' num2str(car_f2,16) ...
              ' -xLAB ' parameters.spins{2} ...
-             ' -yN ' num2str(npts_f1) ...
+             ' -yN ' num2str(2*npts_f1) ...
              ' -yT ' num2str(npts_f1) ' -yMODE Complex' ...
              ' -ySW ' num2str(parameters.sweep(1),16) ...
              ' -yOBS ' num2str(obs_f1,16) ...


### PR DESCRIPTION
## Defect

`interfaces/nmrpipe/fid2pipe.m` declared the indirect dimension with `-yN npts_f1 -yT npts_f1 -yMODE Complex` and wrote one record per t1 increment. The NMRPipe `var2pipe` reference defines `-yN` as "Actual Size in File. Pts Real + Imag." and `-yT` as "Pts Real or Imag.", so a `Complex` dimension has `yN=2*yT`; `txt2pipe.tcl` sets exactly that for complex input (lines 300-310). NMRPipe therefore reads the exported F1 dimension as `npts_f1/2` hypercomplex increments, pairing consecutive t1 increments as a real/imaginary partner pair.

## Measurement

Two-spin 1H/13C HSQC, `sphten-liouv`, no approximation, 14.1 T, `liquid(...,@hsqc,...)` exported with `fid2pipe` and processed with the shipped `proc_hsqc.com`, compared against Spinach's own processing of the same free induction decay (the `hsqc_strychnine.m` scheme). `npoints=[32 64]`, `sweep=[3000 4000]`, `offset=[5661 1775]`; true peak 13C `6036.0 Hz`, 1H `2400.0 Hz`.

Before: F1 dimension `16` points instead of `32`; F1 peak at `4911.0 Hz`, an error of `1125 Hz` (`7.45 ppm` at `150.988 MHz`); spurious mirror at F1 index 4 of amplitude `208.1`, `11.4%` of the `1817.9` main peak; header F1 `ORIG 4348.50 Hz` instead of `4254.75 Hz`, one F1 point off because the axis was computed for 16 complex points. F2 was unaffected at `2400.0 Hz`.

After: F1 dimension `32` points; peak `6036.0 Hz`, F2 `2400.0 Hz`, header `ORIG 4254.75 Hz`; no mirror; the whole plane matches the Spinach reference at unit scale with a maximum residual of `2.0e-8` of the peak. Second regime `npoints=[24 48]`, `offset=[6539 3000]`, peak below both carriers: `6039.0 Hz` and `2416.7 Hz`, matching the reference, residual `2.7e-8`.

A declaration-only change is not sufficient and was measured: `-yN 64 -yT 32` with the same 32 records gives `BYTES 18432` against `PRED 34816` and `nmrPipe -fn FT` exits with "NMRPipe Error Status: 1". Reverting to `-yMODE Real` collapses F2 to half its points and leaves the final plane transposed.

## Change

Each t1 increment is now written as the hypercomplex record pair `(r,rot*r)`, with `rot=-1i` for the echo branch and `+1i` for the anti-echo branch, and the dimension is declared `-yN 2*npts_f1 -yT npts_f1`. The branch-dependent rotation is what `proc_hsqc.com` needs: it conjugates the anti-echo branch with `SIGN -i` before the addition, so the combined pair is `(r,-1i*r)` and the hypercomplex transpose recovers `r` exactly. Three added lines, one changed loop bound, one changed flag, plus a header note; `check_house_style.py` reports no violations and `checkcode` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
