### PR TITLE
fix(cell/totsum): preserve input class for dense-path summation

### DIFF
--- a/kernel/overloads/@cell/totsum.m
+++ b/kernel/overloads/@cell/totsum.m
@@ -43,8 +43,8 @@ if sparse_path
     
 else
     
-    % Run full matrix addition
-    S=zeros(size(A{1}));
+    % Run full matrix addition, preserving the class of the input
+    S=zeros(size(A{1}),class(A{1}));
     for n=1:numel(A)
         S=S+A{n};
     end


### PR DESCRIPTION
## What was wrong

`kernel/overloads/@cell/totsum.m` sums a cell array of numeric matrices.
On the dense path, the accumulator was always initialised as `double`
(`S=zeros(size(A{1}))`), then `S=S+A{n}` accumulated over the cell
array. The `grumble` consistency check only verifies `isnumeric(A{n})`,
which is `true` for integer classes (`int8`/`int16`/`int32`/etc), so a
cell array of non-scalar integer-typed matrices passes validation but
then crashes: MATLAB forbids `double + integer` for non-scalar operands.

## Why it matters physically

Summing cell arrays of integer-typed matrices (index/count/mask arrays)
is a documented, accepted use of this function. A scientist who follows
the documented interface and passes such a cell array gets a hard crash
instead of the sum.

## Fix

Initialise the dense-path accumulator with the class of the input
(`S=zeros(size(A{1}),class(A{1}))`) instead of forcing `double`. This
preserves existing behaviour for `double` inputs (unchanged) and fixes
integer-class inputs.

## Stock probe output

```
ERROR: Integers can only be combined with integers of the same class, or scalar doubles.
```

## Patched probe output

```
SUCCESS
    6    8
   10   12

int32
```

Double and sparse paths re-verified unaffected (same numeric output,
`class` unchanged).

Finding id: F189