### PR TITLE
Fix homospoil Fokker-Planck dimension handling in zeeman-liouv

### DIFF
--- a/kernel/homospoil.m
+++ b/kernel/homospoil.m
@@ -25,8 +25,9 @@
 %        rho  - the state vector(s) with only the longitudi-
 %               nal or only the zero-quantum states kept
 %
-% Note: this function is only available for sphten-liouv formalism; it
-%       supports Fokker-Planck direct products.
+% Note: this function requires sphten-liouv, zeeman-liouv, or zeeman-
+%       hilb formalism; Fokker-Planck direct products are supported
+%       in the Liouville space formalisms.
 %
 % Note: this is a purely mathematical filter that only mimics - in an
 %       idealised way - the effect of a real homospoil pulse. Essenti-
@@ -49,12 +50,13 @@ if strcmp(spin_system.bas.formalism,'zeeman-hilb')
     rho=spdiags(rhod,0,dim,dim); return;
 end
 
-% In Zeeman basis of Liouville space, zero off-diagonals in every stacked column
+% In Zeeman basis of Liouville space, keep the spin-space diagonal of every folded block
 if strcmp(spin_system.bas.formalism,'zeeman-liouv')
-    dim=sqrt(size(rho,1));
-    offdiag_mask=true(dim^2,1);
-    offdiag_mask(1:(dim+1):dim^2)=false;
-    rho(offdiag_mask,:)=0; return;
+    spn_dim=size(spin_system.bas.basis,1); spc_dim=numel(rho)/spn_dim;
+    problem_dims=size(rho); rho=reshape(rho,[spn_dim spc_dim]);
+    hdim=sqrt(spn_dim); offdiag_mask=true(spn_dim,1);
+    offdiag_mask(1:(hdim+1):spn_dim)=false;
+    rho(offdiag_mask,:)=0; rho=reshape(rho,problem_dims); return;
 end
 
 % Store dimension statistics


### PR DESCRIPTION
## Defect

`kernel/homospoil.m`, `zeeman-liouv` branch, took `dim=sqrt(size(rho,1))` as the spin Hilbert dimension, ignoring the spatial part of a Fokker-Planck direct product. `coherence.m` and `correlation.m` fold the spatial dimension out correctly; `homospoil.m` did not.

## Measured before (one spin, `spn_dim=4`, zeeman-liouv, `destroy`)

| case | rows | stock output | correct |
|---|---|---|---|
| non-FP control | 4 | `[1 4]` | `[1 4]` ✓ |
| FP 4-point stack | 16 | `[1 6 11 16]` (diagonal of a fictitious 4×4) | `[1 4 5 8 9 12 13 16]` ✗ |
| FP 8-point stack | 32 | error: `Size inputs must be integers.` | `[1 4 5 8 ... 29 32]` ✗ |

## Fix

Fold spatial dimensions the way `coherence.m`/`correlation.m` do: `spn_dim=size(basis,1)`, `spc_dim=numel(rho)/spn_dim`, reshape to `[spn_dim spc_dim]`, mask the stretched-matrix off-diagonals on the spin dimension only, reshape back. Horizontal-stack support is preserved (both spatial rows and stack columns collapse into `spc_dim`). The header note is corrected to qualify Fokker-Planck support by formalism (Liouville spaces only), matching `coherence.m`. The `sphten-liouv` and `zeeman-hilb` branches are untouched.

## Measured after

| case | patched output |
|---|---|
| non-FP control | `[1 4]` (unchanged) |
| FP 4-point stack | `[1 4 5 8 9 12 13 16]` (correct) |
| FP 8-point stack | `[1 4 5 8 9 12 13 16 17 20 21 24 25 28 29 32]` (correct, no error) |
| horizontal stack (4×2) | rows `[1 4]` kept in each column (preserved) |

## Regression

`tests/kernel/test_dynamic_filter_frontends` (sphten-liouv) passes **stock and patched**, all 10 assertions, `error=0.000e+00` on both homospoil assertions — the untouched path is bit-identical. `checkcode` clean; house-style gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)