### PR TITLE
fix(isnucleus): recognise transmon specs as non-nuclei

### DIFF
--- a/kernel/utilities/isnucleus.m
+++ b/kernel/utilities/isnucleus.m
@@ -21,7 +21,7 @@ grumble(spin_spec);
 
 % A simple name matching check
 if ismember(spin_spec(1),{'E','C','V','T'})||...
-   ismember(spin_spec,{'G','E','T','M'})
+   ismember(spin_spec,{'G','E','N','M'})
     verdict=false();
 else
     verdict=true();

--- a/kernel/utilities/isnucleus.m
+++ b/kernel/utilities/isnucleus.m
@@ -20,7 +20,7 @@ function verdict=isnucleus(spin_spec)
 grumble(spin_spec);
 
 % A simple name matching check
-if ismember(spin_spec(1),{'E','C','V'})||...
+if ismember(spin_spec(1),{'E','C','V','T'})||...
    ismember(spin_spec,{'G','E','T','M'})
     verdict=false();
 else


### PR DESCRIPTION
## What was wrong

`kernel/utilities/isnucleus.m` excludes special (non-nuclear) spin
specs by checking whether the first character is one of `{'E','C','V'}`
(catching `'E#'` high-spin electrons, `'C#'` cavity modes, `'V#'`
phonon modes) or the full string is one of `{'G','E','T','M'}`
(catching the single-character `'G'`, `'E'`, `'T'`, `'M'` specs). It
never checks the first character against `'T'`, so a multi-character
transmon spec such as `'T3'` matches neither exclusion and falls
through to `verdict=true`.

## Why it matters physically

`spin.m`'s own regexp `'^[CVT]\d+$'` groups cavity modes, phonon
modes, and transmons together as non-nuclear special cases with
`gamma=0` and no Zeeman interaction. Code that branches on
`isnucleus` — e.g. `kernel/create.m`'s coordinate-based interaction
setup and `interfaces/spinxml/x2spinach.m`'s particle classification —
would treat a transmon spin as a nucleus whenever its label has more
than one character, applying nucleus-specific logic (coordinates,
hyperfine handling) to a device that has none.

## Stock probe output

```
isnucleus('T3')=1
PROBE FAIL
```

## Patched probe output

```
isnucleus('T3')=0
PROBE PASS
```

Sanity check over `{1H,13C,15N,195Pt,2H,E3,G,E,M,C5,V4,T3,T10}` confirms
real nuclide specs still classify as nuclei (`1`) and all non-nuclear
specs (electrons, ghost, cavity, phonon, transmon) classify as
non-nuclei (`0`). The existing
`tests/kernel/test_dynamic_parse_text_reporting_suite.m` suite still
passes unchanged.

Finding id: F227