### PR TITLE
F082: fix mislabelled detection channels in cidnp_pumping_2.m

### DIFF
--- a/examples/spin_chemistry/cidnp_pumping_2.m
+++ b/examples/spin_chemistry/cidnp_pumping_2.m
@@ -72,12 +72,12 @@ answer=evolution(spin_system,H+1i*R,coil,rho0,0.1,40,'multichannel');
 % Do the plotting
 kfigure(); scale_figure([1.5 1.0]);
 time_axis=linspace(0,4,41);
-subplot(1,3,1); plot(time_axis,real(answer(1,:))); 
-ktitle('$H_{\mathrm{Z}}$'); kxlabel('time, s'); kgrid;
-subplot(1,3,2); plot(time_axis,real(answer(2,:)));
+subplot(1,3,1); plot(time_axis,real(answer(1,:)));
 ktitle('$F_{\mathrm{Z}}$'); kxlabel('time, s'); kgrid;
+subplot(1,3,2); plot(time_axis,real(answer(2,:)));
+ktitle('$-H_{\mathrm{Z}}F_{\mathrm{Z}}$'); kxlabel('time, s'); kgrid;
 subplot(1,3,3); plot(time_axis,real(answer(3,:)));
-ktitle('$H_{\mathrm{Z}}F_{\mathrm{Z}}$'); 
+ktitle('$H_{\mathrm{Z}}$');
 kxlabel('time, s'); kgrid;
 
 end


### PR DESCRIPTION
## What was wrong

`coil=[Fz -HzFz Hz]` makes `evolution(...,'multichannel')` return
`answer` rows in the order Fz, -HzFz, Hz. The plotting block below it
titled subplot 1 as `$H_Z$` (actually Fz data), subplot 2 as `$F_Z$`
(actually -HzFz data), and subplot 3 as `$H_ZF_Z$` (actually Hz data).

## Why it matters physically

A user reproducing Figure 2A of the cited CIDNP paper
(https://doi.org/10.1016/j.jmr.2004.01.011) reads the proton
magnetisation trace as fluorine and vice versa, and the -HzFz curve is
shown under the pure-Fz label, inverting which spin's pumped/relaxing
dynamics is attributed to which nucleus.

## Fix

Relabelled the three subplot titles so they match the actual `coil`
order: subplot 1 -> `$F_{\mathrm{Z}}$`, subplot 2 ->
`$-H_{\mathrm{Z}}F_{\mathrm{Z}}$`, subplot 3 -> `$H_{\mathrm{Z}}$`.

## Probe

19F (channel 2 in the spin system) is pumped at rate 34.0 while 1H
(channel 1) is pumped at rate 1.3, so the Fz trace must show a much
larger range of variation than the Hz trace over the run — an
unambiguous physical fingerprint independent of the labels. The probe
checks that the fast-varying row is titled `F_Z` and the slow-varying
row is titled `H_Z`.

- Stock: `VAR_ROW1=9.671747e+00 VAR_ROW3=3.064990e-01`,
  `TITLE_ROW1=$H_{\mathrm{Z}}$`, `TITLE_ROW3=$H_{\mathrm{Z}}F_{\mathrm{Z}}$`
  -> `RESULT=FAIL` (fast-varying row mislabelled as Hz)
- Patched: same variances, `TITLE_ROW1=$F_{\mathrm{Z}}$`,
  `TITLE_ROW3=$H_{\mathrm{Z}}$` -> `RESULT=PASS`

## Finding id

F082