### PR TITLE
fix(methyl_group): correct sign of C-C bond rotation

### DIFF
--- a/etc/molecules/methyl_group.m
+++ b/etc/molecules/methyl_group.m
@@ -35,7 +35,7 @@ xyz=[[0.000 0.000 0.000];
      [0.000 0.000 1.050]*euler2dcm(0,theta,4*pi/3+phase)];
 
 % Rotate the CC bond
-xyz=xyz*euler2dcm(0,cc_th,cc_ph);
+xyz=xyz*euler2dcm(0,-cc_th,-cc_ph);
 
 % Translate the carbon
 xyz=xyz+c_xyz;

--- a/etc/molecules/methyl_group.m
+++ b/etc/molecules/methyl_group.m
@@ -30,12 +30,12 @@ grumble(c_xyz,cc_th,cc_ph,phase);
 % Generate a canonical methyl group
 theta=acos(1/3);
 xyz=[[0.000 0.000 0.000];
-     [0.000 0.000 1.050]*euler2dcm(0,theta,0*pi/3+phase);
-     [0.000 0.000 1.050]*euler2dcm(0,theta,2*pi/3+phase);
-     [0.000 0.000 1.050]*euler2dcm(0,theta,4*pi/3+phase)];
+     [0.000 0.000 1.050]*euler2dcm(0,theta,0*pi/3+phase)';
+     [0.000 0.000 1.050]*euler2dcm(0,theta,2*pi/3+phase)';
+     [0.000 0.000 1.050]*euler2dcm(0,theta,4*pi/3+phase)'];
 
 % Rotate the CC bond
-xyz=xyz*euler2dcm(0,-cc_th,-cc_ph);
+xyz=xyz*euler2dcm(0,cc_th,cc_ph)';
 
 % Translate the carbon
 xyz=xyz+c_xyz;

--- a/etc/molecules/methyl_group.m
+++ b/etc/molecules/methyl_group.m
@@ -30,12 +30,12 @@ grumble(c_xyz,cc_th,cc_ph,phase);
 % Generate a canonical methyl group
 theta=acos(1/3);
 xyz=[[0.000 0.000 0.000];
-     [0.000 0.000 1.050]*euler2dcm(0,theta,0*pi/3+phase)';
-     [0.000 0.000 1.050]*euler2dcm(0,theta,2*pi/3+phase)';
-     [0.000 0.000 1.050]*euler2dcm(0,theta,4*pi/3+phase)'];
+     [0.000 0.000 1.050]*euler2dcm(0,theta,0*pi/3+phase);
+     [0.000 0.000 1.050]*euler2dcm(0,theta,2*pi/3+phase);
+     [0.000 0.000 1.050]*euler2dcm(0,theta,4*pi/3+phase)];
 
 % Rotate the CC bond
-xyz=xyz*euler2dcm(0,cc_th,cc_ph)';
+xyz=xyz*euler2dcm(0,-cc_th,-cc_ph);
 
 % Translate the carbon
 xyz=xyz+c_xyz;


### PR DESCRIPTION
## What was wrong

`etc/molecules/methyl_group.m:38` applies the C-C bond rotation as a
row-vector postmultiply, `xyz=xyz*euler2dcm(0,cc_th,cc_ph);`. But
`euler2dcm.m`'s own documentation states the returned matrix `R` is to
be used as `v=R*v` for column vectors. Postmultiplying a row vector by
`R` is equivalent to premultiplying its column form by `R'`, not `R`.
Working through `R'=R_gamma(-cc_ph)*R_beta(-cc_th)` acting on `[0,0,1]`
gives `[-sin(cc_th)cos(cc_ph), sin(cc_th)sin(cc_ph), cos(cc_th)]`, an
x-sign flip relative to the documented spherical direction
`(sin(cc_th)cos(cc_ph), sin(cc_th)sin(cc_ph), cos(cc_th))`.

## Why it matters physically

For any non-trivial azimuth `cc_ph`, the C-C bond (and hence the whole
methyl group) is placed at the mirror-image position relative to the
rest of the molecule instead of the documented polar direction. This
silently corrupts the local geometry used to compute dipolar
couplings and CSA orientations for any custom spin system built with
this exported utility function.

## Fix

Negate both angles passed to `euler2dcm`, so the row-postmultiply
matrix `M=euler2dcm(0,-cc_th,-cc_ph)` satisfies `M'=Rz(cc_ph)*Ry(cc_th)`,
which is exactly the rotation that carries `[0,0,1]` to the documented
spherical direction `(sin(cc_th)cos(cc_ph), sin(cc_th)sin(cc_ph),
cos(cc_th))`.

## Probe

Rotate a canonical methyl group with `cc_th=0.7`, `cc_ph=1.1`,
`phase=0.3`, and compare the normalised centroid direction of the
three hydrogens (relative to the carbon) against the documented
spherical formula `(sin(cc_th)cos(cc_ph), sin(cc_th)sin(cc_ph),
cos(cc_th))`.

**Stock probe output:**
```
actual direction:
   -0.2922    0.5741    0.7648
expected spherical direction:
    0.2922    0.5741    0.7648
difference norm:
    0.5844
```

**Patched probe output:**
```
actual direction:
    0.2922    0.5741    0.7648
expected spherical direction:
    0.2922    0.5741    0.7648
difference norm:
   4.8711e-16
```

## Finding id

F008