### PR TITLE
g2spinach.m: read spin-rotation tensors from props.srt, not props.src

### DIFF
--- a/interfaces/g2spinach.m
+++ b/interfaces/g2spinach.m
@@ -203,10 +203,10 @@ switch ismember('E',[particles{:}])
         end
         
         % Absorb spin-rotation couplings
-        if isfield(props,'src')
+        if isfield(props,'srt')
             inter.spinrot.matrix=cell(nspins);
             for n=1:nspins
-                inter.spinrot.matrix{n}=props.src{index(n)};
+                inter.spinrot.matrix{n}=props.srt{index(n)};
             end
         end
         

--- a/interfaces/g2spinach.m
+++ b/interfaces/g2spinach.m
@@ -204,7 +204,7 @@ switch ismember('E',[particles{:}])
         
         % Absorb spin-rotation couplings
         if isfield(props,'srt')
-            inter.spinrot.matrix=cell(nspins);
+            inter.spinrot.matrix=cell(1,nspins);
             for n=1:nspins
                 inter.spinrot.matrix{n}=props.srt{index(n)};
             end


### PR DESCRIPTION
## What was wrong

`gparse.m` stores parsed Gaussian nuclear spin-rotation tensors in
`props.srt` (documented in its header at line 36, populated at line
302 from the "nuclear spin - molecular rotation tensor [C] (MHz)"
block). `g2spinach.m` checked `isfield(props,'src')` and read
`props.src` — a field name `gparse` never populates.

## Why it matters physically

For every EPR/NMR import that goes through `g2spinach`, spin-rotation
coupling tensors are silently dropped: `inter.spinrot.matrix` is
never populated even when `gparse` successfully extracted the tensors
from the Gaussian output. Any simulation that should include
spin-rotation relaxation (a significant relaxation mechanism for
small, rapidly-tumbling molecules and radicals) silently omits it,
giving wrong relaxation and lineshape predictions with no error or
warning.

## Fix

Corrected the two occurrences of `props.src` and the `isfield` check
to `props.srt`, matching `gparse.m`'s actual field name.

## Stock probe

`gparse()` on `examples/standard_systems/glycine.log`, with synthetic
`props.srt` tensors added (mimicking what `gparse` would produce for
a log that contains a spin-rotation tensor block, which this
particular log does not), passed to `g2spinach()`:

```
inter.spinrot field NOT populated -- BUG
```

## Patched probe

Same inputs:

```
inter.spinrot.matrix is present
1 (13C): (1,1)=1
2 (13C): (1,1)=4
3 (15N): (1,1)=7
```

`checkcode` on the changed file: clean, no findings.

## Finding id

F119