### PR TITLE
fix(zfs_sampling): renormalise Gauss-Legendre weights after pruning

### DIFF
--- a/etc/molecules/zfs_sampling.m
+++ b/etc/molecules/zfs_sampling.m
@@ -76,6 +76,9 @@ W=kron(WX,WY); W=W/sum(W);
 % Ignore small weights
 D(W<tol)=[]; E(W<tol)=[]; W(W<tol)=[];
 
+% Renormalise the retained weights
+W=W/sum(W);
+
 end
 
 % Consistency enforcement


### PR DESCRIPTION
## What was wrong

`etc/molecules/zfs_sampling.m` builds a 2D Gauss-Legendre weight grid
for the (D,E) zero-field-splitting distribution and normalises it
once, `W=kron(WX,WY); W=W/sum(W);` (line 74). It then prunes
low-weight grid points, `D(W<tol)=[]; E(W<tol)=[]; W(W<tol)=[];`
(line 77), but never renormalises the retained weights afterwards.

## Why it matters physically

For the documented example call `zfs_sampling(30,5,1e-2)`, the
retained weights sum to about 0.59 instead of 1. Both example callers
(`spa_gd_dota_powder.m`, `holeburn_gd_dota_powder.m`) use the returned
`W` directly, `spectrum=spectrum+W(n)*fftshift(fft(fid,...));`, with
no renormalisation of their own. The powder ESR spectra they build
are therefore systematically under-scaled by roughly 40% in absolute
intensity relative to what the Gaussian-quadrature weighting is meant
to represent.

## Fix

Renormalise `W` immediately after the pruning step:
```matlab
% Renormalise the retained weights
W=W/sum(W);
```

## Probe

`[D,E,W]=zfs_sampling(30,5,1e-2); sum(W)`

**Stock probe output:**
```
sum(W) = 0.5918461005531839
```

**Patched probe output:**
```
sum(W) = 1.0000000000000000
```

## Finding id

F011