### PR TITLE
fix(comsol): guard conc_plot amplitude normalisation against all-zero observable (F286)

### DIFF
--- a/interfaces/comsol/conc_plot.m
+++ b/interfaces/comsol/conc_plot.m
@@ -60,8 +60,12 @@ elseif size(obs,2)==1
 elseif size(obs,2)==2
 
     % Two observables: assume phase + amp and map into HS
-    RGB=hsv2rgb(wrapTo2Pi(obs(:,1))/(2*pi),...
-                obs(:,2)/max(obs(:,2)),...
+    amp_peak=max(obs(:,2));
+
+    % All-zero amplitude column maps to zero saturation
+    if amp_peak==0, amp_sat=zeros(size(obs,1),1);
+    else, amp_sat=obs(:,2)/amp_peak; end
+    RGB=hsv2rgb(wrapTo2Pi(obs(:,1))/(2*pi),amp_sat,...
                 0.50*ones(size(spin_system.mesh.vor.cells,1),1));
 
 elseif size(obs,2)==3


### PR DESCRIPTION
## What was wrong
`interfaces/comsol/conc_plot.m` normalises the amplitude observable with
`obs(:,2)/max(obs(:,2))` (two-observable branch). `grumble()` only
requires `obs` to be finite, real, and 1-3 columns; it does not require
the amplitude column to be non-zero. A legitimately all-zero amplitude
column (e.g. no signal in some Voronoi cells of a microfluidic
simulation) gives `max(obs(:,2))==0`, so every entry becomes `0/0=NaN`,
which then feeds `hsv2rgb` as the saturation channel and produces NaN
face colours.

## Why it matters physically
All-zero amplitude in some or all cells is an ordinary, physically valid
outcome (e.g. no signal detected in a region of a microfluidic device),
not an edge case to be rejected. The plot should render those cells with
zero saturation, not break the colour mapping.

## Fix
When the peak amplitude is zero, the saturation channel is set to zero
throughout instead of dividing by zero. This is a two-line guard with no
change to the non-degenerate behaviour.

## Stock probe output
```
F286 REPRODUCED: NaN face colours from all-zero amplitude observable
```

## Patched probe output
```
F286 NOT REPRODUCED: no NaN face colours
```

## Finding id
F286