### PR TITLE
fix(examples): rebuild spin_system for second Trp conformation (F060)

### DIFF
--- a/examples/nmr_solids/mas_powder_trp_fplanck.m
+++ b/examples/nmr_solids/mas_powder_trp_fplanck.m
@@ -90,6 +90,10 @@ inter.zeeman.matrix=shift_iso(inter.zeeman.matrix,10,28.0);
 inter.zeeman.matrix=shift_iso(inter.zeeman.matrix,11,52.1);
 inter.zeeman.matrix=shift_iso(inter.zeeman.matrix,12,173.3);
 
+% Spinach housekeeping
+spin_system=create(sys,inter);
+spin_system=basis(spin_system,bas);
+
 % Add to the previous simulation
 fid=fid+singlerot(spin_system,@acquire,parameters,'nmr');
 


### PR DESCRIPTION
## What was wrong
`examples/nmr_solids/mas_powder_trp_fplanck.m` builds `sys`/`inter` for the second molecule in the unit cell and edits `inter.zeeman.matrix` with the second conformation's experimental shifts (lines 81-91), but never rebuilds `spin_system` from the updated `sys`/`inter` before reusing it in the second `singlerot(spin_system,...)` call (line 94, now 98). `spin_system` still holds the state built from the first conformation earlier in the script.

## Why it matters physically
The final summed spectrum (`fid=fid+singlerot(...)`) is the first conformation counted twice, not the intended two-conformation powder average. Any spectral feature that should come from the second X-ray conformation's shifts (28.0/52.1/173.3 ppm for atoms 10/11/12) is silently absent from the simulated spectrum.

## Stock probe output
```
shift1_hz=-100664423.747311
shift_stock_hz=-100664423.747311
shift_patched_hz=-100664172.099991
stock_matches_first_conformation=1
stock_matches_second_conformation=0
```
Built the actual first-conformation `sys`/`inter` (via `g2spinach` on `trp_xray.out`) and ran `create`/`basis` exactly as the script does, recording the atom-11 isotropic shift (`shift1_hz`). Then updated `sys`/`inter` to the second conformation's shifts exactly as the script does, but (mirroring the stock bug) did not rebuild `spin_system`: the shift read back out (`shift_stock_hz`) is bit-identical to the stale first-conformation value, confirming the second conformation's data never reaches the simulation.

## Patched probe output
Rebuilding `spin_system=create(sys,inter); spin_system=basis(spin_system,bas);` after the second conformation's shift edits (as this PR now does in the script) yields `shift_patched_hz=-100664172.099991`, a genuinely different, correct value reflecting the second conformation's shifts.

## Fix
Insert the same `spin_system=create(sys,inter); spin_system=basis(spin_system,bas);` housekeeping pair used for the first molecule, immediately after the second conformation's chemical-shift edits and before it is used in `singlerot`.

## Finding id
F060