### PR TITLE
fix(examples): apply 13C gyromagnetic conversion to sweep width (F054)

### DIFF
--- a/examples/nmr_solids/case_studies/mathies_14n_13c/mas_powder_gly_13c.m
+++ b/examples/nmr_solids/case_studies/mathies_14n_13c/mas_powder_gly_13c.m
@@ -76,7 +76,7 @@ for m=1:numel(fields)
     spin_system=basis(spin_system,bas);
     
     % Experiment setup
-    parameters.sweep=200*sys.magnet;      % unchanged in ppm
+    parameters.sweep=200*sys.magnet*spin('13C')/(2*pi*1e6);      % unchanged in ppm
     parameters.offset=43.6*sys.magnet*spin('13C')/(2*pi*1e6);
     parameters.rho0=state(spin_system,'L+','13C');
     parameters.coil=state(spin_system,'L+','13C');


### PR DESCRIPTION
## What was wrong
`examples/nmr_solids/case_studies/mathies_14n_13c/mas_powder_gly_13c.m:79` set `parameters.sweep=200*sys.magnet`, passing a Tesla*200 value directly as a Hz sweep width. This omits the 13C gyromagnetic-ratio conversion (`spin('13C')/(2*pi*1e6)`) that the adjacent offset line (line 80) correctly applies.

## Why it matters physically
The comment states the sweep is meant to be a field-independent 200 ppm window. Without the gyromagnetic conversion, the actual sweep is only ~18.68 ppm — a factor of ~10.7 too narrow. Most of the intended 200 ppm 13C chemical-shift range is folded back (aliased) into the narrow displayed window, producing a spectrum with misplaced, folded peaks.

## Stock probe output
```
measured_sweep_ppm=18.676933
```
(computed as `sweep/(sys.magnet*spin('13C')/(2*pi*1e6))` with the stock `parameters.sweep=200*sys.magnet` and `sys.magnet=9.4`)

## Patched probe output
```
patched_sweep_ppm=200.000000
```

## Fix
`parameters.sweep=200*sys.magnet*spin('13C')/(2*pi*1e6);` — mirrors the conversion already used on the offset line immediately below.

## Finding id
F054