### PR TITLE
fix(examples): convert CSA Euler angles from degrees to radians (F058)

### DIFF
--- a/examples/nmr_solids/fitting/vanadium_csa_nqi/vfit_4sim_ik.m
+++ b/examples/nmr_solids/fitting/vanadium_csa_nqi/vfit_4sim_ik.m
@@ -87,7 +87,7 @@ CSAa=CSiso - 0.5*CSaniso*(CSeta+1.0);
 CSAb=CSiso + 0.5*CSaniso*(CSeta-1.0);
 CSAc=CSiso + CSaniso;
 inter.zeeman.eigs={[CSAa CSAb CSAc]+456.818}; 
-inter.zeeman.euler={[CSAeul_a CSAeul_b CSAeul_c]};
+inter.zeeman.euler={pi/180*[CSAeul_a CSAeul_b CSAeul_c]};
 
 % Quadrupolar couplings
 inter.coupling.matrix{1,1}=eeqq2nqi(Qcc,Qeta,3.5,[0 0 0]);


### PR DESCRIPTION
## What was wrong
`examples/nmr_solids/fitting/vanadium_csa_nqi/vfit_4sim_ik.m:90` sets `inter.zeeman.euler={[CSAeul_a CSAeul_b CSAeul_c]}` directly from the fit parameters. The initial guess for these parameters (line 41, `82.0 180.0 19.0`) is in degrees, matching conventional CSA Euler-angle reporting. `create.m:756` passes `inter.zeeman.euler{n}` straight into `euler2dcm(...)`, whose documentation header explicitly states its inputs must be "Euler angles in radians (ZYZ active convention)".

## Why it matters physically
The optimiser explores Euler angles in degree-space while `euler2dcm` interprets them as radians, so the CSA tensor is rotated to a physically wrong orientation for essentially every parameter set explored, including the initial guess. The fitted CSA orientation reported by the script is meaningless.

## Stock probe output
```
orientation_error_deg=71.655070
```
Computed by rotating a reference vector with `R_stock=euler2dcm([82 180 19])` (stock: raw degree values fed straight into `euler2dcm`) and comparing against `R_fixed=euler2dcm([82 180 19]*pi/180)` (angles correctly converted to radians).

## Patched probe output
```
orientation_error_deg=0.000000
```
Same comparison after applying the `pi/180` conversion inside `vfit_4sim_ik.m`, confirming the patched assignment now matches the correctly-converted radian orientation.

## Fix
`inter.zeeman.euler={[CSAeul_a CSAeul_b CSAeul_c]};` -> `inter.zeeman.euler={pi/180*[CSAeul_a CSAeul_b CSAeul_c]};`

## Finding id
F058