### PR TITLE
F077: rotate NQI tensors into the coordinate frame in bubble_pulse_acquire.m

### DIFF
--- a/examples/parahydrogen/case_studies/hyperpolarised_deuterium/bubble_pulse_acquire.m
+++ b/examples/parahydrogen/case_studies/hyperpolarised_deuterium/bubble_pulse_acquire.m
@@ -23,13 +23,17 @@ inter.coupling.scalar=cell(4,4);
 inter.coupling.scalar{1,2} = 12.0;
 inter.coupling.scalar{3,4} = 0.24;
 
-% NQI tensors from a DFT calculation
-inter.coupling.matrix{3,3}=1e3*[ 108.2    0.1   28.1
-                                   0.1  -55.6    4.5
-                                  28.1    4.5  -52.6];  
-inter.coupling.matrix{4,4}=1e3*[ -55.2    8.1  -14.5
-                                   8.1   -6.3  -73.9
-                                 -14.5  -73.9   61.5];
+% NQI tensors from a DFT calculation, rotated from the
+% Gaussian abc principal axis frame into the standard
+% orientation frame used below for the coordinates, via
+% chi_std=R*chi_abc*R', R taken from the "Rotation matrix
+% to Principal Axis frame" block of ir_active_efg.out
+inter.coupling.matrix{3,3}=1e3*[ 106.7   -6.2   31.9
+                                  -6.2  -55.5    3.3
+                                  31.9    3.3  -51.2];
+inter.coupling.matrix{4,4}=1e3*[ -53.7   11.8  -19.7
+                                   11.8   -5.3  -73.8
+                                  -19.7  -73.8   59.0];
 
 % Cartesian coordinates, DFT calculation
 inter.coordinates={[]; []; % None for D2

--- a/examples/parahydrogen/case_studies/hyperpolarised_deuterium/bubble_pulse_acquire.m
+++ b/examples/parahydrogen/case_studies/hyperpolarised_deuterium/bubble_pulse_acquire.m
@@ -25,15 +25,13 @@ inter.coupling.scalar{3,4} = 0.24;
 
 % NQI tensors from a DFT calculation, rotated from the
 % Gaussian abc principal axis frame into the standard
-% orientation frame used below for the coordinates, via
-% chi_std=R*chi_abc*R', R taken from the "Rotation matrix
-% to Principal Axis frame" block of ir_active_efg.out
+% orientation frame used below for the coordinates
 inter.coupling.matrix{3,3}=1e3*[ 106.7   -6.2   31.9
                                   -6.2  -55.5    3.3
                                   31.9    3.3  -51.2];
 inter.coupling.matrix{4,4}=1e3*[ -53.7   11.8  -19.7
-                                   11.8   -5.3  -73.8
-                                  -19.7  -73.8   59.0];
+                                  11.8   -5.3  -73.8
+                                 -19.7  -73.8   59.0];
 
 % Cartesian coordinates, DFT calculation
 inter.coordinates={[]; []; % None for D2


### PR DESCRIPTION
## What was wrong

`examples/parahydrogen/case_studies/hyperpolarised_deuterium/bubble_pulse_acquire.m`
built `inter.coupling.matrix{3,3}`/`{4,4}` (the D32/D33 nuclear quadrupole
interaction tensors) from the Chi values Gaussian reports in its `abc`
rotational principal-axis frame (see `ir_active_efg.out`, "Nuclear
quadrupole coupling constants [Chi]" block), while `inter.coordinates`
used the same job's input/standard-orientation Cartesian coordinates
(verified: D32 = `[-1.962320 0.573689 -0.576769]` in the "Standard
orientation" block, matching the .m file's `[-1.962 0.573 -0.576]`
exactly, whereas the `abc`-frame "Principal axis orientation" block
gives a different D32 = `[-1.978312 0.454099 -0.545153]`).

The rotation between the two frames is printed in the same output file
as "Rotation matrix to Principal Axis frame" (off-diagonal elements up
to 0.036, i.e. several degrees), so the quadrupolar tensor's principal
axes were rotated relative to the frame defining the inter-nuclear
(dipolar) geometry, with no compensating rotation applied.

## Why it matters physically

The dipolar-quadrupolar cross-correlation term in the Redfield
relaxation superoperator depends on the angle between the dipolar
vector and the quadrupolar tensor's principal axes. With the two
tensors expressed in unaligned frames, that angle — and hence the
magnitude/sign of the cross-correlation contribution to T1/T2 — is
wrong, which corrupts the simulated partially-negative-line (PNL)
spectrum this example produces.

## Fix

Rotated both quadrupole tensors from the Gaussian `abc` frame into the
standard-orientation frame used by `inter.coordinates`, via
`chi_std = R*chi_abc*R'`, with `R` read directly off the "Rotation
matrix to Principal Axis frame" block of `ir_active_efg.out`. Verified
independently that `R'` maps the D32-D33 relative vector from the
standard-orientation coordinates onto the relative vector in the
principal-axis-orientation coordinates to 4-5 significant figures,
confirming the rotation direction used.

## Probe

Diagnostic: `sum(diag(R'*R))` for the Redfield relaxation superoperator
built from the D-D spin system in this example (isolates the effect of
the tensor/coordinate frame mismatch on the relaxation superoperator).

- Stock (unrotated) tensors: `DIAGNOSTIC=1.394525097036e+07`
- Patched (rotated) tensors: `DIAGNOSTIC=1.396978540373e+07`

The two differ by ~0.18%, confirming the frame correction has a
measurable, non-trivial effect on the relaxation superoperator that
governs the simulated PNL lineshape.

## Finding id

F077