### PR TITLE
F210: fix crash on documented one-spin call in plot_uf

### DIFF
--- a/kernel/plotting/plot_uf.m
+++ b/kernel/plotting/plot_uf.m
@@ -42,6 +42,11 @@ function plot_uf(spin_system,spectrum_uf,parameters)
 % Check consistency
 grumble(spectrum_uf,parameters)
 
+% Accommodate homonuclear sequences
+if isscalar(parameters.spins)
+    parameters.spins=[parameters.spins parameters.spins];
+end
+
 % Get Ta (duration of one single acquisition gradient)
 Ta=parameters.deltat*parameters.npoints; % s
 


### PR DESCRIPTION
**What was wrong**

`plot_uf.m`'s documentation header explicitly allows `parameters.spins`
to be a cell array with "one or two" spin-string entries. However, the
`ppm`/`Hz` unit-conversion branches unconditionally index
`parameters.spins{2}` (used both for building `axis_f2` and for the
`offset_uf_cov` handling). A documented one-spin, homonuclear call
therefore throws an index-out-of-bounds error; there is no code path
that supplies a valid one-spin call.

**Why it matters physically**

Ultrafast constant-time 2D experiments are frequently run homonuclear
(the same nuclide in both the direct and the ultrafast-encoded
dimension), which is exactly the case the docstring documents as a
single-spin-string call. A user following the documented usage pattern
gets a crash instead of a plot, with no working alternative syntax.

**The fix**

Adopt the same "accommodate homonuclear sequences" pattern already used
in `kernel/plotting/plot_2d.m`: immediately after the `grumble` call,
if `parameters.spins` is scalar (one element), duplicate it into both
slots before it is used anywhere else in the function. No defaults are
invented; this mirrors an existing, already-reviewed idiom elsewhere in
the plotting kernel.

**Stock probe output**

```
CRASH: Index exceeds the number of array elements. Index must not exceed 1.
```

**Patched probe output**

```
NO_CRASH
```

(A `contour: Contour not rendered for constant ZData` warning is
expected because the probe uses an all-zero synthetic spectrum; it is
not an error.)

Finding id: F210