### PR TITLE
fix(rcv/plus): stop misrouting 1x1 rcv+rcv addition through scalar path

### DIFF
--- a/kernel/overloads/@rcv/plus.m
+++ b/kernel/overloads/@rcv/plus.m
@@ -23,13 +23,13 @@ function C=plus(A,B)
 grumble(A,B);
 
 % Process the special cases
-if isa(A,'rcv')&&isscalar(B)&&isnumeric(B)
+if isa(A,'rcv')&&(~isa(B,'rcv'))&&isscalar(B)&&isnumeric(B)
 
     % Explain the refusal to add a scalar to an RCV object
     error('adding a scalar makes a matrix non-sparse; inflate manually first.');
 
 % Add a scalar to an RCV sparse matrix
-elseif isa(B,'rcv')&&isscalar(A)&&isnumeric(A)
+elseif isa(B,'rcv')&&(~isa(A,'rcv'))&&isscalar(A)&&isnumeric(A)
     
     % Explain the refusal to add a scalar to an RCV object
     error('adding a scalar makes a matrix non-sparse; inflate manually first.');


### PR DESCRIPTION
## What was wrong

`kernel/overloads/@rcv/plus.m` has special-case branches meant to
reject adding a plain MATLAB numeric scalar to an RCV sparse matrix
(because that would densify it). The guard was
`isa(A,'rcv')&&isscalar(B)&&isnumeric(B)`. The `rcv` class overloads
`isnumeric` to always return `true`, and `isscalar` is size-based (via
the class's overloaded `size()`, which returns `[numRows numCols]`).
Consequently, when `B` is itself an ordinary RCV object representing a
genuine 1-by-1 matrix, both `isscalar(B)` and `isnumeric(B)` are true,
so the "reject scalar addition" branch fires and the legitimate
`A+B` (RCV+RCV) addition is refused, even though the real RCV+RCV
addition branch further down handles this case correctly for every
other matrix size.

Note: investigation showed the broader claim in the finding write-up
(that this misroutes *all* ordinary rcv+rcv addition, not just the
1-by-1 case) does not hold — `isscalar` on an RCV object correctly
reflects the underlying matrix dimensions for non-1x1 matrices via the
overloaded `size()`, so 2x2 (and larger) RCV+RCV addition already
worked. The reproducible defect is specifically the 1-by-1 case.

## Why it matters physically

1-by-1 sparse matrices are a legitimate, common degenerate case (e.g.
single-spin operators, scalar coupling blocks extracted from a larger
sparse structure). Addition of two such RCV objects should return
their sum like any other RCV+RCV addition; instead it hard-errors.

## Fix

Excluded the case where the "scalar" operand is itself an `rcv` object
from both scalar-rejection branches, so the rejection now only fires
for genuine MATLAB numeric scalars, and RCV+RCV addition (of any size,
including 1x1) falls through to the correct addition branch.

## Stock probe output

```
1x1 ERROR: adding a scalar makes a matrix non-sparse; inflate manually first.
```

## Patched probe output

```
1x1 SUCCESS: 8
2x2 SUCCESS
     1     3
     4     2

scalar reject OK: adding a scalar makes a matrix non-sparse; inflate manually first.
```

Confirms the fix resolves the 1x1 case, leaves larger RCV+RCV addition
unaffected, and preserves the intended rejection of genuine numeric
scalar addition.

Finding id: F191