### PR TITLE
tests: complete the minimal descriptor used for symmetry validation

### DIFF
--- a/tests/kernel/test_dynamic_remaining_spectral_suite.m
+++ b/tests/kernel/test_dynamic_remaining_spectral_suite.m
@@ -151,6 +151,10 @@ result=test_close(result,'rotor_stack phase grid',rotor_phases,0,1e-14,1e-14,...
 % Check S2 fully symmetric projector construction on a four-state product basis
 spin_system=local_minimal_system('sphten-liouv',4);
 spin_system.comp.nspins=2;
+spin_system.comp.isotopes={'1H','1H'};
+spin_system.inter.zeeman.matrix={zeros(3);zeros(3)};
+spin_system.inter.giant.coeff=cell(2,1);
+spin_system.inter.coupling.matrix=cell(2,2);
 spin_system.bas.basis=[0 0;1 0;0 1;1 1];
 bas.sym_group={'S2'};
 bas.sym_spins={[1 2]};
@@ -197,6 +201,7 @@ spin_system.sys.disable={};
 spin_system.bas.formalism=formalism;
 spin_system.bas.basis=zeros(dim,1);
 spin_system.comp.mults=2;
+spin_system.tols.inter_cutoff=1e-10;
 spin_system.tols.liouv_zero=1e-12;
 spin_system.tols.prop_chop=1e-12;
 spin_system.tols.dense_matrix=0.5;
@@ -224,3 +229,5 @@ if isempty(current_pool)
 end
 
 end
+
+


### PR DESCRIPTION
## Problem

`tests/kernel/test_dynamic_remaining_spectral_suite.m` was one of four pre-existing failures in the regression suite. Measured stack:

```
CAUGHT: Unrecognized field name "inter_cutoff".
  at validate_sym line 49
  at symmetry line 87
  at test_dynamic_remaining_spectral_suite line 158
```

The suite's local `local_minimal_system` helper builds a matrix-only spin system descriptor and set only four tolerances (`liouv_zero`, `prop_chop`, `dense_matrix`, `small_matrix`). `validate_sym` legitimately reads `tols.inter_cutoff`, `inter.zeeman.matrix`, `inter.giant.coeff`, `comp.isotopes`, and (via `get_coupling`) `inter.coupling.matrix`, none of which the descriptor provided. The suite therefore died at the `symmetry` call and the last three checks never ran: 17 of 20 checks were reached.

## Fix

Harness-only; `validate_sym.m` is untouched.

- `local_minimal_system` now sets `tols.inter_cutoff=1e-10`, which is the safe default `tolerances.m` assigns when neither `paranoia` nor `cowboy` is enabled — the case for this descriptor, whose `sys.enable` is empty.
- The symmetry block, which is where `comp.nspins=2` is already declared, now also declares the matching interaction set for two uncoupled protons: identical zero Zeeman tensors, empty giant-spin coefficient cells, and an empty coupling matrix cell array. These are the shapes `create.m` produces for a two-proton system with no couplings and no giant-spin terms (`cell(nspins,1)` and `cell(nspins,nspins)` of empties).
- One trailing blank line added so the house-style gate passes on the file.

## Validation

Test in isolation, after the change: **20/20 checks PASS**, including the three previously-unreached ones:

```
MSG 18: PASS: symmetry projector orthonormality, error=2.220e-16, tolerance=2.732e-14
MSG 19: PASS: symmetry mixed orbit, error=0.000e+00, tolerance=2.000e-14
MSG 20: PASS: symmetry irrep dimension, error=0.000e+00, tolerance=4.000e-14
```

Full suite, `run_tests('verbose',true)`, sorted per-test status lists compared:

| | tests | PASS | FAIL |
|---|---|---|---|
| before | 104 | 100 | 4 |
| after  | 104 | 101 | 3 |

The sorted lists differ in exactly one line — `kernel/dynamic_remaining_spectral_suite` FAIL to PASS. The remaining three failures (`kernel/cache_temp_scratch`, `kernel/dynamic_integrity_includes_mex`, `kernel/wigner_angular_suite`) are unchanged and out of scope here.

Gates on the changed file: `check_house_style.py` 0 violations, `checkcode` 0 messages.

## Relation to #387

Branched off `origin/main`, not off `fix/test-harness-failure-recording`. No file overlap: this PR touches only `tests/kernel/test_dynamic_remaining_spectral_suite.m`; #387 touches `tests/lib/test_true.m`, `tests/lib/test_close.m`, `tests/lib/new_test_result.m`, and `tests/run_tests.m`. They should merge independently. The two are complementary — #387 would have made the truncation visible as recorded failures rather than a single thrown error, and this PR removes the truncation.