### PR TITLE
F083: fix factor-of-two error in singlet yield formula

### DIFF
--- a/examples/spin_chemistry/singlet_yield_nz_1.m
+++ b/examples/spin_chemistry/singlet_yield_nz_1.m
@@ -124,7 +124,7 @@ L=H+1i*R+1i*K;
 x=bicg(L,rho0,1e-8,numel(rho0));
 
 % Convention-free fractional singlet yield
-yield=real((k_cage/2)*imag(S'*x)/(k_cage*imag(EE'*x)));
+yield=real(k_cage*imag(S'*x)/(k_cage*imag(EE'*x)));
 
 end
 


### PR DESCRIPTION
## What was wrong

In `examples/spin_chemistry/singlet_yield_nz_1.m`, `cage_pair()` computed
the fractional singlet recombination yield as

    yield=real((k_cage/2)*imag(S'*x)/(k_cage*imag(EE'*x)));

## Why it matters physically

`kernel/kinetics/kinetics.m` confirms `rp_rates(1)` is the singlet and
`rp_rates(2)` the triplet recombination rate, and for the
`'exponential'` theory branch `K=-sum(rp_rates)*I=-k_cage*I` is a
uniform decay with no dynamic S/T split applied. The resolvent integral
`x=L^{-1}rho0` gives `S'*x` = integral of `P_S(t)dt` and `EE'*x` =
integral of `P_total(t)dt` = `1/k_cage`, so the physically correct
fractional yield is simply `(S'*x)/(EE'*x)`. Multiplying the numerator
by `k_cage/2` while the denominator carries `k_cage` leaves a spurious
residual factor of 1/2 that does not cancel — every singlet
recombination yield this example (and any user code copying the
pattern for radical-pair/spin-chemistry field-effect analysis) computes
is reported at half its true value, corrupting the reported MARY-curve
amplitude / reaction yield.

## Fix

Changed the numerator's `k_cage/2` to `k_cage`, so it cancels exactly
against the denominator's `k_cage`, leaving `yield=(S'*x)/(EE'*x)`.

## Probe

Evaluated the actual resolvent solution `x` for the example's
parameters (field=3 mT, k_cage=3e7, tau_c=3.3 ns, Redfield theory) and
computed both the stock and the corrected yield formula from the same
`S'*x`, `EE'*x`:

- `YIELD_STOCK=3.899301244641e-02`
- `YIELD_CORRECT=7.798602489283e-02`

The corrected value is exactly double the stock value (to solver
tolerance), confirming the fix removes precisely the reported
factor-of-two error.

## Finding id

F083