### PR TITLE
fix(plotting): handle descending ppm axes in crop_2d

### DIFF
--- a/kernel/plotting/crop_2d.m
+++ b/kernel/plotting/crop_2d.m
@@ -55,11 +55,21 @@ axis_f2_hz=ft_axis(parameters.offset(2),parameters.sweep(2),size(spec,2));
 axis_f1_ppm=1e6*(2*pi)*axis_f1_hz/(spin(parameters.spins{1})*spin_system.inter.magnet);
 axis_f2_ppm=1e6*(2*pi)*axis_f2_hz/(spin(parameters.spins{2})*spin_system.inter.magnet);
 
-% Find array bounds
-l_bound_f1=find(axis_f1_ppm>crop_ranges{1}(1),1);
-r_bound_f1=find(axis_f1_ppm>crop_ranges{1}(2),1);
-l_bound_f2=find(axis_f2_ppm>crop_ranges{2}(1),1);
-r_bound_f2=find(axis_f2_ppm>crop_ranges{2}(2),1);
+% Find array bounds, allowing for descending ppm axes of negative-gamma isotopes
+if axis_f1_ppm(1)<axis_f1_ppm(end)
+    l_bound_f1=find(axis_f1_ppm>crop_ranges{1}(1),1);
+    r_bound_f1=find(axis_f1_ppm>crop_ranges{1}(2),1);
+else
+    l_bound_f1=find(axis_f1_ppm<crop_ranges{1}(2),1);
+    r_bound_f1=find(axis_f1_ppm<crop_ranges{1}(1),1);
+end
+if axis_f2_ppm(1)<axis_f2_ppm(end)
+    l_bound_f2=find(axis_f2_ppm>crop_ranges{2}(1),1);
+    r_bound_f2=find(axis_f2_ppm>crop_ranges{2}(2),1);
+else
+    l_bound_f2=find(axis_f2_ppm<crop_ranges{2}(2),1);
+    r_bound_f2=find(axis_f2_ppm<crop_ranges{2}(1),1);
+end
 if isempty(l_bound_f1)||isempty(r_bound_f1)||isempty(l_bound_f2)||isempty(r_bound_f2)
     error('crop_ranges must lie inside the spectrum axes.');
 end


### PR DESCRIPTION
## What was wrong

`kernel/plotting/crop_2d.m` builds a ppm axis with
`axis_ppm=1e6*(2*pi)*axis_hz/(spin(isotope)*magnet)`. For a
negative-gyromagnetic-ratio isotope this divides an ascending Hz axis
by a negative number, producing a descending ppm axis. The bound
search `find(axis_ppm>crop_ranges{1}(1),1)` / `find(axis_ppm>crop_ranges{1}(2),1)`
assumed an ascending axis unconditionally, so on a descending axis it
finds the wrong indices (or a degenerate one-point range).

## Why it matters physically

15N, 29Si, 103Rh and other negative-gamma heteronuclei are routine
detection channels in biomolecular and inorganic NMR (e.g. 15N-HSQC).
Cropping such a 2D spectrum's ppm axis to a user-specified range
silently returned the wrong slice, or in the reproduction case a
degenerate 1x1 "spectrum", instead of the requested region.

## Fix

Detect the ppm axis direction (ascending vs descending, from
`axis_ppm(1)` vs `axis_ppm(end)`) per dimension, and search with the
mirrored comparison/bound pairing on a descending axis. The downstream
offset/sweep/zerofill arithmetic is unaffected because it indexes the
underlying Hz axis, whose ordering is independent of the sign of gamma.

## Stock probe output (15N, crop to central 60% of the ppm range)

```
ppm axis range: 16.4275 to -16.2992 (descending=1)
RESULT: crop succeeded, size=[1 1], of 256x256
expected fraction ~0.6, got f1=0.00390625 f2=0.00390625
```

## Patched probe output

```
ppm axis range: 16.4275 to -16.2992 (descending=1)
RESULT: crop succeeded, size=[154 154], of 256x256
expected fraction ~0.6, got f1=0.601562 f2=0.601562
```

Regression check on an ascending axis (1H) gives the same 0.6016
fraction before and after the fix, so the existing ascending-axis
behaviour is unchanged.

## Finding id

F202