### PR TITLE
F087: subtract nuclear transmitter offset in endor_davies.m

### DIFF
--- a/experiments/esr_hyperfine/endor_davies.m
+++ b/experiments/esr_hyperfine/endor_davies.m
@@ -90,7 +90,7 @@ Nx=(Np+Np')/2; Ny=(Np-Np')/2i;
 
 % Soft pulse frequencies
 parameters.e_frq=parameters.e_frq-parameters.offset(1);
-parameters.n_frq=parameters.n_frq+spin(parameters.spins{2})*spin_system.inter.magnet/(2*pi);
+parameters.n_frq=parameters.n_frq+spin(parameters.spins{2})*spin_system.inter.magnet/(2*pi)-parameters.offset(2);
 
 % Pi pulse on the electron
 rho0=shaped_pulse_af(spin_system,L,Ex,Ey,parameters.rho0, parameters.e_frq,...


### PR DESCRIPTION
## What was wrong

`experiments/esr_hyperfine/endor_davies.m:92-93`:

    parameters.e_frq=parameters.e_frq-parameters.offset(1);
    parameters.n_frq=parameters.n_frq+spin(parameters.spins{2})*spin_system.inter.magnet/(2*pi);

The electron pulse frequency subtracts `parameters.offset(1)`, but the
nuclear pulse frequency only adds the nuclear Larmor term with no
subtraction of `parameters.offset(2)`.

## Why it matters physically

The function header and `grumble()` (lines 176-181) both require
`parameters.offset` to be a two-element row vector explicitly
documented as "transmitter offsets" for the electron and the nucleus
pulses. Any ENDOR simulation with a nonzero nuclear transmitter offset
(the normal case, since offsets are used to place the pulse carrier
away from resonance) gets the nuclear soft pulse centred at the wrong
frequency, silently shifting the simulated ENDOR spectrum with no error
or warning.

## Fix

Added `-parameters.offset(2)` to the nuclear pulse frequency line, so
it mirrors the electron line immediately above it.

## Probe

Extracted the exact source line and evaluated it with mock
`spin_system`/`parameters` (`offset=[0 5e4]`), comparing against the
physically correct frequency (requested frequency + nuclear Larmor term
- documented offset):

- Stock: `ACTUAL=401228298.067626 EXPECTED=401178298.067626` -> FAIL,
  off by exactly the missing 50000 Hz offset
- Patched: `ACTUAL=401178298.067626 EXPECTED=401178298.067626` -> PASS

## Finding id

F087