### PR TITLE
tests: set the Redfield include kernel contract in the fixture

### DIFF
--- a/tests/kernel/test_dynamic_integrity_includes_mex_suite.m
+++ b/tests/kernel/test_dynamic_integrity_includes_mex_suite.m
@@ -188,8 +188,9 @@ end
 
 function result=local_test_redfield_serial(result,serial_file)
 
-% Build a one-dimensional Redfield fixture with an analytical integral
+% Build a one-dimensional Redfield fixture, on-shell kernel at zero shift
 [spin_system,Q,L0,R,expected]=local_redfield_fixture(); %#ok<ASGLU>
+rlx_onshell=true; rlx_shift=0; %#ok<NASGU>
 run(serial_file);
 result=test_close(result,'serial Redfield include integral',R,expected,1e-10,1e-10,...
                   'the serial include must add the one-dimensional analytical Redfield integral');
@@ -202,8 +203,9 @@ end
 
 function result=local_test_redfield_async(result,async_file)
 
-% Build a one-dimensional Redfield fixture with an analytical integral
+% Build a one-dimensional Redfield fixture, on-shell kernel at zero shift
 [spin_system,Q,L0,R,expected]=local_redfield_fixture(); %#ok<ASGLU>
+rlx_onshell=true; rlx_shift=0; %#ok<NASGU>
 run(async_file);
 result=test_close(result,'async Redfield include integral',R,expected,1e-10,1e-10,...
                   'the asynchronous include must reproduce the analytical Redfield integral through parfeval and ValueStore');
@@ -255,12 +257,14 @@ result=test_true(result,'parallel profiler direct script dispatch',...
 
 % Execute the serial Redfield include by script name
 [spin_system,Q,L0,R,expected]=local_redfield_fixture(); %#ok<ASGLU>
+rlx_onshell=true; rlx_shift=0; %#ok<NASGU>
 redfield_integral_serial;
 result=test_close(result,'serial Redfield direct script dispatch',R,expected,1e-10,1e-10,...
                   'direct serial Redfield include dispatch must reproduce the analytical integral');
 
 % Execute the asynchronous Redfield include by script name
 [spin_system,Q,L0,R,expected]=local_redfield_fixture(); %#ok<ASGLU>
+rlx_onshell=true; rlx_shift=0; %#ok<NASGU>
 redfield_integral_async;
 result=test_close(result,'async Redfield direct script dispatch',R,expected,1e-10,1e-10,...
                   'direct asynchronous Redfield include dispatch must reproduce the analytical integral');


### PR DESCRIPTION
`kernel/dynamic_integrity_includes_mex` fails on current main:

```
FAIL kernel/dynamic_integrity_includes_mex  Unrecognized function or variable 'rlx_onshell'.
```

The Nakajima-Zwanzig kernel core (`8e16535a`, 20 August) changed the contract of `redfield_integral_serial.m` and `redfield_integral_async.m`: the calling theory block must now set `rlx_onshell` (back-rotated kernel versus resolvent kernel) and `rlx_shift` (Laplace evaluation point). `relaxation.m:114` sets `rlx_onshell=true; rlx_shift=0` for Bloch-Wangsness-Redfield; the test fixture was never updated, so all four include call sites in the test error out before any check is recorded.

All four sites now set the same pair. On-shell at zero shift is Redfield theory, which is what the analytical one-dimensional reference in `local_redfield_fixture` assumes.

Validated: the test goes from FAIL to PASS (11.2 s) with a parallel pool available, all its checks recorded; `checkcode` reports the same two pre-existing `clear mex` messages as main and no new ones; house-style gate reports only the pre-existing trailing-blank-line item, unchanged from main. Nothing outside `tests/` is touched.