### PR TITLE
fix(r1csa2tauc): avoid cancellation loss of the short-tauc root

### DIFF
--- a/etc/textbook/r1csa2tauc.m
+++ b/etc/textbook/r1csa2tauc.m
@@ -30,9 +30,9 @@ grumble(R1,del_sq,B0,isotope);
 % Get the Zeeman frequency
 omega=-B0*spin(isotope);
 
-% Solve the quadratic equation
-tauc(1)=(del_sq*omega^2-sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1);
+% Solve the quadratic equation, larger root first to avoid cancellation
 tauc(2)=(del_sq*omega^2+sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1);
+tauc(1)=1/(omega^2*tauc(2));
 
 % Check for imaginary components
 if (~isreal(tauc(1)))&&(~isreal(tauc(2)))

--- a/interfaces/agents/spinach-knowledge/etc/textbook/r1csa2tauc.md
+++ b/interfaces/agents/spinach-knowledge/etc/textbook/r1csa2tauc.md
@@ -24,7 +24,7 @@ Estimates the rotational correlation time from the longitudinal CSA relaxation r
 
 - Lines 27-28: Check consistency; implemented by `grumble(R1,del_sq,B0,isotope)`.
 - Lines 30-31: Get the Zeeman frequency; implemented by `omega=-B0*spin(isotope)`.
-- Lines 33-34: Solve the quadratic equation; implemented by `tauc(1)=(del_sq*omega^2-sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1)`.
+- Lines 33-34: Solve the quadratic equation, larger root first to avoid cancellation; implemented by `tauc(2)=(del_sq*omega^2+sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1)`.
 - Lines 37-38: Check for imaginary components; implemented by `if (~isreal(tauc(1)))&&(~isreal(tauc(2)))`.
 
 ### Control flow inferred from the code
@@ -34,8 +34,8 @@ Estimates the rotational correlation time from the longitudinal CSA relaxation r
 ### Key state/data transformations
 
 - Lines 31: computes `omega` using `omega=-B0*spin(isotope)`.
-- Lines 34: computes `tauc(1)` using `tauc(1)=(del_sq*omega^2-sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1)`.
-- Lines 35: computes `tauc(2)` using `tauc(2)=(del_sq*omega^2+sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1)`.
+- Lines 34: computes `tauc(2)` (the large root) using `tauc(2)=(del_sq*omega^2+sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1)`.
+- Lines 35: computes `tauc(1)` (the small root) from the product of the roots by Vieta's formula, `tauc(1)=1/(omega^2*tauc(2))`, which avoids cancellation loss in the subtraction form.
 
 ### Local helper functions
 
@@ -68,7 +68,7 @@ Estimates the rotational correlation time from the longitudinal CSA relaxation r
 - tauc -rotational correlation time, seconds
 - Check consistency
 - Get the Zeeman frequency
-- Solve the quadratic equation
+- Solve the quadratic equation, larger root first to avoid cancellation
 
 ## Internal Spinach / MATLAB structure cues
 


### PR DESCRIPTION
## What was wrong

`etc/textbook/r1csa2tauc.m:34` computed the short-correlation-time root
of the CSA-relaxation quadratic as a direct subtraction:

```matlab
tauc(1)=(del_sq*omega^2-sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1);
```

Whenever `R1` is small compared to `del_sq*omega/15` (weak CSA
relaxation / extreme narrowing — the physical regime where the true
`tauc(1)` limit is small and positive), the minuend and subtrahend agree
to more digits than double precision carries, and the subtraction rounds
to exactly `0`, silently discarding the short-correlation-time root.

## Why it matters physically

A user extracting the rotational correlation time from a weakly
CSA-relaxing nucleus in a fast-tumbling small molecule — a routine
solution-NMR relaxation analysis — gets `tauc(1)=0` exactly instead of
the true nonzero short correlation time, with no warning.

## Fix

Compute the numerically stable large root `tauc(2)` first (an addition,
no cancellation), then recover the short root via Vieta's relation. The
two roots of `15*omega^2*R1*tauc^2-2*del_sq*omega^2*tauc+15*R1=0` (which
is exactly the quadratic the stock code solves) satisfy
`tauc(1)*tauc(2)=1/omega^2`:

```matlab
% Solve the quadratic equation, larger root first to avoid cancellation
tauc(2)=(del_sq*omega^2+sqrt(del_sq^2*omega^4-225*omega^2*R1^2))/(15*omega^2*R1);
tauc(1)=1/(omega^2*tauc(2));
```

## Stock probe output

`r1csa2tauc(1e-8,200,9.4,'1H')`:

```
omega=-2.51471e+09
tauc(1)=0
tauc(2)=2666666667
product=0  expected 1/omega^2=1.581337897e-19
```

## Patched probe output

Same call:

```
tauc(1)=5.930017115e-29
tauc(2)=2666666667
product=1.581337897e-19  matches 1/omega^2
```

Regression check with a more moderate `R1=50` Hz on the same molecule
(1H, B0=9.4 T, del_sq=200): the stock code already loses `tauc(1)` to
`0` here as well; the patched code gives `tauc(1)=2.965008558e-19`,
whose product with `tauc(2)=0.5333333333` matches `1/omega^2` exactly,
confirming the fix is correct rather than merely relocating the
cancellation.

`checkcode` on the changed file is clean.

## Finding id

F014