### PR TITLE
fix(examples): use a portable relative path in leu_chi_fit.m

### DIFF
--- a/examples/karplus_curves/leu_chi_fit.m
+++ b/examples/karplus_curves/leu_chi_fit.m
@@ -7,7 +7,7 @@
 function leu_chi_fit()
 
 % Run the Karplus fitter
-[A,B,C,sA,sB,sC]=karplus_fit('.\leu_chi_data',{[31 29 23 24]});
+[A,B,C,sA,sB,sC]=karplus_fit('leu_chi_data',{[31 29 23 24]});
 
 % Display the answer
 disp(['Karplus A: ' num2str(A) ', stdev ' num2str(sA)]);

--- a/interfaces/agents/spinach-knowledge/examples/karplus_curves/leu_chi_fit.md
+++ b/interfaces/agents/spinach-knowledge/examples/karplus_curves/leu_chi_fit.md
@@ -19,12 +19,12 @@ Karplus coefficients extraction from a DFT dihedral angle scan over one of the c
 
 ### Comment-guided execution stages
 
-- Lines 9-10: Run the Karplus fitter; implemented by `[A,B,C,sA,sB,sC]=karplus_fit('.\leu_chi_data',{[31 29 23 24]})`.
+- Lines 9-10: Run the Karplus fitter; implemented by `[A,B,C,sA,sB,sC]=karplus_fit('leu_chi_data',{[31 29 23 24]})`.
 - Lines 12-13: Display the answer; implemented by `disp(['Karplus A: ' num2str(A) ', stdev ' num2str(sA)])`.
 
 ### Key state/data transformations
 
-- Lines 10: computes `[A,B,C,sA,sB,sC]` using `[A,B,C,sA,sB,sC]=karplus_fit('.\leu_chi_data',{[31 29 23 24]})`.
+- Lines 10: computes `[A,B,C,sA,sB,sC]` using `[A,B,C,sA,sB,sC]=karplus_fit('leu_chi_data',{[31 29 23 24]})`.
 
 ## Implementation structure
 


### PR DESCRIPTION
## What was wrong

`examples/karplus_curves/leu_chi_fit.m` called
`karplus_fit('.\leu_chi_data', ...)` using a Windows-only backslash
path separator.

## Why it matters physically

On any non-Windows machine (the majority of Spinach's academic/HPC
user base) `filesep` is `/`, so `karplus_fit.m`'s
`dir([dir_path filesep '*.log'])` builds the literal string
`.\leu_chi_data/*.log`. MATLAB's `dir()` does not treat an embedded
backslash as a path separator on Unix, so this never matches the real
`leu_chi_data` directory that ships alongside the example.
`karplus_fit`'s `grumble()` only checks that `dir_path` is a character
array, not that it resolves to anything, so `logfiles` ends up empty
and the least-squares Karplus fit silently runs on zero data points
instead of erroring, giving a meaningless A/B/C result with no
indication of the real cause.

## Fix

Changed the path to the plain relative directory name
`'leu_chi_data'`, which resolves correctly with `filesep` on every
platform, consistent with the convention used elsewhere in the example
set (e.g. `examples/nmr_metabol/molecule_b.m` reading
`'molecule_b.xml'`) of running an example with the current directory
set to that example's own folder.

## Probe

`examples/karplus_curves/leu_chi_data` contains 35 Gaussian log files
on disk. Probe: `dir([dir_path filesep '*.log'])` file count.

Stock (`dir_path='.\leu_chi_data'`):
```
log files found: 0
```

Patched (`dir_path='leu_chi_data'`):
```
log files found: 35
```

`leu_chi_fit()` itself was also re-run end to end (with the current
directory set to `examples/karplus_curves`, as the example expects)
after the fix:
```
Karplus A: 11.1733, stdev 0.15776
Karplus B: 1.5123, stdev 0.078018
Karplus C: 0.72034, stdev 0.096386
```
instead of failing silently on an empty dataset.

Finding id: F044