### PR TITLE
fix(levelpop): avoid exp() overflow for low-T/high-field populations

### DIFF
--- a/etc/textbook/levelpop.m
+++ b/etc/textbook/levelpop.m
@@ -52,8 +52,8 @@ H=-mg_ratio*field*S.z; H=full(H);
 % Get the energies
 E=h_bar*diag(H)/(k_bol*temperature);
 
-% Get the populations
-P=exp(-h_bar*diag(H)/(k_bol*temperature));
+% Get the populations, shifted to avoid exp() overflow
+P=exp(-E+min(E));
 
 % Normalise populations
 P=P/sum(P);

--- a/etc/textbook/levelpop.m
+++ b/etc/textbook/levelpop.m
@@ -46,7 +46,7 @@ k_bol=1.380649e-23;          % J/K, exact number
 % Get Pauli matrices
 S=pauli(multipl);
 
-% Zeeman Hamiltonian
+% Get Zeeman Hamiltonian
 H=-mg_ratio*field*S.z; H=full(H);
 
 % Get fractional energies

--- a/etc/textbook/levelpop.m
+++ b/etc/textbook/levelpop.m
@@ -46,7 +46,7 @@ k_bol=1.380649e-23;          % J/K, exact number
 % Get Pauli matrices
 S=pauli(multipl);
 
-% Get Zeeman Hamiltonian
+% Build Zeeman Hamiltonian
 H=-mg_ratio*field*S.z; H=full(H);
 
 % Get fractional energies

--- a/etc/textbook/levelpop.m
+++ b/etc/textbook/levelpop.m
@@ -49,17 +49,14 @@ S=pauli(multipl);
 % Build Zeeman Hamiltonian
 H=-mg_ratio*field*S.z; H=full(H);
 
-% Get the energies
-E=h_bar*diag(H)/(k_bol*temperature);
+% Get Boltzmann exponential args
+B=h_bar*diag(H)/(k_bol*temperature);
 
-% Get the populations, shifted to avoid exp() overflow
-P=exp(-E+min(E));
+% Preconditioned exp
+P=exp(-B+min(B));
 
-% Normalise populations
-P=P/sum(P);
-
-% Population differences
-dP=-diff(P);
+% Normalise and diff
+P=P/sum(P); dP=-diff(P);
 
 end
 

--- a/etc/textbook/levelpop.m
+++ b/etc/textbook/levelpop.m
@@ -46,14 +46,14 @@ k_bol=1.380649e-23;          % J/K, exact number
 % Get Pauli matrices
 S=pauli(multipl);
 
-% Build Zeeman Hamiltonian
+% Zeeman Hamiltonian
 H=-mg_ratio*field*S.z; H=full(H);
 
-% Get Boltzmann exponential args
-B=h_bar*diag(H)/(k_bol*temperature);
+% Get fractional energies
+E=h_bar*diag(H)/(k_bol*temperature);
 
 % Preconditioned exp
-P=exp(-B+min(B));
+P=exp(-E+min(E));
 
 % Normalise and diff
 P=P/sum(P); dP=-diff(P);


### PR DESCRIPTION
## What was wrong

`etc/textbook/levelpop.m:56` computed populations as
`P=exp(-h_bar*diag(H)/(k_bol*temperature))` directly. For a physically
routine electron-spin ('E') input at moderate-to-high field and
dilution-refrigerator temperature, the Zeeman/kT ratio exceeds the
double-precision `exp()` overflow threshold (~709), so the excited-state
term overflows to `Inf`, and the subsequent `P/sum(P)` normalisation
becomes `Inf/Inf = NaN` for every level.

## Why it matters physically

`grumble()` only rejects `temperature==0`; it does not exclude the
low-T/high-field/large-gyromagnetic-ratio regime that Spinach's own
examples use for exactly this kind of system (e.g.
`examples/giant_spin/triple_dy_magn.m`,
`examples/quantum_tech/circuit_qed/resonator_decay.m`, both in the
0.03-0.05 K range). In this regime the physically correct answer is a
near-unity ground-state population with a vanishingly small excited-state
population — instead the function silently returns `NaN` for both.

## Fix

Shift the Boltzmann exponent by `min(E)` before exponentiating (the
standard numerically stable softmax trick):

```matlab
% Get the populations, shifted to avoid exp() overflow
P=exp(-E+min(E));
```

This multiplies every unnormalised population by the same constant
`exp(min(E))`, which cancels exactly in the following `P=P/sum(P)`
normalisation, so the returned `P` is mathematically identical to the
stock formula wherever the stock formula did not overflow, and now also
correct where it did.

## Stock probe output

```
levelpop('E',14,0.003)
E(1)=3138.3 E(2)=-3138.3
P(1)=0 P(2)=NaN
sum(P)=NaN
any_nan=1
```

## Patched probe output

```
levelpop('E',14,0.003)
E(1)=3138.3 E(2)=-3138.3
P(1)=0 P(2)=1
sum(P)=1
any_nan=0
```

Regression check on a non-overflowing input
(`levelpop('E',3.5,0.03)`) gives identical `P=[7.12345e-69 1]` before and
after the fix.

`checkcode` on the changed file is clean.

## Finding id

F012