### PR TITLE
fix(spinjet): convert numeric acquisition prefix before reading files

### DIFF
--- a/interfaces/spinjet/awg_interface.m
+++ b/interfaces/spinjet/awg_interface.m
@@ -84,6 +84,9 @@ switch awg_cmd
         % Acquire data from spectometer
         py_run(spin_system,'Xepr_getdata',cmd_input);
         
+        % Match the numeric-to-string conversion that py_run applies internally
+        if ~ischar(cmd_input{3}), cmd_input{3}=num2str(cmd_input{3}); end
+        
         % Save x axis, imaginary, and real parts of the signal
         data.X  = dlmread([cmd_input{3} '_X.txt']);  %#ok<DLMRD> 
         data.rY = dlmread([cmd_input{3} '_rY.txt']); %#ok<DLMRD> 


### PR DESCRIPTION
## What was wrong

`interfaces/spinjet/py_run.m` converts a non-char element of `arg_in`
to a string only inside its own local copy
(`arg_in{inputs}=num2str(...)`). Cell arrays are passed by value in
MATLAB, so this conversion is not visible to the caller.
`interfaces/spinjet/awg_interface.m`'s `acquire_data` case then builds
`[cmd_input{3} '_X.txt']` (and `_rY.txt`/`_iY.txt`) directly from its
own untouched `cmd_input`, not the converted copy `py_run` used
internally.

## Why it matters physically

`py_run` explicitly supports numeric acquisition-file prefixes (it
converts them with `num2str` before passing them to the python
script). If a scientist passes a numeric prefix, the filenames MATLAB
reads back with `dlmread` do not match the files the python script
actually wrote — a numeric double gets concatenated as a character
code rather than its decimal representation — causing a
file-not-found error or, worse, silently reading an unrelated
same-named file as the acquired spectrum.

## Stock probe output

A stub `py_run.m` shadowing the real one on the path avoids any
Xepr/Python dependency; pre-written `12345_X.txt`/`_rY.txt`/`_iY.txt`
files mimic what `py_run`'s `num2str` conversion would produce for a
numeric acquisition prefix, `cmd_input={'a','b',12345}`:

```
awg_interface raised: The file '〹_X.txt' could not be opened because: No such file or directory
PROBE FAIL: numeric prefix not converted, filenames do not match python output
```

(`char(12345)` is the CJK character U+3039, confirming the raw numeric
value was concatenated instead of being converted.)

## Patched probe output

```
data.X size: 2x3
PROBE PASS: numeric prefix converted, files read correctly
```

## Finding id

F141