### PR TITLE
fix(examples): correct padded grid extent scaling in point_vs_distr.m

### DIFF
--- a/examples/nmr_paramag/point_vs_distr.m
+++ b/examples/nmr_paramag/point_vs_distr.m
@@ -64,8 +64,8 @@ chi=R*diag([(-ax/3+rh) (-ax/3-rh) (2*ax/3)])*R';
 % Pad density with zeros (two volumes each side) to avoid PBC effects
 pad_size=2; pad_density=padarray(rho,pad_size*size(rho),0,'both');
 
-% Update grid extents
-ext=(2*pad_size+1)*ext;
+% Update grid extents to include the padded samples
+ext=ext+[-1 1 -1 1 -1 1]*pad_size*size(rho,1)*(ext(2)-ext(1))/(npoints-1);
 
 % Compute PCS exactly using FFT method for PDE equation
 [expt_pcs,~]=kpcs(pad_density,chi,ext,[x y z],'fft');


### PR DESCRIPTION
## What was wrong

`examples/nmr_paramag/point_vs_distr.m` pads the density grid with
`padarray(rho,pad_size*size(rho),0,'both')`, which adds
`pad_size*size(rho)` samples on each side, per dimension (128 samples
per side for `pad_size=2`, `size(rho)=64`). The extent rescale
`ext=(2*pad_size+1)*ext` only accounts for a `2*pad_size+1=5`x extent
multiplier (75 A for the example's parameters), instead of the extent
implied by the true padded sample count (75.95 A).

## Why it matters physically

`kpcs` interprets the padded density array using the supplied `ext`
to assign physical coordinates to each voxel. Because the extent
update does not match the actual number of padded samples, the padded
grid's implied spacing no longer equals the original grid's spacing,
so density voxels get assigned to the wrong physical coordinates. This
corrupts the PCS values computed from the padded density grid, i.e.
the very quantity the example exists to compute and compare between
the point and multipole/distributed models.

## Fix

Recomputed the extent from the actual number of padded samples and the
pre-padding grid spacing (`(ext(2)-ext(1))/(npoints-1)`), so the padded
grid keeps exactly the same physical spacing as the original,
unpadded grid.

## Probe

Computed the grid spacing implied by the extent update for a 64^3 grid
with `pad_size=2` (the example's own parameters), and compared it to
the true pre-padding spacing.

Stock:
```
grid spacing before padding, Angstrom: 0.4761904762
grid spacing implied by the updated extent, Angstrom: 0.4702194357
relative spacing error: 0.0125391850
```

Patched:
```
grid spacing before padding, Angstrom: 0.4761904762
grid spacing implied by the updated extent, Angstrom: 0.4761904762
relative spacing error: 0.0000000000
```

`point_vs_distr()` was also re-run end to end after the fix
(`rng(1)`, headless) and completed normally, recovering multipole
moments close to the true density's moments.

Finding id: F053