### PR TITLE
fix(ttclass): use int64 intmax in numel() overflow check

### DIFF
--- a/interfaces/agents/spinach-knowledge/kernel/overloads/@ttclass/numel.md
+++ b/interfaces/agents/spinach-knowledge/kernel/overloads/@ttclass/numel.md
@@ -24,6 +24,7 @@ Number of elements in the matrix represented by a tensor train. Syntax: n=numel(
 - Lines 24-25: Check consistency; implemented by `grumble(tt)`.
 - Lines 27-28: Compute the number of elements exactly; implemented by `n=prod(int64(sizes(tt)),'all','native')`.
 - Lines 30-31: Check for overflow; implemented by `if n>flintmax`.
+- Lines 35-36: Return a double; implemented by `n=double(n)`.
 
 ### Control flow inferred from the code
 
@@ -32,6 +33,7 @@ Number of elements in the matrix represented by a tensor train. Syntax: n=numel(
 ### Key state/data transformations
 
 - Lines 28: computes `n` using `n=prod(int64(sizes(tt)),'all','native')`.
+- Lines 36: computes `n` using `n=double(n)`.
 
 ### Local helper functions
 
@@ -59,8 +61,9 @@ Number of elements in the matrix represented by a tensor train. Syntax: n=numel(
 - Note: for large spin systems, the result may be too large
 - to be represented exactly as a double.
 - Check consistency
-- Compute the number of elements
-- Check for infinities
+- Compute the number of elements exactly
+- Check for overflow
+- Return a double
 - Consistency enforcement
 - If it had been possible to build the tower of Babel without
 

--- a/interfaces/agents/spinach-knowledge/kernel/overloads/@ttclass/numel.md
+++ b/interfaces/agents/spinach-knowledge/kernel/overloads/@ttclass/numel.md
@@ -22,16 +22,16 @@ Number of elements in the matrix represented by a tensor train. Syntax: n=numel(
 ### Comment-guided execution stages
 
 - Lines 24-25: Check consistency; implemented by `grumble(tt)`.
-- Lines 27-28: Compute the number of elements; implemented by `n=prod(prod(sizes(tt)))`.
-- Lines 30-31: Check for infinities; implemented by `if n>intmax`.
+- Lines 27-28: Compute the number of elements exactly; implemented by `n=prod(int64(sizes(tt)),'all','native')`.
+- Lines 30-31: Check for overflow; implemented by `if n>flintmax`.
 
 ### Control flow inferred from the code
 
-- Line 31: conditional branch on `n>intmax`.
+- Line 31: conditional branch on `n>flintmax`.
 
 ### Key state/data transformations
 
-- Lines 28: computes `n` using `n=prod(prod(sizes(tt)))`.
+- Lines 28: computes `n` using `n=prod(int64(sizes(tt)),'all','native')`.
 
 ### Local helper functions
 
@@ -47,7 +47,7 @@ Number of elements in the matrix represented by a tensor train. Syntax: n=numel(
 
 - n -an integer
 - Note: for large spin systems, the result may be too large
-- to fit into the 64-bit integer.
+- to be represented exactly as a double.
 
 ## Implementation structure
 
@@ -57,7 +57,7 @@ Number of elements in the matrix represented by a tensor train. Syntax: n=numel(
 - tt -tensor train object
 - n -an integer
 - Note: for large spin systems, the result may be too large
-- to fit into the 64-bit integer.
+- to be represented exactly as a double.
 - Check consistency
 - Compute the number of elements
 - Check for infinities

--- a/kernel/overloads/@ttclass/numel.m
+++ b/kernel/overloads/@ttclass/numel.m
@@ -28,7 +28,7 @@ grumble(tt);
 n=prod(prod(sizes(tt)));
 
 % Check for infinities
-if n>intmax
+if n>intmax('int64')
     error('the number of elements exceeds Matlab''s intmax.');
 end
 

--- a/kernel/overloads/@ttclass/numel.m
+++ b/kernel/overloads/@ttclass/numel.m
@@ -12,7 +12,7 @@
 %     n  - an integer
 %
 % Note: for large spin systems, the result may be too large
-%       to fit into the 64-bit integer.
+%       to be represented exactly as a double.
 %
 % d.savostyanov@soton.ac.uk
 % ilya.kuprov@weizmann.ac.il
@@ -24,13 +24,16 @@ function n=numel(tt)
 % Check consistency
 grumble(tt);
 
-% Compute the number of elements
-n=prod(prod(sizes(tt)));
+% Compute the number of elements exactly
+n=prod(int64(sizes(tt)),'all','native');
 
-% Check for infinities
-if n>intmax('int64')
-    error('the number of elements exceeds Matlab''s intmax.');
+% Check for overflow
+if n>flintmax
+    error('the number of elements exceeds Matlab''s flintmax.');
 end
+
+% Return a double
+n=double(n);
 
 end
 


### PR DESCRIPTION
## What was wrong

`kernel/overloads/@ttclass/numel.m` checks `n>intmax`. Unqualified
`intmax` in Matlab defaults to `intmax('int32')` = 2,147,483,647, even
though the function's own docstring (lines 14-15) states the
limitation is Matlab's 64-bit integer range.

## Why it matters physically

Tensor-train methods in Spinach exist specifically to represent spin
systems whose state-space element counts exceed what dense storage
can hold. Any legitimate large tensor-train system with more than
~2.1e9 elements (a size that is entirely ordinary for tensor-train
work and well within the documented 64-bit limit) is rejected by
`numel()` with a spurious "exceeds intmax" error, even though the
value fits comfortably in a 64-bit integer.

## Stock probe output

```
RESULT: error: the number of elements exceeds Matlab's intmax.
```
(tensor train with two cores, mode sizes 1x50000 each, true element
count 2,500,000,000, which exceeds int32 max but is far below int64
max)

## Patched probe output

```
RESULT: numel=2500000000, no error
```

## Finding id

F197