### PR TITLE
s2m.m: use |J| and |delta_v| for the echo-train repetition count

### DIFF
--- a/experiments/singlets/s2m.m
+++ b/experiments/singlets/s2m.m
@@ -34,7 +34,7 @@ grumble(L,Hx,Hy,rho,J,delta_v);
 t=1/(4*sqrt(J^2+delta_v^2));
 
 % Repetition count
-m1=floor(pi*J/(2*delta_v));
+m1=floor(pi*abs(J)/(2*abs(delta_v)));
 if mod(m1,2)~=0, m1=m1+1; end
 
 % Pulse sequence

--- a/interfaces/agents/spinach-knowledge/experiments/singlets/s2m.md
+++ b/interfaces/agents/spinach-knowledge/experiments/singlets/s2m.md
@@ -25,7 +25,7 @@ S2M sequence of Pileio and Levitt. Syntax: rho=s2m(spin_system,L,Hx,Hy,rho,J,del
 
 - Lines 30-31: Check consistency; implemented by `grumble(L,Hx,Hy,rho,J,delta_v)`.
 - Lines 33-34: Evolution time; implemented by `t=1/(4*sqrt(J^2+delta_v^2))`.
-- Lines 36-37: Repetition count; implemented by `m1=floor(pi*J/(2*delta_v))`.
+- Lines 36-37: Repetition count; implemented by `m1=floor(pi*abs(J)/(2*abs(delta_v)))`.
 - Lines 40-41: Pulse sequence; implemented by `for n=1:m1/2`.
 
 ### Control flow inferred from the code
@@ -37,7 +37,7 @@ S2M sequence of Pileio and Levitt. Syntax: rho=s2m(spin_system,L,Hx,Hy,rho,J,del
 ### Key state/data transformations
 
 - Lines 34: computes `t` using `t=1/(4*sqrt(J^2+delta_v^2))`.
-- Lines 37: computes `m1` using `m1=floor(pi*J/(2*delta_v))`.
+- Lines 37: computes `m1` using `m1=floor(pi*abs(J)/(2*abs(delta_v)))`.
 - Lines 42: computes `rho` using `rho=step(spin_system,L,rho,t)`.
 
 ### Local helper functions


### PR DESCRIPTION
## What was wrong

`experiments/singlets/s2m.m` computes the number of spin-echo blocks in
the S2M sequence as `m1=floor(pi*J/(2*delta_v))`. Neither `grumble()`
nor the surrounding code constrains the signs of `J` and `delta_v`. When
they have opposite signs (an entirely ordinary situation: many
J-couplings are negative, and the sign of `delta_v` depends purely on
which of the two spins is labelled first), `m1` comes out negative, so
both `for n=1:m1/2` and `for n=1:m1` loops execute zero times. Both echo
trains are silently skipped: the function returns without error but
never performs the documented singlet-to-magnetisation transfer.

## Why it matters physically

The repetition count in the M2S/S2M family of sequences (Pileio &
Levitt) is set by the ratio of the magnitudes `|J|/|delta_v|`; the
signs of `J` and `delta_v` are sign-convention artefacts (coupling
sign, spin-labelling order) and have no bearing on how many echo
blocks are needed. A caller who supplies a negative `J` (e.g. a
geminal or other conventionally-negative coupling) together with a
positive `delta_v` gets a function that silently does nothing to the
input state instead of performing the intended long-lived-singlet
transfer, with no error or warning to flag the problem.

## Stock probe

Two-spin `13C-13C` system (9.4 T, offsets ±0.03 ppm giving `delta_v=6`
Hz), starting from singlet order, `s2m` called with `J=55` Hz
(matching the sign convention used in `s2m_example.m`) as a control,
and `J=-55` Hz as the test case, reading out longitudinal
magnetisation:

```
Control (J=+55, delta_v=+6):   0.24075+8.0008e-17i
Test    (J=-55, delta_v=+6):   0
```

The negative-`J` case produces zero transfer.

## Patched probe

Same inputs, after changing the repetition-count line to
`m1=floor(pi*abs(J)/(2*abs(delta_v)));`:

```
Control (J=+55, delta_v=+6):   0.24075+8.0008e-17i
Test    (J=-55, delta_v=+6):   -0.24075-8.0008e-17i
```

The negative-`J` case now transfers with the same magnitude as the
control (the sign flip is the expected physical consequence of
inverting the coupling Hamiltonian).

## Finding id

F111