### PR TITLE
eseem_methyl_crystal: note the timestep/2 sampling of the ESEEM axis (F035, finding withdrawn)

### DIFF
--- a/examples/esr_sol_pulsed/eseem_methyl_crystal.m
+++ b/examples/esr_sol_pulsed/eseem_methyl_crystal.m
@@ -51,8 +51,8 @@ spectrum=fftshift(fft(fid,parameters.zerofill));
 
 % Plot the spectrum
 subplot(2,1,2); 
-plot(linspace(-1/(parameters.timestep),1/(parameters.timestep),...
-     parameters.zerofill)*1e-6,abs(spectrum)); 
+plot(linspace(-1/(2*parameters.timestep),1/(2*parameters.timestep),...
+     parameters.zerofill)*1e-6,abs(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 
 end

--- a/examples/esr_sol_pulsed/eseem_methyl_crystal.m
+++ b/examples/esr_sol_pulsed/eseem_methyl_crystal.m
@@ -49,9 +49,9 @@ fid=apodisation(spin_system,fid-mean(fid),{{'kaiser',6}});
 % Fourier transform
 spectrum=fftshift(fft(fid,parameters.zerofill));
 
-% Plot the spectrum
-subplot(2,1,2); 
-plot(linspace(-1/(2*parameters.timestep),1/(2*parameters.timestep),...
+% Plot the spectrum, interpulse delay increment is timestep/2
+subplot(2,1,2);
+plot(linspace(-1/(parameters.timestep),1/(parameters.timestep),...
      parameters.zerofill)*1e-6,abs(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 


### PR DESCRIPTION
Finding id: F035, file `examples/esr_sol_pulsed/eseem_methyl_crystal.m`

**Correction to the original claim.** This PR first halved the plotted frequency range to ±1/(2·timestep). That was wrong: `experiments/esr_dipolar/eseem.m` advances both echo periods by `timestep/2` per point, so the ESEEM trace is sampled at `timestep/2` and the correct Nyquist range is ±1/timestep, exactly what the stock example used. A probe with a weakly coupled proton at 0.33 T places the peaks at the proton Larmor frequency (14.05 MHz) on the stock range and at half that on the halved range. Finding F035 is withdrawn.

**What this PR now does.** The halving is reverted. The only remaining change is a clarifying comment stating that the interpulse delay increment is timestep/2, so the net diff against main is documentation only. The sibling PRs #463, #464, #467 additionally adopt an FFT-bin-aligned axis.
