### PR TITLE
fix(ttclass/amensum): store the solved last core for single-core trains

### DIFF
--- a/kernel/overloads/@ttclass/amensum.m
+++ b/kernel/overloads/@ttclass/amensum.m
@@ -195,7 +195,7 @@ if all(all(rnk==1))
             else
                 
                 % Save the untruncated last core
-                y.cores{k,1} = reshape(ynew, [ry(k),sz(k,1),sz(k,2),ry(k+1)]);
+                y.cores{k,1}=reshape(ynew,[ry(k),sz(k,1),sz(k,2),ry(k+1)]);
                 
             end
             

--- a/kernel/overloads/@ttclass/amensum.m
+++ b/kernel/overloads/@ttclass/amensum.m
@@ -192,6 +192,11 @@ if all(all(rnk==1))
                     end
                 end
                 
+            else
+                
+                % Save the untruncated last core
+                y.cores{k,1} = reshape(ynew, [ry(k),sz(k,1),sz(k,2),ry(k+1)]);
+                
             end
             
         end


### PR DESCRIPTION
## What was wrong

`kernel/overloads/@ttclass/amensum.m` sums buffered rank-one tensor
train terms into a single tensor train using an AMEn-style sweep. In
the main sweep loop, the freshly solved core `ynew` is only written
back to `y.cores{k,1}` inside `if k<d` (truncation branch), because
that branch is also where the non-orthogonal factor is pushed into the
next core. For a multi-core train (`d>1`) this omission is masked: the
untouched last core becomes core 1 on the next half-sweep (after
`revert`) and gets stored correctly then. For a single-core train
(`d==1`), the sweep never reverses onto a different core, so the
solved value is never written anywhere, and `y` keeps the random
initial guess generated earlier by `ttort(rand(x,opts.init_guess_rank),-1)`,
scaled by the running normalisation factor. No error is raised.

## Why it matters physically

Summing buffered rank-one tensor-train terms for a one-mode/one-site
system (`d==1`) is a legitimate, small degenerate case (e.g. summing
scalar or single-spin operator contributions). The function silently
returns a wrong, effectively random result instead of erroring or
computing the sum.

## Fix

Added the missing `else` branch that stores the untruncated, freshly
solved core into `y.cores{k,1}` when `k==d` (i.e. whenever the
truncation/push-forward path does not apply). This mirrors what
already happens implicitly for interior cores via truncation, and for
`d>1` this branch only ever fires for the current sweep's boundary
core, which is corrected on the next half-sweep in any case, so
multi-core behaviour is unaffected.

## Stock probe output (single 2x2 core, ttclass([3,5],{[1 0;0 2],[0 1;1 0]},[0,0]))

```
expected:
     3     5
     5     6

got:
    4.5900    0.0013
    7.9283    3.3277

max abs diff: 4.99874
```

## Patched probe output

```
expected:
     3     5
     5     6

got:
     3     5
     5     6

max abs diff: 0
```

Multi-core case (2 cores, buffered sum of 2 rank-one terms) re-verified
against `full(x)` ground truth after the fix: max abs diff 3.55e-15,
i.e. unaffected within floating-point round-off.

Finding id: F194