### PR TITLE
fix(comsol): guard conc_plot longitudinal normalisation against constant observable (F288)

### DIFF
--- a/interfaces/agents/spinach-knowledge/interfaces.md
+++ b/interfaces/agents/spinach-knowledge/interfaces.md
@@ -16,7 +16,7 @@
 | `interfaces/comsol/comsol_import.m` | `mesh=comsol_import(comsol)` | COMSOL 2D mesh data import, cropping and preprocessing for Spinach. Syntax: mesh=comsol_import(comsol) Parameters: comso | 100 |
 | `interfaces/comsol/comsol_mesh.m` | `mesh=comsol_mesh(file_name)` | Imports ASCII 2D mesh files produced by COMSOL. Syntax: mesh=comsol_mesh(file_name) Parameters: file_name -a character s | 146 |
 | `interfaces/comsol/comsol_velo.m` | `mesh=comsol_velo(mesh,file_name)` | Imports ASCII 2D flow velocity files produced by COMSOL. Syntax: mesh=comsol_velo(mesh,file_name) Parameters: mesh -mesh | 74 |
-| `interfaces/comsol/conc_plot.m` | `conc_plot(spin_system,conc,obs)` | 2D microfluidic concentration plotting function. Uses mesh tessellation information to plot concentrations as vertical b | 199 |
+| `interfaces/comsol/conc_plot.m` | `conc_plot(spin_system,conc,obs)` | 2D microfluidic concentration plotting function. Uses mesh tessellation information to plot concentrations as vertical b | 194 |
 | `interfaces/comsol/mesh_crop.m` | `mesh=mesh_crop(mesh,ranges)` | 2D microfluidic mesh cropping. Updates the mesh object to remove anything outside the user-specified vertex coordi- nate | 109 |
 | `interfaces/comsol/mesh_inact.m` | `mesh=mesh_inact(mesh,vertex_list)` | Marks 2D microfluidic mesh vertices as inactive in hydrodyna- mic and diffusive transport processes. Syntax: mesh=mesh_i | 63 |
 | `interfaces/comsol/mesh_plot.m` | `mesh_plot(spin_system,qscale,nodelabels)` | 2D microfluidic mesh plotting function. Draws the mesh, its Vo- ronoi tessellation, and a quiver plot of velocities. Syn | 101 |

--- a/interfaces/agents/spinach-knowledge/interfaces.md
+++ b/interfaces/agents/spinach-knowledge/interfaces.md
@@ -16,7 +16,7 @@
 | `interfaces/comsol/comsol_import.m` | `mesh=comsol_import(comsol)` | COMSOL 2D mesh data import, cropping and preprocessing for Spinach. Syntax: mesh=comsol_import(comsol) Parameters: comso | 100 |
 | `interfaces/comsol/comsol_mesh.m` | `mesh=comsol_mesh(file_name)` | Imports ASCII 2D mesh files produced by COMSOL. Syntax: mesh=comsol_mesh(file_name) Parameters: file_name -a character s | 146 |
 | `interfaces/comsol/comsol_velo.m` | `mesh=comsol_velo(mesh,file_name)` | Imports ASCII 2D flow velocity files produced by COMSOL. Syntax: mesh=comsol_velo(mesh,file_name) Parameters: mesh -mesh | 74 |
-| `interfaces/comsol/conc_plot.m` | `conc_plot(spin_system,conc,obs)` | 2D microfluidic concentration plotting function. Uses mesh tessellation information to plot concentrations as vertical b | 194 |
+| `interfaces/comsol/conc_plot.m` | `conc_plot(spin_system,conc,obs)` | 2D microfluidic concentration plotting function. Uses mesh tessellation information to plot concentrations as vertical b | 199 |
 | `interfaces/comsol/mesh_crop.m` | `mesh=mesh_crop(mesh,ranges)` | 2D microfluidic mesh cropping. Updates the mesh object to remove anything outside the user-specified vertex coordi- nate | 109 |
 | `interfaces/comsol/mesh_inact.m` | `mesh=mesh_inact(mesh,vertex_list)` | Marks 2D microfluidic mesh vertices as inactive in hydrodyna- mic and diffusive transport processes. Syntax: mesh=mesh_i | 63 |
 | `interfaces/comsol/mesh_plot.m` | `mesh_plot(spin_system,qscale,nodelabels)` | 2D microfluidic mesh plotting function. Draws the mesh, its Vo- ronoi tessellation, and a quiver plot of velocities. Syn | 101 |

--- a/interfaces/agents/spinach-knowledge/interfaces/comsol/conc_plot.md
+++ b/interfaces/agents/spinach-knowledge/interfaces/comsol/conc_plot.md
@@ -2,7 +2,7 @@
 
 - Source: `/home/kuprov/.openclaw/workspace/Spinach/interfaces/comsol/conc_plot.m`
 - Signature: `conc_plot(spin_system,conc,obs)`
-- Total lines: 194
+- Total lines: 199
 
 ## Purpose
 
@@ -27,51 +27,51 @@
 - Lines 50-51: Neutral grey if no observables supplied; implemented by `RGB=0.5*ones(spin_system.mesh.vor.ncells,3)`.
 - Lines 55-58: One observable: assume phase and map into middle hues; implemented by `RGB=hsv2rgb(wrapTo2Pi(obs)/(2*pi), 0.75*ones(size(spin_system.mesh.vor.cells,1),1), 0.50*ones(size(spin_system.mesh.vor.cells,1),1))`.
 - Lines 62-65: Two observables: assume phase + amp and map into HS; implemented by `RGB=hsv2rgb(wrapTo2Pi(obs(:,1))/(2*pi), obs(:,2)/max(obs(:,2)), 0.50*ones(size(spin_system.mesh.vor.cells,1),1))`.
-- Lines 69-72: Three observables: assume phase + amp + Z and map into HSV; implemented by `RGB=hsv2rgb(wrapTo2Pi(obs(:,1))/(2*pi), obs(:,2)/max(obs(:,2)), (obs(:,3)+min(obs(:,3)))/(max(obs(:,3))-min(obs(:,3))))`.
-- Lines 76-77: Complain and bomb out; implemented by `error('incorrect number of colour mapped observables.')`.
-- Lines 81-82: Find cells with significant bar heights; implemented by `active_cells=find(abs(conc)>1e-3*diff(spin_system.mesh.zext))`.
-- Lines 86-87: Preallocate cap geometry and colours; implemented by `V=zeros(total_vertices,3)`.
-- Lines 92-93: Build lids and bottoms; implemented by `for m=1:numel(active_cells)`.
-- Lines 95-96: Get the vertices of the Voronoi cell; implemented by `n=active_cells(m); nvert=cell_sizes(m)`.
-- Lines 103-104: Build the face connectivity index; implemented by `face=[1:nvert 1]+vertex_offset`.
-- Lines 107-108: Add the colour spec and advance the vertex offset; implemented by `FRGB(m,:)=RGB(n,:)`.
-- Lines 113-116: Draw lids and bottoms of the bars as a multifaceted patch; implemented by `patch('Faces',F,'Vertices',V,'FaceColor','flat', 'FaceVertexCData',FRGB,'EdgeColor','black', 'LineWidth',0.25,'LineJoin','round'); V(:,3)=0`.
-- Lines 121-122: Preallocate side geometry and colours; implemented by `V=zeros(2*total_vertices,3)`.
-- Lines 127-128: Build sides; implemented by `for m=1:numel(active_cells)`.
-- Lines 140-141: Build all walls for this cell; implemented by `local_idx=(1:nvert)'`.
-- Lines 148-149: Advance the vertex and face offsets; implemented by `vertex_offset=vertex_offset+2*nvert`.
+- Lines 69-76: Three observables: assume phase + amp + Z and map into HSV; implemented by `z_range=max(obs(:,3))-min(obs(:,3)); if z_range==0, z_val=ones(size(obs,1),1); else, z_val=(obs(:,3)+min(obs(:,3)))/z_range; end; RGB=hsv2rgb(wrapTo2Pi(obs(:,1))/(2*pi), obs(:,2)/max(obs(:,2)),z_val)`.
+- Lines 80-81: Complain and bomb out; implemented by `error('incorrect number of colour mapped observables.')`.
+- Lines 85-86: Find cells with significant bar heights; implemented by `active_cells=find(abs(conc)>1e-3*diff(spin_system.mesh.zext))`.
+- Lines 90-91: Preallocate cap geometry and colours; implemented by `V=zeros(total_vertices,3)`.
+- Lines 96-97: Build lids and bottoms; implemented by `for m=1:numel(active_cells)`.
+- Lines 99-100: Get the vertices of the Voronoi cell; implemented by `n=active_cells(m); nvert=cell_sizes(m)`.
+- Lines 107-108: Build the face connectivity index; implemented by `face=[1:nvert 1]+vertex_offset`.
+- Lines 111-112: Add the colour spec and advance the vertex offset; implemented by `FRGB(m,:)=RGB(n,:)`.
+- Lines 117-120: Draw lids and bottoms of the bars as a multifaceted patch; implemented by `patch('Faces',F,'Vertices',V,'FaceColor','flat', 'FaceVertexCData',FRGB,'EdgeColor','black', 'LineWidth',0.25,'LineJoin','round'); V(:,3)=0`.
+- Lines 125-126: Preallocate side geometry and colours; implemented by `V=zeros(2*total_vertices,3)`.
+- Lines 131-132: Build sides; implemented by `for m=1:numel(active_cells)`.
+- Lines 144-145: Build all walls for this cell; implemented by `local_idx=(1:nvert)'`.
+- Lines 152-153: Advance the vertex and face offsets; implemented by `vertex_offset=vertex_offset+2*nvert`.
 
 ### Control flow inferred from the code
 
 - Line 41: conditional branch on `exist('obs','var')`.
 - Line 48: conditional branch on `~exist('obs','var')`.
-- Line 93: `for` loop over `m=1:numel(active_cells)`.
-- Line 128: `for` loop over `m=1:numel(active_cells)`.
+- Line 97: `for` loop over `m=1:numel(active_cells)`.
+- Line 132: `for` loop over `m=1:numel(active_cells)`.
 
 ### Key state/data transformations
 
 - Lines 51: computes `RGB` using `RGB=0.5*ones(spin_system.mesh.vor.ncells,3)`.
-- Lines 82: computes `active_cells` using `active_cells=find(abs(conc)>1e-3*diff(spin_system.mesh.zext))`.
-- Lines 83: computes `cell_sizes` using `cell_sizes=cellfun(@numel,spin_system.mesh.vor.cells(active_cells))`.
-- Lines 84: computes `total_vertices` using `total_vertices=sum(cell_sizes)`.
-- Lines 87: computes `V` using `V=zeros(total_vertices,3)`.
-- Lines 88: computes `F` using `F=nan(numel(active_cells),spin_system.mesh.vor.max_cell_size+1)`.
-- Lines 89: computes `FRGB` using `FRGB=zeros(numel(active_cells),3)`.
-- Lines 90: computes `vertex_offset` using `vertex_offset=0`.
-- Lines 96: computes `n` using `n=active_cells(m); nvert=cell_sizes(m)`.
-- Lines 97: computes `vor_cell_x` using `vor_cell_x=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},1)`.
-- Lines 98: computes `vor_cell_y` using `vor_cell_y=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},2)`.
-- Lines 99: computes `vor_cell_z` using `vor_cell_z=conc(n)*ones(size(vor_cell_x))`.
-- Lines 100: computes `vertex_range` using `vertex_range=vertex_offset+(1:nvert)`.
-- Lines 101: computes `V(vertex_range,:)` using `V(vertex_range,:)=[vor_cell_x(:) vor_cell_y(:) vor_cell_z(:)]`.
-- Lines 104: computes `face` using `face=[1:nvert 1]+vertex_offset`.
-- Lines 105: computes `F(m,1:numel(face))` using `F(m,1:numel(face))=face`.
-- Lines 108: computes `FRGB(m,:)` using `FRGB(m,:)=RGB(n,:)`.
-- Lines 116: computes `'LineWidth',0.25,'LineJoin','round'); V(:,3)` using `'LineWidth',0.25,'LineJoin','round'); V(:,3)=0`.
+- Lines 86: computes `active_cells` using `active_cells=find(abs(conc)>1e-3*diff(spin_system.mesh.zext))`.
+- Lines 87: computes `cell_sizes` using `cell_sizes=cellfun(@numel,spin_system.mesh.vor.cells(active_cells))`.
+- Lines 88: computes `total_vertices` using `total_vertices=sum(cell_sizes)`.
+- Lines 91: computes `V` using `V=zeros(total_vertices,3)`.
+- Lines 92: computes `F` using `F=nan(numel(active_cells),spin_system.mesh.vor.max_cell_size+1)`.
+- Lines 93: computes `FRGB` using `FRGB=zeros(numel(active_cells),3)`.
+- Lines 94: computes `vertex_offset` using `vertex_offset=0`.
+- Lines 100: computes `n` using `n=active_cells(m); nvert=cell_sizes(m)`.
+- Lines 101: computes `vor_cell_x` using `vor_cell_x=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},1)`.
+- Lines 102: computes `vor_cell_y` using `vor_cell_y=spin_system.mesh.vor.vertices(spin_system.mesh.vor.cells{n},2)`.
+- Lines 103: computes `vor_cell_z` using `vor_cell_z=conc(n)*ones(size(vor_cell_x))`.
+- Lines 104: computes `vertex_range` using `vertex_range=vertex_offset+(1:nvert)`.
+- Lines 105: computes `V(vertex_range,:)` using `V(vertex_range,:)=[vor_cell_x(:) vor_cell_y(:) vor_cell_z(:)]`.
+- Lines 108: computes `face` using `face=[1:nvert 1]+vertex_offset`.
+- Lines 109: computes `F(m,1:numel(face))` using `F(m,1:numel(face))=face`.
+- Lines 112: computes `FRGB(m,:)` using `FRGB(m,:)=RGB(n,:)`.
+- Lines 120: computes `'LineWidth',0.25,'LineJoin','round'); V(:,3)` using `'LineWidth',0.25,'LineJoin','round'); V(:,3)=0`.
 
 ### Local helper functions
 
-- Line 162: `grumble()` — `function grumble(spin_system,conc,obs)`.
+- Line 166: `grumble()` — `function grumble(spin_system,conc,obs)`.
   - Representative operation: `if ~isfield(spin_system,'mesh')`.
   - Representative operation: `error('mesh information is missing from the spin_system structure.')`.
 

--- a/interfaces/comsol/conc_plot.m
+++ b/interfaces/comsol/conc_plot.m
@@ -67,9 +67,13 @@ elseif size(obs,2)==2
 elseif size(obs,2)==3
 
     % Three observables: assume phase + amp + Z and map into HSV
+    z_range=max(obs(:,3))-min(obs(:,3));
+
+    % Constant longitudinal observable maps to full value throughout
+    if z_range==0, z_val=ones(size(obs,1),1);
+    else, z_val=(obs(:,3)+min(obs(:,3)))/z_range; end
     RGB=hsv2rgb(wrapTo2Pi(obs(:,1))/(2*pi),...
-                obs(:,2)/max(obs(:,2)),...
-                (obs(:,3)+min(obs(:,3)))/(max(obs(:,3))-min(obs(:,3))));
+                obs(:,2)/max(obs(:,2)),z_val);
 
 else
 


### PR DESCRIPTION
## What was wrong
`interfaces/comsol/conc_plot.m`, three-observable branch, normalises the
longitudinal (Z) observable by dividing by
`max(obs(:,3))-min(obs(:,3))`. `grumble()` imposes no non-constant
requirement on `obs`. When `obs(:,3)` is constant across all Voronoi
cells, this range is zero, giving `0/0=NaN` and propagating NaN/Inf into
`hsv2rgb`.

## Why it matters physically
A uniform longitudinal observable is a physically ordinary case (e.g. no
Z-gradient present in the simulated region), not a degenerate input to
be rejected. The plot should render a valid single-colour result instead
of breaking.

## Fix
Guard the division: when the observable's range is zero, the value
channel is set to 1 throughout (a valid, well-defined single colour)
instead of dividing by zero.

## Stock probe output
```
F288 REPRODUCED: NaN/Inf face colours from constant longitudinal observable
```

## Patched probe output
```
F288 NOT REPRODUCED: no NaN/Inf face colours
```

## Finding id
F288