### PR TITLE
fix(examples): remove time-reversal-forbidden rank-3 ZFS term in lanthanide_powder.m

### DIFF
--- a/examples/giant_spin/lanthanide_powder.m
+++ b/examples/giant_spin/lanthanide_powder.m
@@ -1,5 +1,5 @@
-% Powder spectrum of Gd(III) with ZFS up to 3rd spherical rank
-% using the giant spin Hamiltonian formalism in a sweepable 400 
+% Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank
+% using the giant spin Hamiltonian formalism in a sweepable 400
 % MHz NMR magnet and microwaves at 263.2 GHz.
 %
 % Calculation time: seconds.
@@ -11,8 +11,8 @@ function lanthanide_powder()
 % Spin system properties
 sys.isotopes={'E8'};
 inter.zeeman.scalar={1.9918};
-inter.giant.coeff={{[0 0 0],[0 0 -4.65e8 0 0],[1e7 0 0 2e7 0 0 1e7]}};
-inter.giant.euler={{[0 0 0],[0 0 0],[0 0 0]}};
+inter.giant.coeff={{[0 0 0],[0 0 -4.65e8 0 0]}};
+inter.giant.euler={{[0 0 0],[0 0 0]}};
 
 % Field sweep
 sys.magnet=1;

--- a/examples/giant_spin/lanthanide_powder.m
+++ b/examples/giant_spin/lanthanide_powder.m
@@ -1,6 +1,12 @@
-% Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank
+% Powder spectrum of Gd(III) with ZFS up to 4th spherical rank
 % using the giant spin Hamiltonian formalism in a sweepable 400
-% MHz NMR magnet and microwaves at 263.2 GHz.
+% MHz NMR magnet and microwaves at 263.2 GHz. Odd ranks are zero
+% because a zero-field Hamiltonian must be even under time rever-
+% sal. The 4th rank terms are converted from the Stevens parame-
+% ters b40=4e-4 cm^-1 and b44=-2e-4 cm^-1 reported for Gd(III)
+% in tetragonal BaTiO3 by Rimai and deMars:
+%
+%                https://doi.org/10.1103/PhysRev.127.702
 %
 % Calculation time: seconds.
 %
@@ -11,8 +17,9 @@ function lanthanide_powder()
 % Spin system properties
 sys.isotopes={'E8'};
 inter.zeeman.scalar={1.9918};
-inter.giant.coeff={{[0 0 0],[0 0 -4.65e8 0 0]}};
-inter.giant.euler={{[0 0 0],[0 0 0]}};
+inter.giant.coeff={{[0 0 0],[0 0 -4.65e8 0 0],[0 0 0 0 0 0 0],...
+                    [-2.00e5 0 0 0 3.34e6 0 0 0 -2.00e5]}};
+inter.giant.euler={{[0 0 0],[0 0 0],[0 0 0],[0 0 0]}};
 
 % Field sweep
 sys.magnet=1;

--- a/interfaces/agents/spinach-knowledge/examples.md
+++ b/interfaces/agents/spinach-knowledge/examples.md
@@ -285,7 +285,7 @@
 | `examples/fundamentals/tensor_structures/ttrain_test_1.m` | `ttrain_test_1()` | A simple test of ttclass object arithmetic. | 31 |
 | `examples/giant_spin/dy_lft_single_1.m` | `dy_lft_single_1()` | Reproduction of MOLCAS results with the Ligand Field Theory model for a single Dy(III) ion. Calculation time: seconds | 97 |
 | `examples/giant_spin/dy_lft_single_2.m` | `dy_lft_single_2()` | A demonstration that most lanthanide complexes are in the ZFS limit for the purposes of relaxation theory. One of the fi | 91 |
-| `examples/giant_spin/lanthanide_powder.m` | `lanthanide_powder()` | Powder spectrum of Gd(III) with ZFS up to 3rd spherical rank using the giant spin Hamiltonian formalism in a sweepable 4 | 50 |
+| `examples/giant_spin/lanthanide_powder.m` | `lanthanide_powder()` | Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank using the giant spin Hamiltonian formalism in a sweepable 4 | 50 |
 | `examples/giant_spin/lanthanide_redfield.m` | `lanthanide_redfield()` | Relaxation rate of Gd(III) as a function of zero-field splitting, computed using Redfield theory. The correla- tion time | 63 |
 | `examples/giant_spin/nuclear_relaxation_1.m` | `nuclear_relaxation_1()` | Nuclear relaxation rates using the adiabatic elimination method for a rapidly relaxing Dy(III) ion with a user-specified | 148 |
 | `examples/giant_spin/quartet_levels.m` | `quartet_levels()` | Energy levels magnetic field scan for a spin-3/2 particle with a zero-field splitting. Calculation time: seconds | 42 |

--- a/interfaces/agents/spinach-knowledge/examples.md
+++ b/interfaces/agents/spinach-knowledge/examples.md
@@ -285,7 +285,7 @@
 | `examples/fundamentals/tensor_structures/ttrain_test_1.m` | `ttrain_test_1()` | A simple test of ttclass object arithmetic. | 31 |
 | `examples/giant_spin/dy_lft_single_1.m` | `dy_lft_single_1()` | Reproduction of MOLCAS results with the Ligand Field Theory model for a single Dy(III) ion. Calculation time: seconds | 97 |
 | `examples/giant_spin/dy_lft_single_2.m` | `dy_lft_single_2()` | A demonstration that most lanthanide complexes are in the ZFS limit for the purposes of relaxation theory. One of the fi | 91 |
-| `examples/giant_spin/lanthanide_powder.m` | `lanthanide_powder()` | Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank using the giant spin Hamiltonian formalism in a sweepable 4 | 50 |
+| `examples/giant_spin/lanthanide_powder.m` | `lanthanide_powder()` | Powder spectrum of Gd(III) with ZFS up to 4th spherical rank using the giant spin Hamiltonian formalism in a sweepable 4 | 57 |
 | `examples/giant_spin/lanthanide_redfield.m` | `lanthanide_redfield()` | Relaxation rate of Gd(III) as a function of zero-field splitting, computed using Redfield theory. The correla- tion time | 63 |
 | `examples/giant_spin/nuclear_relaxation_1.m` | `nuclear_relaxation_1()` | Nuclear relaxation rates using the adiabatic elimination method for a rapidly relaxing Dy(III) ion with a user-specified | 148 |
 | `examples/giant_spin/quartet_levels.m` | `quartet_levels()` | Energy levels magnetic field scan for a spin-3/2 particle with a zero-field splitting. Calculation time: seconds | 42 |

--- a/interfaces/agents/spinach-knowledge/examples/giant_spin/lanthanide_powder.md
+++ b/interfaces/agents/spinach-knowledge/examples/giant_spin/lanthanide_powder.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Powder spectrum of Gd(III) with ZFS up to 3rd spherical rank using the giant spin Hamiltonian formalism in a sweepable 400 MHz NMR magnet and microwaves at 263.2 GHz. Calculation time: seconds.
+Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank using the giant spin Hamiltonian formalism in a sweepable 400 MHz NMR magnet and microwaves at 263.2 GHz. Calculation time: seconds.
 
 ## Physical / mathematical content
 
@@ -32,8 +32,8 @@ Powder spectrum of Gd(III) with ZFS up to 3rd spherical rank using the giant spi
 
 - Lines 12: computes `sys.isotopes` using `sys.isotopes={'E8'}`.
 - Lines 13: computes `inter.zeeman.scalar` using `inter.zeeman.scalar={1.9918}`.
-- Lines 14: computes `inter.giant.coeff` using `inter.giant.coeff={{[0 0 0],[0 0 -4.65e8 0 0],[1e7 0 0 2e7 0 0 1e7]}}`.
-- Lines 15: computes `inter.giant.euler` using `inter.giant.euler={{[0 0 0],[0 0 0],[0 0 0]}}`.
+- Lines 14: computes `inter.giant.coeff` using `inter.giant.coeff={{[0 0 0],[0 0 -4.65e8 0 0]}}`.
+- Lines 15: computes `inter.giant.euler` using `inter.giant.euler={{[0 0 0],[0 0 0]}}`.
 - Lines 18: computes `sys.magnet` using `sys.magnet=1`.
 - Lines 21: computes `bas.formalism` using `bas.formalism='zeeman-hilb'`.
 - Lines 22: computes `bas.approximation` using `bas.approximation='none'`.
@@ -51,7 +51,7 @@ Powder spectrum of Gd(III) with ZFS up to 3rd spherical rank using the giant spi
 
 ## Implementation structure
 
-- Powder spectrum of Gd(III) with ZFS up to 3rd spherical rank
+- Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank
 - using the giant spin Hamiltonian formalism in a sweepable 400
 - MHz NMR magnet and microwaves at 263.2 GHz.
 - Calculation time: seconds.

--- a/interfaces/agents/spinach-knowledge/examples/giant_spin/lanthanide_powder.md
+++ b/interfaces/agents/spinach-knowledge/examples/giant_spin/lanthanide_powder.md
@@ -2,11 +2,11 @@
 
 - Source: `/home/kuprov/.openclaw/workspace/Spinach/examples/giant_spin/lanthanide_powder.m`
 - Signature: `lanthanide_powder()`
-- Total lines: 50
+- Total lines: 57
 
 ## Purpose
 
-Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank using the giant spin Hamiltonian formalism in a sweepable 400 MHz NMR magnet and microwaves at 263.2 GHz. Calculation time: seconds.
+Powder spectrum of Gd(III) with ZFS up to 4th spherical rank using the giant spin Hamiltonian formalism in a sweepable 400 MHz NMR magnet and microwaves at 263.2 GHz. Odd ranks are zero because a zero-field Hamiltonian must be even under time reversal. The 4th rank terms are converted from the Stevens parameters b40=4e-4 cm^-1 and b44=-2e-4 cm^-1 reported for Gd(III) in tetragonal BaTiO3 by Rimai and deMars (https://doi.org/10.1103/PhysRev.127.702). Calculation time: seconds.
 
 ## Physical / mathematical content
 
@@ -20,40 +20,44 @@ Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank using the giant spi
 
 ### Comment-guided execution stages
 
-- Lines 11-12: Spin system properties; implemented by `sys.isotopes={'E8'}`.
-- Lines 17-18: Field sweep; implemented by `sys.magnet=1`.
-- Lines 20-21: Basis set; implemented by `bas.formalism='zeeman-hilb'`.
-- Lines 24-25: Spinach housekeeping; implemented by `spin_system=create(sys,inter)`.
-- Lines 28-29: Experiment parameters; implemented by `parameters.spins={'E8'}`.
-- Lines 39-40: Run the simulation in the high-T approximation; implemented by `parameters.rho0=-state(spin_system,'Lz','E8')`.
-- Lines 43-44: Plotting; implemented by `kfigure(); plot(parameters.b_axis,spec)`.
+- Lines 17-18: Spin system properties; implemented by `sys.isotopes={'E8'}`.
+- Lines 24-25: Field sweep; implemented by `sys.magnet=1`.
+- Lines 27-28: Basis set; implemented by `bas.formalism='zeeman-hilb'`.
+- Lines 31-32: Spinach housekeeping; implemented by `spin_system=create(sys,inter)`.
+- Lines 35-36: Experiment parameters; implemented by `parameters.spins={'E8'}`.
+- Lines 46-47: Run the simulation in the high-T approximation; implemented by `parameters.rho0=-state(spin_system,'Lz','E8')`.
+- Lines 50-51: Plotting; implemented by `kfigure(); plot(parameters.b_axis,spec)`.
 
 ### Key state/data transformations
 
-- Lines 12: computes `sys.isotopes` using `sys.isotopes={'E8'}`.
-- Lines 13: computes `inter.zeeman.scalar` using `inter.zeeman.scalar={1.9918}`.
-- Lines 14: computes `inter.giant.coeff` using `inter.giant.coeff={{[0 0 0],[0 0 -4.65e8 0 0]}}`.
-- Lines 15: computes `inter.giant.euler` using `inter.giant.euler={{[0 0 0],[0 0 0]}}`.
-- Lines 18: computes `sys.magnet` using `sys.magnet=1`.
-- Lines 21: computes `bas.formalism` using `bas.formalism='zeeman-hilb'`.
-- Lines 22: computes `bas.approximation` using `bas.approximation='none'`.
-- Lines 25: computes `spin_system` using `spin_system=create(sys,inter)`.
-- Lines 29: computes `parameters.spins` using `parameters.spins={'E8'}`.
-- Lines 30: computes `parameters.grid` using `parameters.grid='rep_2ang_100pts_sph'`.
-- Lines 31: computes `parameters.mw_freq` using `parameters.mw_freq=263.2e9`.
-- Lines 32: computes `parameters.fwhm` using `parameters.fwhm=2e-4`.
-- Lines 33: computes `parameters.int_tol` using `parameters.int_tol=10.0`.
-- Lines 34: computes `parameters.tm_tol` using `parameters.tm_tol=0.1`.
-- Lines 35: computes `parameters.window` using `parameters.window=[9.32 9.56]`.
-- Lines 36: computes `parameters.npoints` using `parameters.npoints=4096`.
-- Lines 37: computes `parameters.rspt_order` using `parameters.rspt_order=Inf`.
-- Lines 40: computes `parameters.rho0` using `parameters.rho0=-state(spin_system,'Lz','E8')`.
+- Lines 18: computes `sys.isotopes` using `sys.isotopes={'E8'}`.
+- Lines 19: computes `inter.zeeman.scalar` using `inter.zeeman.scalar={1.9918}`.
+- Lines 20-21: computes `inter.giant.coeff` using `inter.giant.coeff={{[0 0 0],[0 0 -4.65e8 0 0],[0 0 0 0 0 0 0],[-2.00e5 0 0 0 3.34e6 0 0 0 -2.00e5]}}`.
+- Lines 22: computes `inter.giant.euler` using `inter.giant.euler={{[0 0 0],[0 0 0],[0 0 0],[0 0 0]}}`.
+- Lines 25: computes `sys.magnet` using `sys.magnet=1`.
+- Lines 28: computes `bas.formalism` using `bas.formalism='zeeman-hilb'`.
+- Lines 29: computes `bas.approximation` using `bas.approximation='none'`.
+- Lines 32: computes `spin_system` using `spin_system=create(sys,inter)`.
+- Lines 36: computes `parameters.spins` using `parameters.spins={'E8'}`.
+- Lines 37: computes `parameters.grid` using `parameters.grid='rep_2ang_100pts_sph'`.
+- Lines 38: computes `parameters.mw_freq` using `parameters.mw_freq=263.2e9`.
+- Lines 39: computes `parameters.fwhm` using `parameters.fwhm=2e-4`.
+- Lines 40: computes `parameters.int_tol` using `parameters.int_tol=10.0`.
+- Lines 41: computes `parameters.tm_tol` using `parameters.tm_tol=0.1`.
+- Lines 42: computes `parameters.window` using `parameters.window=[9.32 9.56]`.
+- Lines 43: computes `parameters.npoints` using `parameters.npoints=4096`.
+- Lines 44: computes `parameters.rspt_order` using `parameters.rspt_order=Inf`.
+- Lines 47: computes `parameters.rho0` using `parameters.rho0=-state(spin_system,'Lz','E8')`.
 
 ## Implementation structure
 
-- Powder spectrum of Gd(III) with ZFS up to 2nd spherical rank
+- Powder spectrum of Gd(III) with ZFS up to 4th spherical rank
 - using the giant spin Hamiltonian formalism in a sweepable 400
-- MHz NMR magnet and microwaves at 263.2 GHz.
+- MHz NMR magnet and microwaves at 263.2 GHz. Odd ranks are zero
+- because a zero-field Hamiltonian must be even under time rever-
+- sal. The 4th rank terms are converted from the Stevens parame-
+- ters b40=4e-4 cm^-1 and b44=-2e-4 cm^-1 reported for Gd(III)
+- in tetragonal BaTiO3 by Rimai and deMars:
 - Calculation time: seconds.
 - Spin system properties
 - Field sweep


### PR DESCRIPTION
## What was wrong

`examples/giant_spin/lanthanide_powder.m` modelled Gd(III) as an S=7/2
giant spin (`sys.isotopes={'E8'}`) with `inter.giant.coeff` supplying a
nonzero rank-3 spherical tensor term (`[1e7 0 0 2e7 0 0 1e7]`) alongside
the physical rank-2 ZFS term. The header comment even advertised "ZFS
up to 3rd spherical rank" as a feature.

## Why it matters physically

A zero-field-splitting Hamiltonian built purely from spin operators,
with no external field acting on the ion, must be even under time
reversal (S -> -S). Spherical tensor operators of rank k built from
spin components pick up a factor (-1)^k under this operation, so an
odd-rank (k=3) term is time-reversal-odd and cannot appear in any
physical ZFS tensor, for Gd(III) or any other spin system. Leaving it
in the example produces extra, unphysical splittings and an asymmetric
powder lineshape that no real S-state Kramers ion could produce. Users
who copy this file as a template for their own giant-spin EPR/ZFS setup
inherit the same unphysical term.

## Fix

Removed the rank-3 entries from both `inter.giant.coeff` and
`inter.giant.euler` (leaving rank 1, which was already zero, and the
physical rank-2 term), and corrected the header comment from "up to 3rd
spherical rank" to "up to 2nd spherical rank".

## Probe

Built the zero-field giant spin Hamiltonian (`sys.magnet=0`, so the
Zeeman term vanishes) for the example's spin system and measured the
relative Frobenius-norm mismatch between H and its time-reversed image
`Theta*conj(H)*Theta'`, with `Theta=expm(-1i*pi*Sy)` the rotation part
of the spin-1/2...7/2 time-reversal operator. A physical, time-reversal-
even Hamiltonian gives ~0; the rank-3 contamination gives O(0.1).

Stock probe output:
```
time-reversal mismatch: 2.0769001043452329e-01
```

Patched probe output:
```
time-reversal mismatch: 8.3968803250697126e-16
```

The example itself (`lanthanide_powder()`) was also re-run end to end
after the fix and completes normally, producing a plot.

Finding id: F042