### PR TITLE
fix(comsol): correct sign in conc_plot longitudinal normalisation (F287)

### DIFF
--- a/interfaces/comsol/conc_plot.m
+++ b/interfaces/comsol/conc_plot.m
@@ -69,7 +69,7 @@ elseif size(obs,2)==3
     % Three observables: assume phase + amp + Z and map into HSV
     RGB=hsv2rgb(wrapTo2Pi(obs(:,1))/(2*pi),...
                 obs(:,2)/max(obs(:,2)),...
-                (obs(:,3)+min(obs(:,3)))/(max(obs(:,3))-min(obs(:,3))));
+                (obs(:,3)-min(obs(:,3)))/(max(obs(:,3))-min(obs(:,3))));
 
 else
 


### PR DESCRIPTION
## What was wrong
`interfaces/comsol/conc_plot.m`, three-observable branch, normalises the
longitudinal (Z) observable as
`(obs(:,3)+min(obs(:,3)))/(max(obs(:,3))-min(obs(:,3)))` — adding the
minimum instead of subtracting it. For `obs(:,3)=[-1;1]` this gives
`([-1;1]+(-1))/2 = [-1;0]` instead of the intended `[0;1]` normalisation.

## Why it matters physically
Any observable with a nonzero minimum (the ordinary case) gets an HSV
"value" component outside or shifted from [0,1], producing systematically
wrong colours/brightness for every non-degenerate longitudinal
observable, not just an edge case.

## Fix
Changed `+min(obs(:,3))` to `-min(obs(:,3))` so the value channel is
correctly normalised into [0,1].

## Stock probe output
Face colour RGB for the minimum-Z cell contained a component of -1.0000
(clearly outside the valid [0,1] colour range):
```
   -1.0000   -0.0955         0
```

## Patched probe output
Minimum-Z cell now renders black (V=0) and maximum-Z cell V=1:
```
         0         0         0
    1.0000    0.1910         0
```

## Finding id
F287