### PR TITLE
fix(interfaces): increment GISSMO subsystem counter on a matching block

### DIFF
--- a/interfaces/gissmo/gissmo2spinach.m
+++ b/interfaces/gissmo/gissmo2spinach.m
@@ -167,12 +167,15 @@ for n=1:numel(xml.children)
             end
                     
         end
-          
+
+        % Move on to the next subsystem
+        current_subsystem=current_subsystem+1;
+
     elseif strcmpi(xml.children(n).name,'coupling_matrix')
-        
+
         % Increment subsystem counter
         current_subsystem=current_subsystem+1;
-        
+
     end
     
 end


### PR DESCRIPTION
## What was wrong

`interfaces/gissmo/gissmo2spinach.m`'s `current_subsystem` counter was
only incremented in the `elseif` branch, which fires when a
`coupling_matrix` XML element does *not* match the requested
subsystem. The `if` branch, which fires when it *does* match, never
incremented the counter.

## Why it matters physically

Once `current_subsystem` first equals the requested `subsystem` (its
initial value is 1, so this is immediate for `subsystem=1`), every
subsequent `coupling_matrix` block in the file also satisfies
`current_subsystem==subsystem` and gets processed as well, silently
overwriting `inter.zeeman.scalar{idx}` and `inter.coupling.scalar`
entries from the requested subsystem with values from later
subsystems. Calling `gissmo2spinach('molecule_b.xml',1)` therefore
returns a hybrid spin system with the wrong chemical shifts and the
wrong coupling network, with no error raised, for any multi-subsystem
GISSMO file.

## Fix

Increment `current_subsystem` after processing a matching block too,
so every `coupling_matrix` element in the file is visited exactly
once and only the requested subsystem's data ends up in the output.

## Probe

`examples/nmr_metabol/molecule_b.xml` has 3 subsystems; subsystem 1
has 13 spins with spin 1's chemical shift at 1.49275 ppm, while
subsystem 3 (7 spins, indices 1-7 again) sets spin 1's shift to
6.93530 ppm.

Stock:
```
spins returned for subsystem 1: 13
chemical shift of spin 1, ppm: 6.93530
```

Patched:
```
spins returned for subsystem 1: 13
chemical shift of spin 1, ppm: 1.49275
```

`examples/nmr_metabol/molecule_b.m` was also re-run end to end after
the fix and completes normally.

Finding id: F051