### PR TITLE
fix(overtone_pa): include R,K in the drift generator during the pulse (F103)

### DIFF
--- a/experiments/overtone/overtone_pa.m
+++ b/experiments/overtone/overtone_pa.m
@@ -76,7 +76,7 @@ switch parameters.method
         
         % Get the pulse Hamiltonian
         pulseop=parameters.rf_pwr*Lx;
-        pulseop=average(spin_system,pulseop/2,H,pulseop/2,omega,'matrix_log');
+        pulseop=average(spin_system,pulseop/2,H+1i*R+1i*K,pulseop/2,omega,'matrix_log');
 
         % Apply the pulse
         parameters.rho0=propagator(spin_system,pulseop,parameters.rf_dur)*parameters.rho0;
@@ -87,7 +87,7 @@ switch parameters.method
         pulse_frq=ovt_frq-parameters.rf_frq;
 
         % Apply the pulse
-        parameters.rho0=shaped_pulse_af(spin_system,H,Lx,0*Lx,parameters.rho0,pulse_frq,...
+        parameters.rho0=shaped_pulse_af(spin_system,H+1i*R+1i*K,Lx,0*Lx,parameters.rho0,pulse_frq,...
                                         parameters.rf_pwr,parameters.rf_dur,-pi/2,2,'expm');
         
 end


### PR DESCRIPTION
## What was wrong

`experiments/overtone/overtone_pa.m` computes the post-pulse state for
both the `'average'` branch (average-Hamiltonian theory via `average()`
+ `propagator()`) and the `'fplanck'` branch (`shaped_pulse_af()`) using
only the bare Hamiltonian `H` as the drift generator during the
documented pulse duration `parameters.rf_dur`. The relaxation
superoperator `R` and kinetics superoperator `K`, which the function
receives as arguments and later uses (via `overtone_a`) for the
acquisition period, are silently dropped for the pulse itself.

## Why it matters physically

The function's own documentation states that `R` must be present (non-
thermalised) for the acquisition matrix inversion in `overtone_a` to be
meaningful, i.e. the intended use case has non-negligible relaxation
over the timescales of the experiment, including `rf_dur`. Overtone
pulses in quadrupolar-nucleus NMR are long compared to conventional
pulses (hundreds of microseconds, cf. `examples/nmr_overtone/mas_glycine_1.m`
which uses `rf_dur=260e-6` s), so relaxation/kinetics during the pulse
is routinely significant. Omitting them from the pulse propagator gives
a systematically wrong post-pulse state and hence a wrong spectrum
whenever R or K are non-negligible over `rf_dur`, exactly the regime the
function is documented for.

## Fix

Use `H+1i*R+1i*K` as the drift generator passed to `average()` and to
`shaped_pulse_af()`, matching the Liouvillian convention already used
elsewhere in Spinach, e.g. `experiments/nqr/nqr_pa.m:59`
(`shaped_pulse_af(spin_system,H+1i*R+1i*K,...)`). No other code was
touched.

## Probe

Static (non-spinning) single 14N (I=1) system, `damp_rate=3e4` Hz,
`rf_dur=260e-6` s (values from `examples/nmr_overtone/mas_glycine_1.m`).
Spectrum computed with `crystal(spin_system,@overtone_pa,parameters,'qnmr')`
is compared against a hand-built reference that runs the same
`average()`/`shaped_pulse_af()` calls but correctly includes `R,K` in
the drift generator during the pulse.

**Stock (before fix):**
```
average branch relative error: 2439.60197759
fplanck branch relative error: 2439.60197774
```

**Patched (after fix):**
```
average branch relative error: 3.46215930097e-11
fplanck branch relative error: 0
```

Both branches now match the R,K-aware reference to numerical precision.

## Finding id

F103