### PR TITLE
examples: match the coote scripts to the paper settings

### DIFF
--- a/examples/optimal_control/bloch_siegert/coote_badcop.m
+++ b/examples/optimal_control/bloch_siegert/coote_badcop.m
@@ -1,8 +1,13 @@
-% Reproduction of BADCOP-style selective decoupling logic 
+% Reproduction of BADCOP-style selective decoupling logic
 % from (https://doi.org/10.1038/s41467-018-05400-4) with
 % Bloch-Siegert corrections enabled in the optimiser and
-% simulator BADCOP1, BADCOP2, and BADCOP3 are designed 
-% and validated.
+% simulator. BADCOP1, BADCOP2, and BADCOP3 are designed
+% and validated. Durations, RF ceilings, the contraction
+% factor, and the inversion bands are those of Table 1
+% and the text of the paper, and the 53.2 ppm carrier is
+% the one stated in Supplementary Figure 5. Only BADCOP2
+% and BADCOP3 are asked to preserve C-beta magnetisation
+% outside their inversion band.
 %
 % Calculation time: minutes
 %
@@ -39,7 +44,7 @@ Iz=state(spin_system,'Lz','13C'); Iz=Iz/norm(Iz,2);
 D=hamiltonian(assume(spin_system,'nmr'));
 
 % Paper parameters
-carrier_ppm=100;
+carrier_ppm=53.2;
 alpha_scale=0.91;
 pulse_dur=1e-3;
 ca_ppm=linspace(40,72,100);
@@ -49,22 +54,27 @@ co_hz=ppm2hz(co_ppm-carrier_ppm,sys.magnet,'13C');
 
 % Build all three variants from Table 1
 variants={...
-    struct('name','BADCOP1','rf_hz',5.94e3,'cb_inv_ppm',[5 37]),...
-    struct('name','BADCOP2','rf_hz',4.87e3,'cb_inv_ppm',[28 35]),...
-    struct('name','BADCOP3','rf_hz',7.22e3,'cb_inv_ppm',[10 45])};
+    struct('name','BADCOP1','rf_hz',5.94e3,'cb_inv_ppm',[5 37],'cb_prs',false),...
+    struct('name','BADCOP2','rf_hz',4.87e3,'cb_inv_ppm',[28 35],'cb_prs',true),...
+    struct('name','BADCOP3','rf_hz',7.22e3,'cb_inv_ppm',[10 45],'cb_prs',true)};
 
 % Design and evaluate each variant
 for k=1:numel(variants)
 
-    % Build C-beta inversion and preservation grids
+    % Build the C-beta inversion grid
     cb_inv_ppm=linspace(variants{k}.cb_inv_ppm(1),...
                         variants{k}.cb_inv_ppm(2),60);
-    cb_prs_ppm=linspace(5,80,80);
-    mask=(cb_prs_ppm<variants{k}.cb_inv_ppm(1))|...
-         (cb_prs_ppm>variants{k}.cb_inv_ppm(2));
-    cb_prs_ppm=cb_prs_ppm(mask);
     cb_inv_hz=ppm2hz(cb_inv_ppm-carrier_ppm,sys.magnet,'13C');
-    cb_prs_hz=ppm2hz(cb_prs_ppm-carrier_ppm,sys.magnet,'13C');
+
+    % Only BADCOP2 and BADCOP3 preserve C-beta outside that band
+    if variants{k}.cb_prs
+        cb_prs_ppm=linspace(5,80,80);
+        mask=(cb_prs_ppm<variants{k}.cb_inv_ppm(1))|...
+             (cb_prs_ppm>variants{k}.cb_inv_ppm(2));
+        cb_prs_hz=ppm2hz(cb_prs_ppm(mask)-carrier_ppm,sys.magnet,'13C');
+    else
+        cb_prs_hz=[];
+    end
 
     % Assemble full offset list
     all_hz=[ca_hz co_hz cb_inv_hz cb_prs_hz];

--- a/examples/optimal_control/bloch_siegert/coote_goodcop.m
+++ b/examples/optimal_control/bloch_siegert/coote_goodcop.m
@@ -1,8 +1,12 @@
-% Reproduction of the GOODCOP pulse design logic from 
-% (https://doi.org/10.1038/s41467-018-05400-4) with 
-% Bloch-Siegert corrections enabled in the optimiser 
+% Reproduction of the GOODCOP pulse design logic from
+% (https://doi.org/10.1038/s41467-018-05400-4) with
+% Bloch-Siegert corrections enabled in the optimiser
 % and simulator. The pulse enforces contracted-time
-% C-alpha evolution while inverting CO.
+% C-alpha evolution while inverting CO. The duration,
+% the RF ceiling, the time contraction factor, and the
+% two ensemble bands are those of Table 1 and the text
+% of the paper; the 53.2 ppm carrier is the one stated
+% in Supplementary Figure 5.
 %
 % Calculation time: minutes
 %
@@ -39,7 +43,7 @@ Iz=state(spin_system,'Lz','13C'); Iz=Iz/norm(Iz,2);
 D=hamiltonian(assume(spin_system,'nmr'));
 
 % Paper parameters
-carrier_ppm=100;
+carrier_ppm=53.2;
 alpha_scale=0.90;
 pulse_dur=150e-6;
 max_rf_hz=15e3;


### PR DESCRIPTION
Audit of `coote_goodcop.m` and `coote_badcop.m` against the paper cited in
their headers, Coote et al., *Nat Commun* **9**, 3014 (2018),
doi:10.1038/s41467-018-05400-4, and its Supplementary Information.

Two settings did not match the paper; everything else already did.

**Carrier.** Both scripts placed the 13C carrier at 100 ppm. Supplementary
Figure 5 states the carrier explicitly: "All trajectories are expressed in a
rotating frame at the Ca carrier frequency of 53.2 ppm". The carrier is not
cosmetic here: it sets the offsets at which the RF ceiling and the
Bloch-Siegert shift act, and it moves the CO band from a 13-17 kHz offset to
the 22.5-26.5 kHz offset at which the published pulses actually have to work.

**C-beta preservation.** The BADCOP1 design in the paper samples only three
bands: 100 Ca shifts in [40,72] ppm, 30 CO shifts in [165,185] ppm, and 60
C-beta shifts in [5,37] ppm to be inverted. Preservation of longitudinal
magnetisation outside the inversion band is introduced one subsection later,
for the two band-selective pulses only ("Two additional BADCOP pulses ... We
also specifically optimize the pulses to not invert (i.e., to preserve)
longitudinal magnetization for C-beta outside of the desired selective
decoupling bandwidth"), and Table 1 carries the "other C-beta are not
inverted" clause for BADCOP2 and BADCOP3 alone. The script imposed it on all
three, so BADCOP1 was being asked to satisfy a constraint the paper does not
give it. It is now applied to BADCOP2 and BADCOP3 only.

Checked and left alone, because they already match: field (800 MHz proton),
durations (150 us, 1 ms), RF ceilings (15.00, 5.94, 4.87, 7.22 kHz), time
contraction factors (0.90, 0.91), all ensemble bands and their point counts,
the alternating Ix/Iy universal-rotation targets and their
`exp(-i*omega*a*T*Iz)` propagator, and the deliberate 40-45 ppm overlap
between the BADCOP3 inversion band and the Ca band, which is what produces
the loss of glycine Ca that the paper reports. The RF ceiling is enforced by
`optimcon`'s default SNS penalty, which stayed at zero throughout.

**Validation** on this branch, MATLAB R2026a, seeded initial guess.

`coote_goodcop`: 200 L-BFGS iterations, fidelity 0.999922, zero penalty.
Profile over 0-200 ppm: CO inverted to Mz = -0.9991 worst case across
165-185 ppm, Ca longitudinal magnetisation +0.99997 worst case across
35-75 ppm. This is the Figure 2d behaviour.

`coote_badcop`: six optimisations, 200 iterations each, final fidelities
0.9611/0.9611 (BADCOP1), 0.9555/0.9555 (BADCOP2), 0.8931/0.8931 (BADCOP3),
penalties at zero. Measured profiles, mean Mz:

- BADCOP1: -0.98 over 10-35 ppm, +0.98 and above from 43 ppm up, CO -0.995.
- BADCOP2: -0.92 over 28-35 ppm, positive elsewhere, CO -1.000.
- BADCOP3: -0.96 over 10-35 ppm and still -0.60 at 37-43 ppm, +0.34 at
  43-45 ppm, +0.95 at 45-50 ppm, +0.999 above 50 ppm, CO -1.000.

Each reproduces its published counterpart, including the BADCOP3 edge that
the paper describes: inversion reaching about 43 ppm, and the desired Ca
behaviour only recovering above about 47 ppm, which is why glycine Ca are
degraded with that pulse.

`checkcode` is silent on both files and the house-style gate is clean.