### PR TITLE
v2fplanck: eigenvalue test for the diffusion tensor field

### DIFF
--- a/kernel/utilities/v2fplanck.m
+++ b/kernel/utilities/v2fplanck.m
@@ -304,8 +304,9 @@ if numel(parameters.npts)==2
             error('the diffusion tensor field must be symmetric at every voxel.');
         end
         d_off=(parameters.dxy+parameters.dyx)/2;
-        if any(parameters.dxx(:)<0)||any(parameters.dyy(:)<0)||...
-           any(parameters.dxx(:).*parameters.dyy(:)-d_off(:).^2<0)
+        d_ten=reshape([parameters.dxx(:) d_off(:) d_off(:) parameters.dyy(:)]',...
+                      [2 2 numel(d_off)]); d_eig=pageeig(d_ten);
+        if any(min(d_eig,[],1)<-20*eps()*max(abs(d_eig),[],1),'all')
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end
@@ -354,10 +355,9 @@ if (numel(parameters.npts)==3)
         s12=(parameters.dxy(:)+parameters.dyx(:))/2; m11=parameters.dxx(:);
         s13=(parameters.dxz(:)+parameters.dzx(:))/2; m22=parameters.dyy(:);
         s23=(parameters.dyz(:)+parameters.dzy(:))/2; m33=parameters.dzz(:);
-        det_top=m11.*(m22.*m33-s23.^2)-s12.*(s12.*m33-s23.*s13)+s13.*(s12.*s23-m22.*s13);
-        if any(m11<0)||any(m22<0)||any(m33<0)||...
-           any(m11.*m22-s12.^2<0)||any(m11.*m33-s13.^2<0)||...
-           any(m22.*m33-s23.^2<0)||any(det_top<0)
+        d_ten=reshape([m11 s12 s13 s12 m22 s23 s13 s23 m33]',[3 3 numel(m11)]);
+        d_eig=pageeig(d_ten);
+        if any(min(d_eig,[],1)<-20*eps()*max(abs(d_eig),[],1),'all')
             error('the diffusion tensor field must be positive semidefinite at every voxel.');
         end
     end


### PR DESCRIPTION
The diffusion tensor field gate tested principal minors of each voxel tensor against zero. A legitimate rank-deficient tensor (a rotated rank-one or rank-two diffusion field) has minors that round negative, so the gate rejected valid input: 8 of 50 rotated rank-one 2D fields and 20 of 50 rank-two 3D fields on a 12x12(x12) grid. No threshold on the minors fixes this, since the determinant of an indefinite tensor with two small eigenvalues sits closer to zero than that of a legitimate rank-deficient one.

**Change.** Both blocks stack the voxel tensors and test the spectrum directly: reject when the smallest eigenvalue falls below `-20*eps` of the largest in magnitude. That is a relative test with no scale of its own, and it separates the two classes cleanly.

**Validation.** Marker-confirmed probe, parent and branch side by side, all fields through production `v2fplanck` calls.

- rotated rank-one 2D, 50 fields: 42/50 accepted on the parent, 50/50 here
- rank-two 3D, 50 fields: 30/50 accepted on the parent, 50/50 here
- indefinite 2D and 3D tensors: rejected by both
- near-cancelling indefinite tensors, relative smallest eigenvalues -3.3e-10, -5.0e-8 and -9.0e-6: rejected by both
- 64000-voxel call: 0.34 s parent, 0.25 s here
- `diffusion_test_2b` and `diffusion_weighted_2d` run to completion; house-style gate and `checkcode` clean
