### PR TITLE
examples: MAS pulse-acquire on the diamond P1 centre

### DIFF
--- a/examples/quantum_tech/diamond_defects/diamond_p1_mas.m
+++ b/examples/quantum_tech/diamond_defects/diamond_p1_mas.m
@@ -1,0 +1,71 @@
+% Powder magic angle spinning EPR spectrum of the P1 substitutional
+% nitrogen defect in diamond at 7 Tesla. The initial condition is a
+% transverse electron magnetisation, and therefore no pulse is need-
+% ed: the single angle spinning context calls acquire.m directly.
+%
+% The anisotropy is carried by the 14N hyperfine coupling, of which
+% the dipolar part is 10.9 MHz; the two outer hyperfine lines there-
+% fore acquire sideband manifolds, whereas the central line has no
+% hyperfine anisotropy and stays sharp. The rotation frequency used
+% here is above what a mechanical rotor can deliver, but within the
+% range reported for optically levitated nanoparticles:
+%
+%           R. Reimann et al., Phys. Rev. Lett. 121, 033602 (2018)
+%           J. Ahn et al., Phys. Rev. Lett. 121, 033603 (2018)
+%
+% Calculation time: minutes
+%
+% ilya.kuprov@weizmann.ac.il
+
+function diamond_p1_mas()
+
+% P1 centre parameters
+p1_params.orientation='111';
+p1_params.nitrogen='14N';
+
+% Build the spin system
+[sys,inter]=diamond_p1(p1_params);
+
+% Magnet field
+sys.magnet=7;
+
+% Basis set
+bas.formalism='sphten-liouv';
+bas.approximation='none';
+
+% Spinach housekeeping
+spin_system=create(sys,inter);
+spin_system=basis(spin_system,bas);
+
+% Rotor parameters
+parameters.rate=5e6;
+parameters.axis=[1 1 1];
+parameters.max_rank=17;
+
+% Sequence parameters
+parameters.spins={'E'};
+parameters.rho0=state(spin_system,'L+','E');
+parameters.coil=state(spin_system,'L+','E');
+parameters.offset=1.234e7;
+parameters.sweep=3e8;
+parameters.npoints=4096;
+parameters.zerofill=16384;
+parameters.grid='rep_2ang_1600pts_sph';
+parameters.axis_units='MHz-labframe';
+parameters.invert_axis=1;
+parameters.verbose=0;
+
+% Simulation
+fid=singlerot(spin_system,@acquire,parameters,'esr');
+
+% Apodisation
+fid=apodisation(spin_system,fid,{{'exp',6}});
+
+% Fourier transform
+spectrum=fftshift(fft(fid,parameters.zerofill));
+
+% Plotting
+kfigure(); plot_1d(spin_system,real(spectrum),parameters);
+
+end
+


### PR DESCRIPTION
Adds `examples/quantum_tech/diamond_defects/diamond_p1_mas.m`: a powder-averaged
time-domain pulse-acquire EPR simulation of the P1 substitutional nitrogen
defect in diamond at 7 Tesla, run under magic angle spinning through the
`singlerot` context. The initial state is transverse electron magnetisation, so
no pulse is applied and `acquire.m` is called directly. The spin system comes
from the shipped `diamond_p1` constructor with 14N.

## Physics

P1 has no zero-field splitting, so the anisotropy is carried entirely by the
14N hyperfine tensor `diag([81.3 81.3 114.0])` MHz, whose dipolar part is
10.9 MHz. The `m_I=0` line therefore has no hyperfine anisotropy and carries no
spinning sidebands, while the two outer hyperfine lines carry full manifolds.

The rotation frequency, 5 MHz, is above what a mechanical rotor can deliver but
within the range reported for optically levitated nanoparticles (Reimann et al.,
PRL 121, 033602 (2018); Ahn et al., PRL 121, 033603 (2018)), which is stated in
the file header.

`parameters.offset` is positive here: the P1 g-tensor sits below the free
electron value that Spinach uses for the electron rotating frame, so the
centring offset has the opposite sign to the nitroxide and NV cases.
`parameters.axis_units` is `MHz-labframe` rather than `MHz`, the plain
rotating-frame axis in `axis_1d.m` applying no sign conversion.

## Validation

- Sideband spacing 4.9991 MHz against a 5 MHz rotor frequency, the frequency bin
  being 18.3 kHz.
- Spectrum centred: centre of gravity 0.0106 MHz on the raw axis.
- No folding at the window edges: 7.1e-6 of the maximum in the outer 3%.
- Rotor rank convergence, 17 against 27: 1.7e-6.
- Powder grid convergence, 800 against 1600 points: 2.2e-3; 1600 against 3200:
  7.1e-4.
- House style gate clean, MATLAB `checkcode` empty.
- Run time about four minutes on 24 cores.

None of the files this example depends on changed between the commit the
validation was run against and the base of this branch.

## Known, not established

The central line sits at 196162.70 MHz where the first-order g-shift alone
predicts 196162.32 MHz. A test of whether the 0.39 MHz residual follows an
A-squared law, as a second-order hyperfine shift would, was inconclusive: the
peak-picking window also contained spinning sidebands. No cause is being
claimed. The residual is 0.13% of the sweep width.