### PR TITLE
fix(trajan): avoid equal-limits crash for flat level population plots

### DIFF
--- a/kernel/trajan.m
+++ b/kernel/trajan.m
@@ -273,8 +273,16 @@ switch property
         % Compute Y axis extents
         max_val=max(result,[],'all');
         min_val=min(result,[],'all');
-        y_axis_extents=[min_val-0.05*(max_val-min_val) 
-                        max_val+0.05*(max_val-min_val)];
+        if max_val==min_val
+
+            % Pad a flat trajectory so that the axis limits differ
+            pad=max(0.05*abs(max_val),1e-6);
+            y_axis_extents=[max_val-pad max_val+pad];
+
+        else
+            y_axis_extents=[min_val-0.05*(max_val-min_val)
+                            max_val+0.05*(max_val-min_val)];
+        end
 
     otherwise
         


### PR DESCRIPTION
## What was wrong

In `kernel/trajan.m`'s `'level_populations'` branch, the Y-axis extents
are computed as
`[min_val-0.05*(max_val-min_val) max_val+0.05*(max_val-min_val)]`. When
every plotted population is numerically identical, `max_val==min_val`
and both limits collapse to the same number. MATLAB's `ylim()` raises
an error on equal lower/upper bounds, crashing the plot instead of
drawing a flat line.

## Why it matters physically

A thermal-equilibrium or steady-state trajectory has, by definition,
constant level populations over the plotted range. This is exactly the
situation right before dynamics start in
`examples/dnp_mas/cross_effect_mas_steady.m` and
`examples/dnp_mas/solid_effect_mas_steady.m`. Any diagnostic call to
`trajan(...,'level_populations')` on such a trajectory crashes instead
of showing the (entirely valid) flat line.

## Stock probe output

```
PROBE FAIL: Limits must be a 2-element vector of increasing numeric values.
```

## Patched probe output

```
PROBE PASS
```

Probe: single `'1H'` spin system in `sphten-liouv` formalism, using
`unit_state` (the maximally mixed state, with exactly equal Zeeman
level populations) repeated across 5 time points, then calling
`trajan(spin_system,traj,'level_populations')`. The existing
`tests/kernel/test_dynamic_trajectory_frontends.m` suite still passes
unchanged.

Finding id: F223