### PR TITLE
fix(spinxml): reject duplicate isotope entries in shielding_refs

### DIFF
--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -886,6 +886,14 @@ for n=1:numel(shielding_refs)
         error('the second part of each element of parameters.rframes must be a number.');
     end
 end
+
+% Extract isotope labels for the duplicate check below
+isotope_list=cellfun(@(x)x{1},shielding_refs,'UniformOutput',false);
+
+% Catch duplicate isotope entries in shielding_refs
+if numel(unique(isotope_list))<numel(isotope_list)
+    error('shielding_refs contains a duplicate isotope entry.');
+end
 end
 
 % People who think they know everything are a great 

--- a/interfaces/spinxml/x2spinach.m
+++ b/interfaces/spinxml/x2spinach.m
@@ -886,11 +886,7 @@ for n=1:numel(shielding_refs)
         error('the second part of each element of parameters.rframes must be a number.');
     end
 end
-
-% Extract isotope labels for the duplicate check below
 isotope_list=cellfun(@(x)x{1},shielding_refs,'UniformOutput',false);
-
-% Catch duplicate isotope entries in shielding_refs
 if numel(unique(isotope_list))<numel(isotope_list)
     error('shielding_refs contains a duplicate isotope entry.');
 end


### PR DESCRIPTION
## What was wrong
`interfaces/spinxml/x2spinach.m`'s `grumble` validated the shape of
each element of `shielding_refs` but never checked for duplicate
isotope entries. In the `'shielding'` branch (around line 543) the
loop applies `A=eye(3)*shielding_refs{k}{2}-A` for every matching
isotope entry with no break or duplicate check.

## Why it matters physically
A user who builds `shielding_refs` by merging reference tables from
more than one source (an easy, unflagged mistake) gets a silently
wrong chemical shift for that nucleus, with no warning that the
duplicate was even present.

## Stock probe output (fails)
Single 13C spin, true absolute shielding 10 ppm, duplicate reference
`{{'13C',189.7},{'13C',189.7}}` (expected shift 179.7 ppm):
```
Computed shift (Hz on diagonal / ppm): 10.00000000000000
Expected shift: 179.69999999999999
PROBE RESULT: FAIL
```
The double transform cancels out and silently returns the raw
shielding value instead of erroring or computing the correct shift.

## Patched probe output (passes)
```
CAUGHT ERROR: shielding_refs contains a duplicate isotope entry.
PROBE RESULT: PASS
```
Sanity check that a single, non-duplicate reference is unaffected:
```
Shift (no duplicate): 179.700000
SANITY: PASS
```

## Fix
Added a duplicate-isotope check to the existing `grumble` validation,
so a malformed `shielding_refs` is rejected up front with an
informative error instead of silently corrupting the shift.

## Finding id
F143