### PR TITLE
fix(kernel): recover correct sign in euler_sup beta=pi branch

### DIFF
--- a/kernel/conventions/transforms/euler_sup.m
+++ b/kernel/conventions/transforms/euler_sup.m
@@ -61,8 +61,11 @@ elseif (abs(dcm_comp(3,3)+1)<1e-12)&&...
     % Recover alpha-gamma from both matrix elements
     alpha_m_gamma=atan2(-dcm_comp(2,1),-dcm_comp(1,1));
 
-    % Return special case, sign-correct
-    gam=-alpha_m_gamma/2; rot_cmp=[-gam pi gam];
+    % Recover the third angle
+    gam=-alpha_m_gamma/2;
+
+    % Return special case
+    rot_cmp=[-gam pi gam];
 
 else
 

--- a/kernel/conventions/transforms/euler_sup.m
+++ b/kernel/conventions/transforms/euler_sup.m
@@ -58,14 +58,11 @@ elseif (abs(dcm_comp(3,3)+1)<1e-12)&&...
        (abs(rot_one(1)-rot_two(1))<1e-12)&&...
        (abs(rot_one(3)-rot_two(3))<1e-12)
 
-    % Clamp the cosine argument 
-    dcm_11=max(min(dcm_comp(1,1),1),-1);
+    % Recover alpha-gamma from both matrix elements
+    alpha_m_gamma=atan2(-dcm_comp(2,1),-dcm_comp(1,1));
 
-    % Recover the third angle 
-    gam=(acos(dcm_11)-pi)/2;
-
-    % Return special case
-    rot_cmp=[-gam pi gam];
+    % Return special case, sign-correct
+    gam=-alpha_m_gamma/2; rot_cmp=[-gam pi gam];
 
 else
 


### PR DESCRIPTION
## What was wrong
`kernel/conventions/transforms/euler_sup.m`'s singular `beta=pi`
branch recovered the third angle with `gam=(acos(dcm_comp(1,1))-pi)/2`
— i.e. from a cosine alone. `acos` always returns a value in
`[0,pi]`, so this recovers `|alpha-gamma|/2` rather than the signed
`alpha-gamma`, discarding sign information that is carried by the
off-diagonal entries of the composite DCM.

## Why it matters physically
Any composition of two rotations whose Euler `beta=pi` singularity is
hit — an entirely ordinary case, not an edge-of-range situation — can
get a composite orientation that is wrong by O(1) in Frobenius norm:
wrong axis system, wrong tensor rotation, wrong simulated spectrum
for whichever crystal/molecular orientation triggers this branch.

## Stock probe output (fails)
Composing `[-pi/4 pi/2 pi/4]` with itself, a genuine `beta=pi`
composite whose true ZYZ representation is `[-pi/4 pi pi/4]`:
```
rot_cmp = [0.7853981634 3.1415926536 -0.7853981634]
Frobenius norm of reconstruction error: 2.8284271247
PROBE RESULT: FAIL
```

## Patched probe output (passes)
```
rot_cmp = [-0.7853981634 3.1415926536 0.7853981634]
Frobenius norm of reconstruction error: 0.0000000000
PROBE RESULT: PASS
```

## Fix
`R=Rz(alpha)Ry(beta)Rz(gamma)` at `beta=pi` reduces to
`Ry(pi)Rz(gamma-alpha)`, giving
`dcm_comp(1,1)=-cos(alpha-gamma)` and
`dcm_comp(2,1)=-sin(alpha-gamma)`. Recovering `alpha-gamma` via
`atan2(-dcm_comp(2,1),-dcm_comp(1,1))` uses both matrix elements and
therefore preserves the sign that a plain `acos` throws away.
Regression-checked against the pre-existing identity-rotation branch
and a normal (non-singular) composition, both unaffected.

## Finding id
F147