### PR TITLE
ufmq.m: correct documented parameter name to nWURST

### DIFF
--- a/experiments/spen/ufmq.m
+++ b/experiments/spen/ufmq.m
@@ -34,7 +34,7 @@
 %
 % parameters.chirptype      can be 'wurst' or 'smoothed'
 %
-% parameters.smfactor       smoothing factor for the pulse
+% parameters.nWURST         chirp pulse smoothing parameter
 %
 % Outputs:
 %


### PR DESCRIPTION
## What was wrong

The documentation header of `experiments/spen/ufmq.m` advertised
`parameters.smfactor` as the chirp-pulse smoothing field, but the
implementation reads and requires `parameters.nWURST`: the
`chirp_pulse` call at line 67 passes `parameters.nWURST`, and
`grumble()` explicitly requires the field to be present, erroring
"should be specified in parameters.nWURST variable" if it is missing.

## Why it matters physically

A user who builds their `parameters` struct exactly as documented
(`parameters.smfactor`) gets an immediate crash instead of a working
ultrafast multiple-quantum SPEN sequence — the function is unusable
without reverse-engineering the field name from the source. Checking
the repository's own working callers
(`examples/nmr_spen/ufmq_2spin.m`, `ufmq_4spin.m`, `ufmq_6spin.m`)
shows they all already use `parameters.nWURST`, confirming that the
implementation and its real-world callers are correct and it is the
header text that is stale. The fix corrects the documentation to
match the implementation rather than changing working code and three
working examples.

## Stock probe

Minimal grumble-level harness with a dummy spin system, calling `ufmq`
with `parameters` built exactly per the documented header:

```
Documented-field call (smfactor): smoothing factor should be specified in parameters.nWURST variable.
nWURST-field call: no error (passed grumble and ran)
```

## Patched probe

Same harness after the documentation fix (behaviour is identical,
since only a comment line changed, confirming no regression):

```
Documented-field call (smfactor): smoothing factor should be specified in parameters.nWURST variable.
nWURST-field call: no error (passed grumble and ran)
```

## Finding id

F113