### PR TITLE
fix(overtone_dante): fold relaxation and kinetics into the DANTE preparation train

### DIFF
--- a/experiments/overtone/overtone_dante.m
+++ b/experiments/overtone/overtone_dante.m
@@ -59,6 +59,9 @@ grumble(parameters,H,R,K);
 % Get the overtone frequency
 ovt_frq=-2*spin(parameters.spins{1})*spin_system.inter.magnet/(2*pi);
 
+% Compose Liouvillian
+L=H+1i*R+1i*K;
+
 % Project pulse operators
 Lx=kron(speye(parameters.spc_dim),parameters.Lx);
 
@@ -76,13 +79,13 @@ omega=2*pi*ovt_frq-2*pi*parameters.rf_frq;
 
 % Get the pulse Hamiltonian
 pulseop=parameters.pulse_amp*Lx;
-pulseop=average(spin_system,pulseop/2,H,pulseop/2,omega,'matrix_log');
+pulseop=average(spin_system,pulseop/2,L,pulseop/2,omega,'matrix_log');
 
 % Precompute pulse propagator
 PP=propagator(spin_system,pulseop,parameters.pulse_dur);
 
 % Precompute evolution propagator
-PE=propagator(spin_system,H,cycle_length-parameters.pulse_dur);
+PE=propagator(spin_system,L,cycle_length-parameters.pulse_dur);
 
 % Combine the propagators
 P=clean_up(spin_system,PE*PP,spin_system.tols.prop_chop);


### PR DESCRIPTION
## What was wrong

In `experiments/overtone/overtone_dante.m`, the DANTE pulse propagator

```matlab
pulseop=average(spin_system,pulseop/2,H,pulseop/2,omega,'matrix_log');
...
PE=propagator(spin_system,H,cycle_length-parameters.pulse_dur);
```

was built from the bare Hamiltonian `H` alone, for both the pulse
segment and the inter-pulse evolution segment of every DANTE cycle.

## Why it matters physically

`R` and `K` are received from the context function and, per the
function's own documented contract ("relaxation must be present in
the system dynamics, non-thermalised" — see the acquisition side,
`overtone_a.m`), are required to be present. But they were never
folded into the Liouvillian anywhere in the preparation train: `H`
alone was used, silently dropping all relaxation and kinetics
throughout `n_periods*pulse_num` applications of the propagator `P`.
For any nonzero R or K acting on the timescale of the DANTE train,
this gives the wrong state handed to `overtone_a`, silently distorting
the resulting overtone spectrum.

## Fix

Compose `L=H+1i*R+1i*K` once (the standard Liouvillian used throughout
the rest of the repository), and use `L` instead of `H` in both the
`average()` call that builds the pulse Hamiltonian and the
`propagator()` call that builds the inter-pulse evolution propagator.
`average()`'s `'matrix_log'` theory is an exact algorithm that works
on any linear generator, so substituting the (generally non-Hermitian)
`L` for `H` is algebraically valid.

## Probe

14N NQI system (glycine-like parameters) in `sphten-liouv` formalism
with `damp` relaxation (rate 8000 Hz), driven through a 2-pulse,
4-period DANTE train. Compared the patched `overtone_dante()` output
against an inline reference replicating the stock (H-only, no R/K)
algorithm, both feeding into `overtone_a()`.

Stock probe output (relative mismatch, stock vs patched):
```
4.0174
```

## Finding id

F102