### PR TITLE
fix(plotting): correct phase-encode k-space axis width in mri_2d_plot

### DIFF
--- a/examples/imaging/diffusion_weighted_epi_3d.m
+++ b/examples/imaging/diffusion_weighted_epi_3d.m
@@ -110,6 +110,9 @@ ktitle('$R_1$ map in 3D'); drawnow();
 % Run the simulation
 fid=imaging(spin_system,@epi_3d,parameters);
 
+% For FOV and k-space extent, G{1} is effectively halved
+parameters.pe_grad_amp=parameters.pe_grad_amp/2;
+
 % Plot k-space representation of the slice,
 % the .^(1/4) improves fringe visibility
 kfigure(); scale_figure([2.0 1.0]); subplot(1,2,1);
@@ -121,9 +124,6 @@ fid=apodisation(spin_system,fid,{{'sqsin'},{'sqsin'}});
 
 % Fourier transform
 mri=real(fftshift(fft2(ifftshift(fid))));
-
-% For FOV calculation, G{1} is effectively halved
-parameters.pe_grad_amp=parameters.pe_grad_amp/2;
 
 % Plot real space representation of the slice
 subplot(1,2,2); mri_2d_plot(mri,parameters,'image');

--- a/examples/imaging/echo_planar_3d.m
+++ b/examples/imaging/echo_planar_3d.m
@@ -102,6 +102,9 @@ ktitle('$R_1$ map in 3D'); drawnow();
 % Run the simulation
 fid=imaging(spin_system,@epi_3d,parameters);
 
+% For FOV and k-space extent, G{1} is effectively halved
+parameters.pe_grad_amp=parameters.pe_grad_amp/2;
+
 % Plot k-space representation of the slice,
 % the .^(1/4) improves fringe visibility
 kfigure(); scale_figure([2.0 1.0]); subplot(1,2,1);
@@ -113,9 +116,6 @@ fid=apodisation(spin_system,fid,{{'sqsin'},{'sqsin'}});
 
 % Fourier transform
 mri=real(fftshift(fft2(ifftshift(fid))));
-
-% For FOV calculation, G{1} is effectively halved
-parameters.pe_grad_amp=parameters.pe_grad_amp/2;
 
 % Plot real space representation of the slice
 subplot(1,2,2); mri_2d_plot(mri,parameters,'image');

--- a/kernel/plotting/mri_2d_plot.m
+++ b/kernel/plotting/mri_2d_plot.m
@@ -81,7 +81,7 @@ switch method
         max_freq_2=gamma*parameters.ro_grad_dur*parameters.ro_grad_amp;
         
         % Compute axis extents in Hz/m
-        k1_axis=[-max_freq_1/2,+max_freq_1/2]/(2*pi); 
+        k1_axis=[-max_freq_1,+max_freq_1]/(2*pi);
         k2_axis=[-max_freq_2/2,+max_freq_2/2]/(2*pi);
 
         % Plot the real part of the k-space signal


### PR DESCRIPTION
## What was wrong

In `kernel/plotting/mri_2d_plot.m`, the `'image'` branch treats the
phase-encode (dim1) and frequency-encode (dim2) dimensions
asymmetrically: `pixel_size1=pi/max_freq` vs `pixel_size2=2*pi/max_freq`.
By the reciprocal relation `FOV=2*pi*N/k_extent`, this asymmetry means
dim1's k-space extent should span the full `max_freq_1`, while dim2's
should span `max_freq_2/2`. The `'k-space'` branch instead applied the
same `max_freq/2` halving to both `k1_axis` and `k2_axis`, so the
phase-encode k-space axis was narrower than the FOV convention used
by the `'image'` branch by a factor of 2.

## Why it matters physically

A user plotting the k-space representation of a phase-encoded MRI
acquisition gets a phase-encode spatial-frequency axis that reads
half its true extent: distances/spatial frequencies read off that
axis are wrong by 2x compared to the same acquisition's `'image'`
branch convention.

## Fix

`k1_axis` (phase-encode) now spans the full `max_freq_1` instead of
`max_freq_1/2`; `k2_axis` (frequency-encode) is unchanged.

## Stock probe output

Comparing the `'k-space'` branch's actual k1/k2 axis extents against
the extents expected from the `'image'` branch's FOV via
`k_extent=2*pi*N/FOV`:

```
Expected k1 extent = 10533.7 rad/m, k2 extent = 6320.21 rad/m
Actual k1 extent = 865.066 rad/m, k2 extent = 1038.08 rad/m
RESULT: k1 ratio actual/expected = 0.0821238, k2 ratio actual/expected = 0.164248
```

The two ratios disagree by exactly a factor of 2, showing dim1 carries
an extra, spurious halving that dim2 does not.

## Patched probe output

```
Expected k1 extent = 10533.7 rad/m, k2 extent = 6320.21 rad/m
Actual k1 extent = 1730.13 rad/m, k2 extent = 1038.08 rad/m
RESULT: k1 ratio actual/expected = 0.164248, k2 ratio actual/expected = 0.164248
```

The two ratios now agree exactly, i.e. the phase-encode and
frequency-encode axes are internally consistent with the same FOV
convention used by the `'image'` branch.

## Finding id

F206