### PR TITLE
fix(plotting): remove off-by-one in plot_uf conventional-dimension axis

### DIFF
--- a/interfaces/agents/spinach-knowledge/kernel/plotting/plot_uf.md
+++ b/interfaces/agents/spinach-knowledge/kernel/plotting/plot_uf.md
@@ -24,8 +24,7 @@ Plotting utility for ultrafast constant-time 2D pulse sequences. Syntax: plot_uf
 - Lines 42-43: Check consistency; implemented by `grumble(spectrum_uf,parameters)`.
 - Lines 45-46: Get Ta (duration of one single acquisition gradient); implemented by `Ta=parameters.deltat*parameters.npoints`.
 - Lines 48-49: Get sweep width conventional dimension; implemented by `sweep_conv=1/(2*Ta)`.
-- Lines 51-52: Get resolution conventional dimension; implemented by `res_conv=1/(2*Ta*parameters.nloops)`.
-- Lines 54-55: Get axis in the conventional dimension; implemented by `axis_f2=(-sweep_conv/2:res_conv:sweep_conv/2-1)+parameters.offset(2)`.
+- Lines 51-52: Get axis in the conventional dimension; implemented by `axis_f2=ft_axis(parameters.offset(2),sweep_conv,parameters.nloops)`.
 - Lines 57-58: Get the magnetogyric ratio; implemented by `gamma=spin(parameters.spins{1})`.
 - Lines 60-61: Get kmax (maximal k-value); implemented by `k_max=gamma*parameters.Ga*Ta/(2*pi)`.
 - Lines 63-65: Get constant c (in according to Prog.Nucl.Magn.Reson.Spectrosc. 57,2010,241); implemented by `t_max=2*parameters.Te`.
@@ -49,8 +48,7 @@ Plotting utility for ultrafast constant-time 2D pulse sequences. Syntax: plot_uf
 
 - Lines 46: computes `Ta` using `Ta=parameters.deltat*parameters.npoints`.
 - Lines 49: computes `sweep_conv` using `sweep_conv=1/(2*Ta)`.
-- Lines 52: computes `res_conv` using `res_conv=1/(2*Ta*parameters.nloops)`.
-- Lines 55: computes `axis_f2` using `axis_f2=(-sweep_conv/2:res_conv:sweep_conv/2-1)+parameters.offset(2)`.
+- Lines 52: computes `axis_f2` using `axis_f2=ft_axis(parameters.offset(2),sweep_conv,parameters.nloops)`.
 - Lines 58: computes `gamma` using `gamma=spin(parameters.spins{1})`.
 - Lines 61: computes `k_max` using `k_max=gamma*parameters.Ga*Ta/(2*pi)`.
 - Lines 65: computes `t_max` using `t_max=2*parameters.Te`.
@@ -105,4 +103,4 @@ Plotting utility for ultrafast constant-time 2D pulse sequences. Syntax: plot_uf
 
 ## Internal Spinach / MATLAB structure cues
 
-- Called routines detected from the main body: `grumble()`, `spin()`, `flipud()`, `kxlabel()`, `kylabel()`, `set()`, `ismatrix()`, `isfield()`, `isscalar()`, `ischar()`, `ismember()`.
+- Called routines detected from the main body: `grumble()`, `ft_axis()`, `spin()`, `flipud()`, `kxlabel()`, `kylabel()`, `set()`, `ismatrix()`, `isfield()`, `isscalar()`, `ischar()`, `ismember()`.

--- a/interfaces/agents/spinach-knowledge/kernel/plotting/plot_uf.md
+++ b/interfaces/agents/spinach-knowledge/kernel/plotting/plot_uf.md
@@ -24,7 +24,7 @@ Plotting utility for ultrafast constant-time 2D pulse sequences. Syntax: plot_uf
 - Lines 42-43: Check consistency; implemented by `grumble(spectrum_uf,parameters)`.
 - Lines 45-46: Get Ta (duration of one single acquisition gradient); implemented by `Ta=parameters.deltat*parameters.npoints`.
 - Lines 48-49: Get sweep width conventional dimension; implemented by `sweep_conv=1/(2*Ta)`.
-- Lines 51-52: Get axis in the conventional dimension; implemented by `axis_f2=ft_axis(parameters.offset(2),sweep_conv,parameters.nloops)`.
+- Lines 51-52: Get axis in the conventional dimension; implemented by `axis_f2=sweep_conv*(-floor(parameters.nloops/2):(ceil(parameters.nloops/2)-1))/parameters.nloops+parameters.offset(2)`.
 - Lines 57-58: Get the magnetogyric ratio; implemented by `gamma=spin(parameters.spins{1})`.
 - Lines 60-61: Get kmax (maximal k-value); implemented by `k_max=gamma*parameters.Ga*Ta/(2*pi)`.
 - Lines 63-65: Get constant c (in according to Prog.Nucl.Magn.Reson.Spectrosc. 57,2010,241); implemented by `t_max=2*parameters.Te`.
@@ -48,7 +48,7 @@ Plotting utility for ultrafast constant-time 2D pulse sequences. Syntax: plot_uf
 
 - Lines 46: computes `Ta` using `Ta=parameters.deltat*parameters.npoints`.
 - Lines 49: computes `sweep_conv` using `sweep_conv=1/(2*Ta)`.
-- Lines 52: computes `axis_f2` using `axis_f2=ft_axis(parameters.offset(2),sweep_conv,parameters.nloops)`.
+- Lines 52: computes `axis_f2` using `axis_f2=sweep_conv*(-floor(parameters.nloops/2):(ceil(parameters.nloops/2)-1))/parameters.nloops+parameters.offset(2)`.
 - Lines 58: computes `gamma` using `gamma=spin(parameters.spins{1})`.
 - Lines 61: computes `k_max` using `k_max=gamma*parameters.Ga*Ta/(2*pi)`.
 - Lines 65: computes `t_max` using `t_max=2*parameters.Te`.
@@ -103,4 +103,4 @@ Plotting utility for ultrafast constant-time 2D pulse sequences. Syntax: plot_uf
 
 ## Internal Spinach / MATLAB structure cues
 
-- Called routines detected from the main body: `grumble()`, `ft_axis()`, `spin()`, `flipud()`, `kxlabel()`, `kylabel()`, `set()`, `ismatrix()`, `isfield()`, `isscalar()`, `ischar()`, `ismember()`.
+- Called routines detected from the main body: `grumble()`, `spin()`, `flipud()`, `kxlabel()`, `kylabel()`, `set()`, `ismatrix()`, `isfield()`, `isscalar()`, `ischar()`, `ismember()`.

--- a/kernel/plotting/plot_uf.m
+++ b/kernel/plotting/plot_uf.m
@@ -48,11 +48,8 @@ Ta=parameters.deltat*parameters.npoints; % s
 % Get sweep width conventional dimension
 sweep_conv=1/(2*Ta); % Hz
 
-% Get resolution conventional dimension
-res_conv=1/(2*Ta*parameters.nloops); % Hz
-
 % Get axis in the conventional dimension
-axis_f2=(-sweep_conv/2:res_conv:sweep_conv/2-res_conv)+parameters.offset(2);
+axis_f2=ft_axis(parameters.offset(2),sweep_conv,parameters.nloops);
 
 % Get the magnetogyric ratio        
 gamma=spin(parameters.spins{1}); % rad/s T
@@ -163,8 +160,8 @@ if ~isfield(parameters,'dims')
 end
 if (~isnumeric(parameters.nloops))||(~isreal(parameters.nloops))||...
    (~isscalar(parameters.nloops))||(~isfinite(parameters.nloops))||...
-   (parameters.nloops<1)||(mod(parameters.nloops,1)~=0)
-    error('parameters.nloops must be a finite positive real integer.');
+   (parameters.nloops<3)||(mod(parameters.nloops,1)~=0)
+    error('parameters.nloops must be a finite real integer greater than 2.');
 end
 if (~isnumeric(parameters.Te))||(~isreal(parameters.Te))||...
    (~isscalar(parameters.Te))||(~isfinite(parameters.Te))||(parameters.Te<=0)

--- a/kernel/plotting/plot_uf.m
+++ b/kernel/plotting/plot_uf.m
@@ -49,7 +49,7 @@ Ta=parameters.deltat*parameters.npoints; % s
 sweep_conv=1/(2*Ta); % Hz
 
 % Get axis in the conventional dimension
-axis_f2=ft_axis(parameters.offset(2),sweep_conv,parameters.nloops);
+axis_f2=sweep_conv*(-floor(parameters.nloops/2):(ceil(parameters.nloops/2)-1))/parameters.nloops+parameters.offset(2);
 
 % Get the magnetogyric ratio        
 gamma=spin(parameters.spins{1}); % rad/s T
@@ -160,8 +160,8 @@ if ~isfield(parameters,'dims')
 end
 if (~isnumeric(parameters.nloops))||(~isreal(parameters.nloops))||...
    (~isscalar(parameters.nloops))||(~isfinite(parameters.nloops))||...
-   (parameters.nloops<3)||(mod(parameters.nloops,1)~=0)
-    error('parameters.nloops must be a finite real integer greater than 2.');
+   (parameters.nloops<1)||(mod(parameters.nloops,1)~=0)
+    error('parameters.nloops must be a finite positive real integer.');
 end
 if (~isnumeric(parameters.Te))||(~isreal(parameters.Te))||...
    (~isscalar(parameters.Te))||(~isfinite(parameters.Te))||(parameters.Te<=0)

--- a/kernel/plotting/plot_uf.m
+++ b/kernel/plotting/plot_uf.m
@@ -52,7 +52,7 @@ sweep_conv=1/(2*Ta); % Hz
 res_conv=1/(2*Ta*parameters.nloops); % Hz
 
 % Get axis in the conventional dimension
-axis_f2=(-sweep_conv/2:res_conv:sweep_conv/2-1)+parameters.offset(2); 
+axis_f2=(-sweep_conv/2:res_conv:sweep_conv/2-res_conv)+parameters.offset(2);
 
 % Get the magnetogyric ratio        
 gamma=spin(parameters.spins{1}); % rad/s T


### PR DESCRIPTION
## What was wrong

In `kernel/plotting/plot_uf.m`,
`axis_f2=(-sweep_conv/2:res_conv:sweep_conv/2-1)+parameters.offset(2)`
subtracts the dimensioned literal `1` (i.e. 1 Hz) from the upper
endpoint of the colon range, instead of subtracting one `res_conv`
step as intended (mirroring how `axis_f1` is built a few lines below
using `0:(uf_dim_size-1)`).

## Why it matters physically

`res_conv=1/(2*Ta*parameters.nloops)` is commonly well below 1 Hz for
realistic ultrafast-NMR loop counts, so
`floor((sweep_conv-1)/res_conv)` undercounts the number of grid points
by exactly one relative to `floor(sweep_conv/res_conv)`. `axis_f2`
therefore comes out one element shorter than the spectrum's column
count for ordinary (not contrived) acquisition parameters, and
`contour(axis_f2,axis_f1,flipud(spectrum_uf))` fails with a dimension
mismatch. A user with a normal, sub-Hz-resolution ultrafast dataset
cannot plot it at all.

## Fix

Replaced the literal `1` with `res_conv`, so the axis endpoint is one
grid step below the half-sweep, matching the digital resolution.

## Stock probe output

```
Ta=0.01 sweep_conv=50 res_conv=0.5
buggy axis_f2 length=99, correct (sweep_conv/res_conv) length=100, ga_points_number(rows)=9
RESULT: error: The size of X must match the size of Z or the number of columns of Z.
```

## Patched probe output

```
Ta=0.01 sweep_conv=50 res_conv=0.5
buggy axis_f2 length=99, correct (sweep_conv/res_conv) length=100, ga_points_number(rows)=9
RESULT: plot_uf succeeded, no error
```

## Finding id

F209