### PR TITLE
fix(kernel): align dcm2euler reconstruction tolerance with its own admissibility gate (F296)

### DIFF
--- a/kernel/conventions/transforms/dcm2euler.m
+++ b/kernel/conventions/transforms/dcm2euler.m
@@ -59,7 +59,7 @@ q.j=evecs(3,best); q.k=evecs(4,best);
 alpha=mod(alpha,2*pi); gamma=mod(gamma,2*pi);
 
 % Make sure the result is good enough and bomb out if not
-if norm(dcm-euler2dcm(alpha,beta,gamma),1)>1e-3
+if norm(dcm-euler2dcm(alpha,beta,gamma),1)>1e-2
     disp(dcm); disp(euler2dcm(alpha,beta,gamma));
     error('DCM to Euler conversion failed.');
 end


### PR DESCRIPTION
## What was wrong
`kernel/conventions/transforms/dcm2euler.m`'s `grumble()` accepts a
non-orthogonal DCM up to 1e-2 orthogonality/determinant deviation
(warning only below that, hard error above). But the post-hoc
nearest-rotation reconstruction check on line 62 errored whenever the
residual `norm(dcm-euler2dcm(alpha,beta,gamma),1)` exceeded the much
tighter 1e-3. A DCM that passes the function's own admissibility gate
(e.g. `dcm=1.002*eye(3)`, orthogonality deviation ~0.004, only a
warning) can have a reconstruction residual (~0.002) that exceeds 1e-3,
so the function still crashed with `'DCM to Euler conversion failed.'`
on input it had itself just accepted.

## Why it matters physically
Mildly non-orthogonal DCMs of this kind arise routinely from imperfectly
refined orientation matrices (e.g. fit from experimental or MD data,
plausible at the 0.1-0.5% level). The function's documentation promises
it "either returns a correct answer or gives an informative error" for
admissible input; instead it silently contradicted its own admissibility
gate and threw an opaque failure on physically ordinary input.

## Fix
Raised the reconstruction residual tolerance from 1e-3 to 1e-2 so it is
consistent with the orthogonality/determinant tolerance `grumble()`
actually enforces. Exact proper rotations are unaffected — reconstruction
error stays at machine precision — and genuinely non-orthogonal input
beyond 1e-2 is still rejected by `grumble()` before reaching this check,
so no invalid input becomes silently accepted.

## Stock probe output
```
F296 REPRODUCED: DCM to Euler conversion failed.
```

## Patched probe output
```
F296 NOT REPRODUCED: dcm2euler succeeded
```
Sanity checks on the patched code: exact proper rotation round-trips to
machine precision (`max abs error: 4.44089e-16`); a badly non-orthogonal
DCM (`1.05*eye(3)`) is still correctly rejected by `grumble()`.

## Finding id
F296