### PR TITLE
examples: use the kernel ppm2hz in the coote scripts

### DIFF
--- a/examples/optimal_control/bloch_siegert/coote_badcop.m
+++ b/examples/optimal_control/bloch_siegert/coote_badcop.m
@@ -44,8 +44,8 @@ alpha_scale=0.91;
 pulse_dur=1e-3;
 ca_ppm=linspace(40,72,100);
 co_ppm=linspace(165,185,30);
-ca_hz=ppm2hz(sys.magnet,'13C',ca_ppm,carrier_ppm);
-co_hz=ppm2hz(sys.magnet,'13C',co_ppm,carrier_ppm);
+ca_hz=ppm2hz(ca_ppm-carrier_ppm,sys.magnet,'13C');
+co_hz=ppm2hz(co_ppm-carrier_ppm,sys.magnet,'13C');
 
 % Build all three variants from Table 1
 variants={...
@@ -63,8 +63,8 @@ for k=1:numel(variants)
     mask=(cb_prs_ppm<variants{k}.cb_inv_ppm(1))|...
          (cb_prs_ppm>variants{k}.cb_inv_ppm(2));
     cb_prs_ppm=cb_prs_ppm(mask);
-    cb_inv_hz=ppm2hz(sys.magnet,'13C',cb_inv_ppm,carrier_ppm);
-    cb_prs_hz=ppm2hz(sys.magnet,'13C',cb_prs_ppm,carrier_ppm);
+    cb_inv_hz=ppm2hz(cb_inv_ppm-carrier_ppm,sys.magnet,'13C');
+    cb_prs_hz=ppm2hz(cb_prs_ppm-carrier_ppm,sys.magnet,'13C');
 
     % Assemble full offset list
     all_hz=[ca_hz co_hz cb_inv_hz cb_prs_hz];
@@ -137,7 +137,7 @@ for k=1:numel(variants)
 
     % Validate on a dense ppm grid
     eval_ppm=linspace(0,200,251);
-    eval_hz=ppm2hz(sys.magnet,'13C',eval_ppm,carrier_ppm);
+    eval_hz=ppm2hz(eval_ppm-carrier_ppm,sys.magnet,'13C');
     mz_bs=zeros(size(eval_hz));
     mz_nobs=zeros(size(eval_hz));
     for n=1:numel(eval_hz)
@@ -178,14 +178,6 @@ for k=1:numel(variants)
     klegend({'BSS on','BSS off'},'Location','Best'); drawnow;
 
 end
-
-end
-
-function off_hz=ppm2hz(magnet,isotope,ppm_grid,carrier_ppm)
-
-% Convert ppm values into offset frequencies in Hz
-frq_hz=abs(spin(isotope)*magnet/(2*pi));
-off_hz=(ppm_grid-carrier_ppm)*1e-6*frq_hz;
 
 end
 

--- a/examples/optimal_control/bloch_siegert/coote_goodcop.m
+++ b/examples/optimal_control/bloch_siegert/coote_goodcop.m
@@ -49,8 +49,8 @@ ca_ppm=linspace(35,75,100);
 co_ppm=linspace(165,185,30);
 
 % Convert to offset frequencies
-ca_hz=ppm2hz(sys.magnet,'13C',ca_ppm,carrier_ppm);
-co_hz=ppm2hz(sys.magnet,'13C',co_ppm,carrier_ppm);
+ca_hz=ppm2hz(ca_ppm-carrier_ppm,sys.magnet,'13C');
+co_hz=ppm2hz(co_ppm-carrier_ppm,sys.magnet,'13C');
 all_hz=[ca_hz co_hz];
 
 % Build state pairs correlated to offset ensemble
@@ -110,7 +110,7 @@ pulse_nobs=mat2cell(pulse_nobs,[1 1]);
 
 % Validate on a dense ppm grid
 eval_ppm=linspace(0,200,251);
-eval_hz=ppm2hz(sys.magnet,'13C',eval_ppm,carrier_ppm);
+eval_hz=ppm2hz(eval_ppm-carrier_ppm,sys.magnet,'13C');
 mz_bs=zeros(size(eval_hz));
 mz_nobs=zeros(size(eval_hz));
 for n=1:numel(eval_hz)
@@ -147,14 +147,6 @@ plot(eval_ppm,mz_nobs,'LineWidth',1.5); kgrid;
 kxlabel('$^{13}$C chemical shift / ppm');
 kylabel('Final M$_Z$'); ktitle('GOODCOP profile ');
 legend({'BSS on','BSS off'},'Location','Best');
-
-end
-
-function off_hz=ppm2hz(magnet,isotope,ppm_grid,carrier_ppm)
-
-% Convert ppm values into offset frequencies in Hz
-frq_hz=abs(spin(isotope)*magnet/(2*pi));
-off_hz=(ppm_grid-carrier_ppm)*1e-6*frq_hz;
 
 end
 


### PR DESCRIPTION
Both `coote_goodcop.m` and `coote_badcop.m` carried a local `ppm2hz` helper that shadowed the
kernel function of the same name with a different signature:

```
function off_hz=ppm2hz(magnet,isotope,ppm_grid,carrier_ppm)
frq_hz=abs(spin(isotope)*magnet/(2*pi));
off_hz=(ppm_grid-carrier_ppm)*1e-6*frq_hz;
```

The call sites now reference the shifts to the carrier explicitly and call the kernel
`ppm2hz(ppm,B0,nucleus)`; the helper is deleted from both files. Eight call sites in total,
five in `coote_badcop.m` and three in `coote_goodcop.m`.

**Numerically identical.** The helper took `abs()` of the magnetogyric ratio while the kernel
function preserves its sign, and `spin('13C')` is positive, so the two agree exactly on the
grids these scripts use. Measured over all five grids in the two files (`35-75`, `165-185`,
`0-200`, `40-72` and `5-80` ppm at 14.1 T): maximum absolute difference `0.000e+00` Hz, with
-9814.245458 Hz at 35 ppm in both conventions. The `abs()` would have mattered only for a
negative-gamma nucleus — for `15N` the two differ in sign — and neither script uses one.

`checkcode` returns no messages for either file, and both pass the house-style gate.
