### PR TITLE
fix(examples): set inter_cutoff in Hz, not rad/s (F062)

### DIFF
--- a/examples/nmr_solids/wise_mas_gly.m
+++ b/examples/nmr_solids/wise_mas_gly.m
@@ -28,7 +28,7 @@ bas.approximation='IK-0';
 bas.level=3;
 
 % Ignore interactions below 200 Hz
-sys.tols.inter_cutoff=2*pi*200;
+sys.tols.inter_cutoff=200;
 
 % Use GPU arithmetic
 sys.enable={'greedy'}; % 'gpu'

--- a/interfaces/agents/spinach-knowledge/examples/nmr_solids/wise_mas_gly.md
+++ b/interfaces/agents/spinach-knowledge/examples/nmr_solids/wise_mas_gly.md
@@ -25,7 +25,7 @@ WISE of alpha-glycine powder under MAS. Calculation time: hours, much faster on 
 - Lines 13-14: 400 MHz spectrometer; implemented by `sys.magnet=9.4`.
 - Lines 16-17: Isotropic alpha-glycine chemical shifts; implemented by `inter.zeeman.matrix=shift_iso(inter.zeeman.matrix,1,176.4)`.
 - Lines 25-26: Basis set; implemented by `bas.formalism='sphten-liouv'`.
-- Lines 30-31: Ignore interactions below 200 Hz; implemented by `sys.tols.inter_cutoff=2*pi*200`.
+- Lines 30-31: Ignore interactions below 200 Hz; implemented by `sys.tols.inter_cutoff=200`.
 - Lines 33-34: Use GPU arithmetic; implemented by `sys.enable={'greedy'}`.
 - Lines 36-37: Spinach housekeeping; implemented by `spin_system=create(sys,inter)`.
 - Lines 40-41: Experiment setup; implemented by `parameters.spins={'1H','13C'}`.
@@ -45,7 +45,7 @@ WISE of alpha-glycine powder under MAS. Calculation time: hours, much faster on 
 - Lines 26: computes `bas.formalism` using `bas.formalism='sphten-liouv'`.
 - Lines 27: computes `bas.approximation` using `bas.approximation='IK-0'`.
 - Lines 28: computes `bas.level` using `bas.level=3`.
-- Lines 31: computes `sys.tols.inter_cutoff` using `sys.tols.inter_cutoff=2*pi*200`.
+- Lines 31: computes `sys.tols.inter_cutoff` using `sys.tols.inter_cutoff=200`.
 - Lines 34: computes `sys.enable` using `sys.enable={'greedy'}`.
 - Lines 37: computes `spin_system` using `spin_system=create(sys,inter)`.
 - Lines 41: computes `parameters.spins` using `parameters.spins={'1H','13C'}`.


### PR DESCRIPTION
## What was wrong
`examples/nmr_solids/wise_mas_gly.m:31` sets `sys.tols.inter_cutoff=2*pi*200` (~1256.6). `create.m`'s coupling-absorption code (`kernel/create.m` around lines 1049 and 1066) compares raw Hz-valued coupling norms directly against `spin_system.tols.inter_cutoff` *before* the `2*pi` rad/s conversion is applied — both comparisons are explicitly commented "Hz at this point". `inter_cutoff` is therefore expected in Hz, not rad/s.

## Why it matters physically
The comment on the preceding line says "Ignore interactions below 200 Hz", but the rad/s-scaled cutoff of ~1256.6 silently discards real dipolar/scalar couplings with norms between 200 Hz and ~1256.6 Hz — couplings the script's own stated intent is to keep. This removes genuine spin-spin interactions from the system and changes the simulated WISE cross-peak pattern without any warning to the user.

## Stock probe output
```
stock_cutoff=1256.637061
patched_cutoff=200.000000
stock_kept=0
patched_kept=1
```
A representative 500 Hz test coupling (well above the intended 200 Hz cutoff) is discarded under the stock `2*pi*200` cutoff (`stock_kept=0`) because `create.m` compares it in Hz against a value that is really in rad/s.

## Patched probe output
The same 500 Hz coupling is correctly kept once `inter_cutoff` is set to `200` (Hz), matching the units `create.m` expects (`patched_kept=1`).

## Fix
`sys.tols.inter_cutoff=2*pi*200;` -> `sys.tols.inter_cutoff=200;`

## Finding id
F062