### PR TITLE
fix(hyscore): use adjoint Liouvillian for backward coil propagation

### DIFF
--- a/experiments/esr_hyperfine/hyscore.m
+++ b/experiments/esr_hyperfine/hyscore.m
@@ -68,7 +68,7 @@ rho_stack=evolution(spin_system,L,[],rho,1/parameters.sweep,...
 rho_stack=step(spin_system,Lx,rho_stack,pi);
 
 % Propagate coil state backwards in time
-coil=evolution(spin_system,L,[],parameters.coil,-parameters.tau,1,'final');
+coil=evolution(spin_system,L',[],parameters.coil,-parameters.tau,1,'final');
 
 % Apply a backwards pulse on the coil
 coil=step(spin_system,-Lx,coil,pi/2);


### PR DESCRIPTION
## What was wrong

`experiments/esr_hyperfine/hyscore.m:71` propagated the detection (coil)
state backwards in time using the plain Liouvillian `L`:

```matlab
coil=evolution(spin_system,L,[],parameters.coil,-parameters.tau,1,'final');
```

This computes `exp(+1i*L*tau)*coil`. The algebraically correct way to
fold a bra/detection-state's backward evolution into the coil is with
the adjoint Liouvillian, `exp(+1i*L'*tau)*coil`.

## Why it matters physically

`L=H+1i*R+1i*K` is only Hermitian when relaxation and kinetics are both
absent. For any realistic HYSCORE simulation that includes relaxation
or kinetics (R or K nonzero — the normal case), `L` is non-Hermitian,
so `L` and `L'` differ, and the tau-filter intensities and phases in the
resulting 2D spectrum come out wrong. The effect vanishes only in the
special coherent-only case where `L` is Hermitian, which is why this
bug can go unnoticed on simple test cases.

All comparable "fold tau evolution into the coil" sequences elsewhere
in the repository (`experiments/nmr_protein/hnca.m`, `hncaco.m`,
`hncoca.m`, `hcch_cosy.m`, `hcanh.m`) correctly use `L'` for exactly
this pattern, confirming that the plain `L` in `hyscore.m` was the
outlier rather than an accepted convention.

## Fix

Changed `L` to `L'` in the single backward-coil-propagation call.

## Probe

14N-nitroxide ESR system (`sys.isotopes={'E','14N'}`) with `t1_t2`
relaxation theory switched on, so `L=H+1i*R+1i*K` is genuinely
non-Hermitian. The probe runs stock `hyscore.m` and an inline reference
copy of the same sequence with the adjoint-corrected backward
propagation, and reports the relative discrepancy between the two FIDs.

Stock probe output (relative discrepancy, stock vs. adjoint-correct):
```
252.2798
```

Patched probe output:
```
0
```

## Finding id

F088