### PR TITLE
fix(utilities): rspt_eig crashes on symmetry-reduced level populations (F234)

### DIFF
--- a/kernel/utilities/rspt_eig.m
+++ b/kernel/utilities/rspt_eig.m
@@ -60,9 +60,6 @@ function [E,V,dE,T,LP]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,B)
 % Check consistency
 grumble(parameters,Hz,Hc,Hmw,B);
 
-% Hamiltonian, needed for both branches below
-H=B*Hz+Hc; H=full((H+H')/2);
-
 % Recursive call for symmetry
 if isfield(spin_system.bas,'irrep')
 
@@ -98,6 +95,9 @@ if isfield(spin_system.bas,'irrep')
     E=cell2mat(E); V=cell2mat(V);
 
 else
+
+    % Hamiltonian
+    H=B*Hz+Hc; H=full((H+H')/2);
 
     % Decide the method
     switch parameters.rspt_order
@@ -155,6 +155,9 @@ if (nargout>4)&&isfield(parameters,'rho0')
     LP=real(diag(V'*rho0*V));
 
 elseif nargout>4
+
+    % Hamiltonian
+    H=B*Hz+Hc; H=(H+H')/2;
 
     % Thermal equilibrium
     rho0=equilibrium(spin_system,H);

--- a/kernel/utilities/rspt_eig.m
+++ b/kernel/utilities/rspt_eig.m
@@ -60,6 +60,9 @@ function [E,V,dE,T,LP]=rspt_eig(spin_system,parameters,Hz,Hc,Hmw,B)
 % Check consistency
 grumble(parameters,Hz,Hc,Hmw,B);
 
+% Hamiltonian, needed for both branches below
+H=B*Hz+Hc; H=full((H+H')/2);
+
 % Recursive call for symmetry
 if isfield(spin_system.bas,'irrep')
 
@@ -95,9 +98,6 @@ if isfield(spin_system.bas,'irrep')
     E=cell2mat(E); V=cell2mat(V);
 
 else
-
-    % Hamiltonian
-    H=B*Hz+Hc; H=full((H+H')/2);
 
     % Decide the method
     switch parameters.rspt_order


### PR DESCRIPTION
## What was wrong

`rspt_eig` has two mutually exclusive branches gated on
`isfield(spin_system.bas,'irrep')`: the symmetry branch (recursive
per-irrep calls that assemble `E` and `V`) and the else branch, which
also builds `H=B*Hz+Hc`. Shared tail code after the branches computes
the 5th output (`LP`, level populations) via
`rho0=equilibrium(spin_system,H)` whenever 5 outputs are requested and
`parameters.rho0` was not supplied — but `H` was only ever assigned in
the else branch, never in the symmetry branch.

## Why it matters physically

Symmetry reduction of the basis (`spin_system.bas.irrep`) is a
standard performance feature. A user who symmetry-reduces the basis
and requests the documented 5th output without separately supplying
`parameters.rho0` gets an "unrecognized variable H" crash instead of
the thermal level populations.

## Fix

Moved the `H=B*Hz+Hc; H=full((H+H')/2);` construction out of the else
branch to run once before the `if`/`else`, using the same full
lab-frame `Hz`, `Hc`, `B` arguments that are already in scope in both
branches. `H` is now always defined by the time the shared tail code
runs, in both the symmetry and non-symmetry paths.

## Probe

Minimal `zeeman-hilb` `spin_system` with a two-irrep
`bas.irrep` symmetry basis, `rspt_order=Inf`, 5 outputs requested,
no `parameters.rho0` supplied.

- stock: `CRASHED: Unrecognized function or variable 'H'.` -> PROBE FAIL
- patched: `PROBE PASS: LP computed without error, LP=[0.5000000000 0.5000000000]`

`checkcode` on the changed file: clean, no findings.
`tests/kernel/test_dynamic_remaining_spectral_suite.m` (which exercises
the non-symmetry `rspt_eig` path against a dense-diagonalisation
reference) still passes with no failures.

## Finding id

F234