### PR TITLE
fix(spinjet): escape shell metacharacters in py_run arguments

### DIFF
--- a/interfaces/spinjet/py_run.m
+++ b/interfaces/spinjet/py_run.m
@@ -63,6 +63,9 @@ if ~isempty(arg_in)
             arg_in{inputs}=arg_in{inputs}(2:end-1);
         end
 
+        % Escape characters that are special inside double quotes
+        arg_in{inputs}=regexprep(arg_in{inputs},'([\\$`"])','\\$1');
+
         % Append the command string
         command_string=[command_string '"' arg_in{inputs} '" ']; %#ok<AGROW>
         


### PR DESCRIPTION
## What was wrong
`interfaces/spinjet/py_run.m` builds a `system()` command string by
wrapping each user-supplied argument in double quotes only, with no
escaping of shell metacharacters that remain special inside double
quotes (`$`, `` ` ``, `\`, `"`).

## Why it matters physically
Scientists pass sample/label strings, Windows-style paths, or other
free text to the Xepr instrument-control python scripts through this
function. A dollar sign, backtick, backslash, or embedded quote in
such a string is silently mangled by shell expansion before it
reaches the script, or breaks the command outright — the instrument
is then driven with the wrong argument rather than the one supplied.

## Stock probe output (fails)
```
Exception with error code (2) in echo_args_probe.py, python script
returned with error > /bin/bash: -c: line 1: unexpected EOF while
looking for matching `'
```

## Patched probe output (passes)
```
INPUT:  [a$b`c\d"e]
OUTPUT: [a$b`c\d"e]
PROBE RESULT: PASS
```

## Fix
Escape `\`, `$`, `` ` ``, and `"` with a leading backslash before
each argument is quoted and appended to the command string, so the
shell receives the literal characters the caller supplied.

## Finding id
F142