### PR TITLE
fix(utilities): remncomm must keep degenerate cross-terms (F233)

### DIFF
--- a/examples/singlet_states/eigenstate_analysis.m
+++ b/examples/singlet_states/eigenstate_analysis.m
@@ -39,7 +39,7 @@ report(spin_system,['Singlet state norm: ' ...
                     num2str(norm(full(rho),2))]);
 
 % Remove the part that does not commute with H
-[EvH,~]=eig(H); rho_inv=remncomm(rho,EvH);
+[EvH,EnH]=eig(H,'vector'); rho_inv=remncomm(rho,EvH,EnH);
 
 % Remove the unit part
 rho_inv=remtrace(rho_inv);
@@ -78,7 +78,7 @@ report(spin_system,['Singlet state norm: ' ...
 H=(H+ctranspose(H))/2;
 
 % Remove the part that does not commute with H
-[EvH,~]=eig(H); rho_inv=remncomm(rho,EvH);
+[EvH,EnH]=eig(H,'vector'); rho_inv=remncomm(rho,EvH,EnH);
 
 % Remove the unit part
 rho_inv=remtrace(rho_inv);

--- a/examples/singlet_states/eigenstate_analysis.m
+++ b/examples/singlet_states/eigenstate_analysis.m
@@ -39,7 +39,7 @@ report(spin_system,['Singlet state norm: ' ...
                     num2str(norm(full(rho),2))]);
 
 % Remove the part that does not commute with H
-[EvH,EnH]=eig(H,'vector'); rho_inv=remncomm(rho,EvH,EnH);
+[EvH,evals_h]=eig(H,'vector'); rho_inv=remncomm(rho,EvH,evals_h);
 
 % Remove the unit part
 rho_inv=remtrace(rho_inv);
@@ -78,7 +78,7 @@ report(spin_system,['Singlet state norm: ' ...
 H=(H+ctranspose(H))/2;
 
 % Remove the part that does not commute with H
-[EvH,EnH]=eig(H,'vector'); rho_inv=remncomm(rho,EvH,EnH);
+[EvH,evals_h]=eig(H,'vector'); rho_inv=remncomm(rho,EvH,evals_h);
 
 % Remove the unit part
 rho_inv=remtrace(rho_inv);

--- a/interfaces/agents/spinach-knowledge/examples/singlet_states/eigenstate_analysis.md
+++ b/interfaces/agents/spinach-knowledge/examples/singlet_states/eigenstate_analysis.md
@@ -30,7 +30,7 @@ Stationary state analysis for the spin system of allyl pyruvate, finding out whi
 - Lines 31-32: Tidy up rounding errors; implemented by `H=(H+ctranspose(H))/2`.
 - Lines 34-35: Get the singlet state; implemented by `rho=singlet(spin_system,3,4)`.
 - Lines 37-39: Report the norm; implemented by `report(spin_system,['Singlet state norm: ' num2str(norm(full(rho),2))])`.
-- Lines 41-42: Remove the part that does not commute with H; implemented by `[EvH,~]=eig(H); rho_inv=remncomm(rho,EvH)`.
+- Lines 41-42: Remove the part that does not commute with H; implemented by `[EvH,evals_h]=eig(H,'vector'); rho_inv=remncomm(rho,EvH,evals_h)`.
 - Lines 44-45: Remove the unit part; implemented by `rho_inv=remtrace(rho_inv)`.
 - Lines 47-49: Report the norm; implemented by `report(spin_system,[' of which commutes with H: ' num2str(norm(full(rho_inv),2))])`.
 - Lines 51-52: Project out the ZZ component; implemented by `zz_state=state(spin_system,{'Lz','Lz'},{3 4})`.
@@ -49,7 +49,7 @@ Stationary state analysis for the spin system of allyl pyruvate, finding out whi
 - Lines 24: computes `bas.approximation` using `bas.approximation='none'`.
 - Lines 29: computes `H` using `H=hamiltonian(spin_system); H=full(H)`.
 - Lines 35: computes `rho` using `rho=singlet(spin_system,3,4)`.
-- Lines 42: computes `[EvH,~]` using `[EvH,~]=eig(H); rho_inv=remncomm(rho,EvH)`.
+- Lines 42: computes `[EvH,evals_h]` using `[EvH,evals_h]=eig(H,'vector'); rho_inv=remncomm(rho,EvH,evals_h)`.
 - Lines 45: computes `rho_inv` using `rho_inv=remtrace(rho_inv)`.
 - Lines 52: computes `zz_state` using `zz_state=state(spin_system,{'Lz','Lz'},{3 4})`.
 - Lines 63: computes `parameters.offset` using `parameters.offset=2850`.

--- a/interfaces/agents/spinach-knowledge/kernel.md
+++ b/interfaces/agents/spinach-knowledge/kernel.md
@@ -484,7 +484,7 @@
 | `kernel/utilities/polinfo.m` | `polinfo(p,level,label)` | Draws an ASCII diagram of a polyadic object. Syntax: polinfo(p) Parameters: p - polyadic object Outputs: an ASCII diagra | 111 |
 | `kernel/utilities/poolsize.m` | `n=poolsize()` | Returns the current parallel pool size. Syntax: n=poolsize() Parameters: none Outputs: n - number of workers in the curr | 40 |
 | `kernel/utilities/prune_subgraphs.m` | `subgraphs=prune_subgraphs(subgraphs)` | Removes subgraphs that are contained entirely within other subgraphs. Syntax: subgraphs=prune_subgraphs(subgraphs) Param | 59 |
-| `kernel/utilities/remncomm.m` | `A=remncomm(A,EvB)` | Removes from the Hermitian operator A the part that does not com- mute with the Hermitian operator B. Syntax: C=remncomm | 54 |
+| `kernel/utilities/remncomm.m` | `A=remncomm(A,EvB,evals_b)` | Removes from the Hermitian operator A the part that does not com- mute with the Hermitian operator B. Syntax: C=remncomm | 54 |
 | `kernel/utilities/remtrace.m` | `A=remtrace(A)` | Subtracts an appropriate multiple of the unit matrix to make the input matrix traceless. Syntax: A=remtrace(A) Parameter | 39 |
 | `kernel/utilities/repcols.m` | `B=repcols(A,col_nums,rep_counts)` | Replicates specified columns of a matrix or cell array a specified number of times. Syntax: B=repcols(A,col_nums,rep_cou | 66 |
 | `kernel/utilities/report.m` | `report(spin_system,report_string)` | Writes a log message to the console or an ACSII file. The message includes the call stack of the function that produced  | 126 |

--- a/interfaces/agents/spinach-knowledge/kernel/utilities/remncomm.md
+++ b/interfaces/agents/spinach-knowledge/kernel/utilities/remncomm.md
@@ -1,12 +1,12 @@
 # kernel/utilities/remncomm.m
 
 - Source: `/home/kuprov/.openclaw/workspace/Spinach/kernel/utilities/remncomm.m`
-- Signature: `A=remncomm(A,EvB)`
+- Signature: `A=remncomm(A,EvB,evals_b)`
 - Total lines: 54
 
 ## Purpose
 
-Removes from the Hermitian operator A the part that does not com- mute with the Hermitian operator B. Syntax: C=remncomm(A,EvB)
+Removes from the Hermitian operator A the part that does not com- mute with the Hermitian operator B. Syntax: C=remncomm(A,EvB,evals_b)
 
 ## Physical / mathematical content
 
@@ -21,16 +21,20 @@ Removes from the Hermitian operator A the part that does not com- mute with the 
 
 ### Comment-guided execution stages
 
-- Lines 26-27: Check consistency; implemented by `grumble(A,EvB)`.
-- Lines 29-30: The standard projector expression; implemented by `A=EvB*(diag(diag(EvB'*A*EvB)))*EvB'`.
+- Lines 30-31: Check consistency; implemented by `grumble(A,EvB,evals_b)`.
+- Lines 33-34: Move A into the eigenbasis of B; implemented by `A=EvB'*A*EvB`.
+- Lines 36-38: Zero out elements linking non-degenerate eigenvalues of B; implemented by `degen_mask=abs(evals_b-evals_b.')<=1e-10*max(abs(evals_b)); A=A.*degen_mask`.
+- Lines 40-41: Move the commuting part back into the original basis; implemented by `A=EvB*A*EvB'`.
 
 ### Key state/data transformations
 
-- Lines 30: computes `A` using `A=EvB*(diag(diag(EvB'*A*EvB)))*EvB'`.
+- Lines 34: computes `A` using `A=EvB'*A*EvB`.
+- Lines 37: computes `degen_mask` using `degen_mask=abs(evals_b-evals_b.')<=1e-10*max(abs(evals_b))`.
+- Lines 41: computes `A` using `A=EvB*A*EvB'`.
 
 ### Local helper functions
 
-- Line 35: `grumble()` — `function grumble(A,EvB)`. The first scientific measurement of the speed of electricity was conducted in 1764 by French physicist Jean-Antoine Nollet. He ar-
+- Line 46: `grumble()` — `function grumble(A,EvB,evals_b)`. The first scientific measurement of the speed of electricity was conducted in 1764 by French physicist Jean-Antoine Nollet. He ar-
   - Representative operation: `if (~isnumeric(A))||(size(A,1)~=size(A,2))|| (~ishermitian(A))`.
   - Representative operation: `(~ishermitian(A))`.
 
@@ -39,28 +43,36 @@ Removes from the Hermitian operator A the part that does not com- mute with the 
 - A -a square matrix
 - EvB -a square matrix containing eigenvectors
 - of B in columns
+- evals_b - a column vector containing the eigenvalues
+- of B in the same order as the columns of EvB
 
 ## Outputs
 
 - C -a square matrix
-- Note: when the matrix B is diagonal, the part of A that commutes
-- with it is the diagonal part, so just use diag(diag(A))
+- Note: within a degenerate eigenspace of B, every Hermitian operator
+- supported on that eigenspace commutes with B, so the corres-
+- ponding block of A (not just its diagonal) is kept
 
 ## Implementation structure
 
 - Removes from the Hermitian operator A the part that does not com-
 - mute with the Hermitian operator B. Syntax:
-- C=remncomm(A,EvB)
+- C=remncomm(A,EvB,evals_b)
 - A - a square matrix
 - EvB - a square matrix containing eigenvectors
 - of B in columns
+- evals_b - a column vector containing the eigenvalues
+- of B in the same order as the columns of EvB
 - C - a square matrix
-- Note: when the matrix B is diagonal, the part of A that commutes
-- with it is the diagonal part, so just use diag(diag(A))
+- Note: within a degenerate eigenspace of B, every Hermitian operator
+- supported on that eigenspace commutes with B, so the corres-
+- ponding block of A (not just its diagonal) is kept
 - Check consistency
-- The standard projector expression
+- Move A into the eigenbasis of B
+- Zero out elements linking non-degenerate eigenvalues of B
+- Move the commuting part back into the original basis
 - Consistency enforcement
 
 ## Internal Spinach / MATLAB structure cues
 
-- Called routines detected from the main body: `grumble()`, `ishermitian()`.
+- Called routines detected from the main body: `grumble()`, `isfinite()`, `ishermitian()`.

--- a/kernel/utilities/remncomm.m
+++ b/kernel/utilities/remncomm.m
@@ -1,7 +1,7 @@
 % Removes from the Hermitian operator A the part that does not com-
 % mute with the Hermitian operator B. Syntax:
 %
-%                       C=remncomm(A,EvB,EnB)
+%                       C=remncomm(A,EvB,evals_b)
 %
 % Parameters:
 %
@@ -10,8 +10,8 @@
 %    EvB   -  a square matrix containing eigenvectors 
 %             of B in columns
 %
-%    EnB   -  a column vector containing the eigenvalues
-%             of B in the same order as the columns of EvB
+%    evals_b - a column vector containing the eigenvalues
+%              of B in the same order as the columns of EvB
 %
 % Outputs:
 %
@@ -19,22 +19,22 @@
 %
 % Note: within a degenerate eigenspace of B, every Hermitian operator
 %       supported on that eigenspace commutes with B, so the corres-
-%       ponding block of A (not just its diagonal) is kept.
+%       ponding block of A (not just its diagonal) is kept
 %       
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=remncomm.m>
 
-function A=remncomm(A,EvB,EnB)
+function A=remncomm(A,EvB,evals_b)
 
 % Check consistency
-grumble(A,EvB,EnB);
+grumble(A,EvB,evals_b);
 
 % Move A into the eigenbasis of B
 A=EvB'*A*EvB;
 
 % Zero out elements linking non-degenerate eigenvalues of B
-degen_mask=abs(EnB-EnB.')<=1e-10*max(abs(EnB));
+degen_mask=abs(evals_b-evals_b.')<=1e-10*max(abs(evals_b));
 A=A.*degen_mask;
 
 % Move the commuting part back into the original basis
@@ -43,7 +43,7 @@ A=EvB*A*EvB';
 end
 
 % Consistency enforcement
-function grumble(A,EvB,EnB)
+function grumble(A,EvB,evals_b)
 if (~isnumeric(A))||(size(A,1)~=size(A,2))||...
    (~ishermitian(A))
     error('A must be a Hermitian matrix.');
@@ -51,9 +51,9 @@ end
 if (~isnumeric(EvB))||(size(EvB,1)~=size(EvB,2))
     error('EvB must be a square array of column vectors.');
 end
-if (~isnumeric(EnB))||(~iscolumn(EnB))||(~isreal(EnB))||...
-   (numel(EnB)~=size(EvB,2))
-    error('EnB must be a real column vector with as many elements as EvB has columns.');
+if (~isnumeric(evals_b))||(~iscolumn(evals_b))||(~isreal(evals_b))||...
+   (~all(isfinite(evals_b)))||(numel(evals_b)~=size(EvB,2))
+    error('evals_b must be a finite real column vector with as many elements as EvB has columns.');
 end
 end
 
@@ -66,3 +66,4 @@ end
 % that the transmission speed of electricity was very high. Nollet
 % could find so many monks and convince them to get electrocuted be-
 % cause he was the Abbot of a large French monastery.
+

--- a/kernel/utilities/remncomm.m
+++ b/kernel/utilities/remncomm.m
@@ -1,7 +1,7 @@
 % Removes from the Hermitian operator A the part that does not com-
 % mute with the Hermitian operator B. Syntax:
 %
-%                         C=remncomm(A,EvB)
+%                       C=remncomm(A,EvB,EnB)
 %
 % Parameters:
 %
@@ -10,35 +10,50 @@
 %    EvB   -  a square matrix containing eigenvectors 
 %             of B in columns
 %
+%    EnB   -  a column vector containing the eigenvalues
+%             of B in the same order as the columns of EvB
+%
 % Outputs:
 %
 %    C     -  a square matrix
 %
-% Note: when the matrix B is diagonal, the part of A that commutes
-%       with it is the diagonal part, so just use diag(diag(A))
+% Note: within a degenerate eigenspace of B, every Hermitian operator
+%       supported on that eigenspace commutes with B, so the corres-
+%       ponding block of A (not just its diagonal) is kept.
 %       
 % ilya.kuprov@weizmann.ac.il
 %
 % <https://spindynamics.org/wiki/index.php?title=remncomm.m>
 
-function A=remncomm(A,EvB)
+function A=remncomm(A,EvB,EnB)
 
 % Check consistency
-grumble(A,EvB);
+grumble(A,EvB,EnB);
 
-% The standard projector expression
-A=EvB*(diag(diag(EvB'*A*EvB)))*EvB';
+% Move A into the eigenbasis of B
+A=EvB'*A*EvB;
+
+% Zero out elements linking non-degenerate eigenvalues of B
+degen_mask=abs(EnB-EnB.')<=1e-10*max(abs(EnB));
+A=A.*degen_mask;
+
+% Move the commuting part back into the original basis
+A=EvB*A*EvB';
 
 end
 
 % Consistency enforcement
-function grumble(A,EvB)
+function grumble(A,EvB,EnB)
 if (~isnumeric(A))||(size(A,1)~=size(A,2))||...
    (~ishermitian(A))
     error('A must be a Hermitian matrix.');
 end
 if (~isnumeric(EvB))||(size(EvB,1)~=size(EvB,2))
     error('EvB must be a square array of column vectors.');
+end
+if (~isnumeric(EnB))||(~iscolumn(EnB))||(~isreal(EnB))||...
+   (numel(EnB)~=size(EvB,2))
+    error('EnB must be a real column vector with as many elements as EvB has columns.');
 end
 end
 
@@ -51,4 +66,3 @@ end
 % that the transmission speed of electricity was very high. Nollet
 % could find so many monks and convince them to get electrocuted be-
 % cause he was the Abbot of a large French monastery.
-

--- a/tests/kernel/test_lowlevel_utilities_suite.m
+++ b/tests/kernel/test_lowlevel_utilities_suite.m
@@ -38,6 +38,9 @@ result=test_close(result,'remtrace',remtrace(C),[-1 1;0 1],1e-15,1e-15,...
 H=[2 1+2i;1-2i 5];
 result=test_close(result,'remncomm diagonal basis',remncomm(H,eye(2),[1;2]),diag(diag(H)),1e-15,1e-15,...
                   'in the eigenbasis of a non-degenerate B only the diagonal part commutes with B');
+H=[2 1+2i 3;1-2i 5 1i;3 -1i 1];
+result=test_close(result,'remncomm degenerate basis',remncomm(H,eye(3),[1;1;2]),[2 1+2i 0;1-2i 5 0;0 0 1],1e-15,1e-15,...
+                  'in the eigenbasis of a degenerate B the whole degenerate block of A commutes with B');
 
 % Check Frobenius inner product and anti-diagonal transpose
 D=[1+1i 2-1i;3 4i];

--- a/tests/kernel/test_lowlevel_utilities_suite.m
+++ b/tests/kernel/test_lowlevel_utilities_suite.m
@@ -36,8 +36,8 @@ C=[2 1;0 4];
 result=test_close(result,'remtrace',remtrace(C),[-1 1;0 1],1e-15,1e-15,...
                   'remtrace subtracts trace(A)/dim times the unit matrix');
 H=[2 1+2i;1-2i 5];
-result=test_close(result,'remncomm diagonal basis',remncomm(H,eye(2)),diag(diag(H)),1e-15,1e-15,...
-                  'in the eigenbasis of B only the diagonal part commutes with B');
+result=test_close(result,'remncomm diagonal basis',remncomm(H,eye(2),[1;2]),diag(diag(H)),1e-15,1e-15,...
+                  'in the eigenbasis of a non-degenerate B only the diagonal part commutes with B');
 
 % Check Frobenius inner product and anti-diagonal transpose
 D=[1+1i 2-1i;3 4i];


### PR DESCRIPTION
## What was wrong

`remncomm(A,EvB)` computed the commuting part of `A` with respect to
`B` as `EvB*diag(diag(EvB'*A*EvB))*EvB'` unconditionally. This is only
correct when `B` is non-degenerate (the function's own docstring said
so). When `B` has a degenerate eigenspace, any Hermitian operator
supported entirely within that eigenspace commutes with `B`, so the
correct commuting part keeps the whole block linking degenerate
eigenvectors, not just the diagonal.

## Why it matters physically

`examples/singlet_states/eigenstate_analysis.m` calls
`remncomm(rho,EvH)` with `EvH=eig(H)` on a real spin Hamiltonian.
Degenerate eigenspaces are the norm rather than the exception in such
systems (e.g. singlet-triplet manifolds), so the function was
routinely stripping legitimate commuting cross-terms, under-sizing the
reported "commuting part" and over-sizing the "invariant-removed"
residual — corrupting singlet-content estimates and any other
eigenstate-analysis result built on this function.

## Fix

Added an `EnB` eigenvalue argument so the function can identify which
columns of `EvB` are degenerate, and now keeps the block linking
eigenvectors whose eigenvalues agree to within `1e-10*max(|EnB|)`,
zeroing only elements linking genuinely distinct eigenvalues. Updated
the two call sites in `eigenstate_analysis.m` to supply eigenvalues via
`eig(H,'vector')`, and updated the existing unit test
(`tests/kernel/test_lowlevel_utilities_suite.m`) to pass a
non-degenerate `EnB`, matching the invariant it already asserts.

## Probe

`B=diag([1 1 2])` (indices 1,2 degenerate), `A=[0 3 1;3 0 1;1 1 0]`.
Expected commuting part (block on 1,2 kept, index 3 isolated):
`[0 3 0;3 0 0;0 0 0]`.

- stock: `measured error norm=4.2426406871192848` -> PROBE FAIL
- patched: `measured error norm=0.0000000000000000` -> PROBE PASS

## Finding id

F233