### PR TITLE
fix(kernel): support stacked states in evolution() multichannel mode

### DIFF
--- a/interfaces/agents/spinach-knowledge/kernel/evolution.md
+++ b/interfaces/agents/spinach-knowledge/kernel/evolution.md
@@ -116,10 +116,14 @@ Time evolution function. Performs all types of time propagation with automatic t
 - tial state) or a matrix (if starting from a
 - stack of initial states).
 - 'multichannel' -returns the time dynamics of several
-- observables as rows of a matrix. Note
-- that destination state screening may be
-- less efficient when there are multiple
-- destinations to screen against.
+- observables as rows of a matrix (if
+- starting from a single initial state)
+- or as a channels-by-time-by-states
+- array (if starting from a stack of
+- initial states). Note that destination
+- state screening may be less efficient
+- when there are multiple destinations
+- to screen against.
 - coil -the detection state, used when 'observable' is specified as
 - the output option. If 'multichannel' is selected, the coil
 - should contain multiple columns corresponding to individual

--- a/interfaces/agents/spinach-knowledge/kernel/krylov.md
+++ b/interfaces/agents/spinach-knowledge/kernel/krylov.md
@@ -102,10 +102,14 @@ Krylov propagation function. Avoids matrix exponentiation, but can be slow. Shou
 - tial state) or a matrix (if starting from a
 - stack of initial states).
 - 'multichannel' -returns the time dynamics of several
-- observables as rows of a matrix. Note
-- that destination state screening may be
-- less efficient when there are multiple
-- destinations to screen against.
+- observables as rows of a matrix (if
+- starting from a single initial state)
+- or as a channels-by-time-by-states
+- array (if starting from a stack of
+- initial states). Note that destination
+- state screening may be less efficient
+- when there are multiple destinations
+- to screen against.
 - coil -the detection state, used when 'observable' is specified as
 - the output option. If 'multichannel' is selected, the coil
 - should contain multiple columns corresponding to individual

--- a/interfaces/agents/spinach-knowledge/kernel/krylov.md
+++ b/interfaces/agents/spinach-knowledge/kernel/krylov.md
@@ -42,7 +42,7 @@ Krylov propagation function. Avoids matrix exponentiation, but can be slow. Shou
 - Lines 144-145: Preallocate the answer; implemented by `answer=zeros([(nsteps+1) size(rho,2)],'like',1i)`.
 - Lines 147-148: Set the initial point; implemented by `answer(1,:)=gather(coil'*rho)`.
 - Lines 156-157: Assign the answer; implemented by `answer(n+1,:)=gather(coil'*rho)`.
-- Lines 170-171: Preallocate the answer; implemented by `answer=zeros([size(coil,2) (nsteps+1)],'like',1i)`.
+- Lines 170-171: Preallocate the answer; implemented by `answer=zeros([size(coil,2) (nsteps+1) size(rho,2)],'like',1i)`.
 
 ### Control flow inferred from the code
 

--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -41,10 +41,14 @@
 %                               stack of initial states).
 %
 %                'multichannel' - returns the time dynamics of several
-%                                 observables as rows of a matrix. Note
-%                                 that destination state screening may be
-%                                 less efficient when there are multiple
-%                                 destinations to screen against.
+%                                 observables as rows of a matrix (if
+%                                 starting from a single initial state)
+%                                 or as a channels-by-time-by-states
+%                                 array (if starting from a stack of
+%                                 initial states). Note that destination
+%                                 state screening may be less efficient
+%                                 when there are multiple destinations
+%                                 to screen against.
 %
 %      coil   - the detection state, used when 'observable' is specified as
 %               the output option. If 'multichannel' is selected, the coil
@@ -619,7 +623,7 @@ switch spin_system.bas.formalism
                 end
                 
                 % Preallocate the answer
-                answer=zeros([size(coil,2) (nsteps+1)],'like',1i);
+                answer=zeros([size(coil,2) (nsteps+1) size(rho,2)],'like',1i);
                 
                 % Loop over independent subspaces
                 parfor (sub=1:nsubs,nworkers)
@@ -643,7 +647,7 @@ switch spin_system.bas.formalism
                         P=propagator(spin_system,L_loc,timestep);
                         
                         % Preallocate the local answer
-                        answer_loc=zeros([size(coil_loc,2) (nsteps+1)],'like',1i);
+                        answer_loc=zeros([size(coil_loc,2) (nsteps+1) size(rho_loc,2)],'like',1i);
                         
                         % Adapt to the target device
                         if ismember('gpu',spin_system.sys.enable)
@@ -656,7 +660,7 @@ switch spin_system.bas.formalism
                             
                             % Propagate the system
                             for n=1:(nsteps+1)
-                                answer_loc(:,n)=gather(coil_loc'*rho_loc);
+                                answer_loc(:,n,:)=gather(coil_loc'*rho_loc);
                                 rho_loc=P*rho_loc;
                             end
                             
@@ -667,7 +671,7 @@ switch spin_system.bas.formalism
                             
                             % Propagate the system
                             for n=1:(nsteps+1)
-                                answer_loc(:,n)=coil_loc'*rho_loc;
+                                answer_loc(:,n,:)=coil_loc'*rho_loc;
                                 rho_loc=P*rho_loc;
                             end
                         

--- a/kernel/krylov.m
+++ b/kernel/krylov.m
@@ -36,10 +36,14 @@
 %                            stack of initial states).
 %
 %             'multichannel' - returns the time dynamics of several
-%                              observables as rows of a matrix. Note
-%                              that destination state screening may be
-%                              less efficient when there are multiple
-%                              destinations to screen against.
+%                              observables as rows of a matrix (if
+%                              starting from a single initial state)
+%                              or as a channels-by-time-by-states
+%                              array (if starting from a stack of
+%                              initial states). Note that destination
+%                              state screening may be less efficient
+%                              when there are multiple destinations
+%                              to screen against.
 %
 %   coil   - the detection state, used when 'observable' is specified as
 %            the output option. If 'multichannel' is selected, the coil
@@ -168,10 +172,10 @@ switch output
     case 'multichannel'
         
         % Preallocate the answer
-        answer=zeros([size(coil,2) (nsteps+1)],'like',1i);
+        answer=zeros([size(coil,2) (nsteps+1) size(rho,2)],'like',1i);
         
         % Set the initial point
-        answer(:,1)=answer(:,1)+gather(coil'*rho);
+        answer(:,1,:)=gather(coil'*rho);
         
         % Loop over steps
         for n=1:nsteps
@@ -180,7 +184,7 @@ switch output
             rho=step(spin_system,L,rho,timestep);
             
             % Assign the answer
-            answer(:,n+1)=gather(coil'*rho);
+            answer(:,n+1,:)=gather(coil'*rho);
             
             % Inform the user
             if (n==nsteps)||(toc(feedback)>1)


### PR DESCRIPTION
## What was wrong
`kernel/evolution.m` documents that stacks of initial states are
supported by `'final'`, `'refocus'`, `'observable'`, and
`'multichannel'` evolution. In the exact-propagator branch of the
`'multichannel'` case, `answer_loc` was preallocated as
`[channels x (nsteps+1)]` and each step assigned the full
`[channels x states]` overlap matrix `coil_loc'*rho_loc` into the
single column `answer_loc(:,n)`, which is a dimension-mismatch
assignment whenever `rho` has more than one column.

## Why it matters physically
A user running documented wavefunction (or Liouville-space) `'multi-
channel'` evolution with a stack of initial states — a normal way to
evaluate several starting conditions against several observables at
once — gets an immediate crash instead of the documented result.

## Stock probe output (fails)
Two-channel coil, two-column state stack, small system so the exact
propagator branch (not Krylov) is taken:
```
CAUGHT ERROR: Unable to perform assignment because the size of the
left side is 2-by-1 and the size of the right side is 2-by-2.
PROBE RESULT: FAIL
```

## Patched probe output (passes)
```
size(answer)=[2  6  2]
PROBE RESULT: PASS
```

Full check against direct propagator-action references:
```
single-state size=[2  6] ndims=2
single-state max abs diff vs reference: 0.000e+00
stack size=[2  6  2]
stack column 1 max abs diff: 1.067e-17
stack column 2 max abs diff: 1.067e-17
PROBE RESULT: PASS
```

## Fix
`answer`/`answer_loc` are now preallocated as
`[channels x (nsteps+1) x states]` instead of
`[channels x (nsteps+1)]`, and `coil_loc'*rho_loc` is assigned
directly into `answer_loc(:,n,:)` (MATLAB accepts a same-numel 2-D
assignment into a 3-D slice without an explicit reshape). Because
MATLAB drops a trailing singleton dimension, the previously-working
single-state case keeps its exact 2-D output shape and values.
`kernel/dynamic_propagation_frontends`, the existing regression test
covering `evolution()`'s `'multichannel'` mode, passes unchanged. The
documentation header is updated to state the
channels-by-time-by-states output shape for the stack case.

## Finding id
F152