### PR TITLE
fix(evolution): refuse total integral for polyadic Liouvillians with a clear error

### DIFF
--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -121,6 +121,11 @@ grumble(L,coil,rho,timestep,nsteps,output);
 % Call Krylov propagation for polyadics
 if isa(L,'polyadic')
 
+    % Refuse integrals of unitary dynamics
+    if strcmp(output,'total')&&strcmp(spin_system.bas.formalism,'zeeman-wavef')
+        error('total observable integral is not defined for unitary wavefunction evolution.');
+    end
+
     % Refuse relaxation-weighted integrals, krylov() has no such case
     if strcmp(output,'total')
         error('total observable integral is not implemented for polyadic Liouvillians, use inflate(L) to materialise it first.');

--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -120,8 +120,16 @@ grumble(L,coil,rho,timestep,nsteps,output);
 
 % Call Krylov propagation for polyadics
 if isa(L,'polyadic')
+
+    % Refuse relaxation-weighted integrals, krylov() has no such case
+    if strcmp(output,'total')
+        error('total observable integral is not implemented for polyadic Liouvillians, use inflate(L) to materialise it first.');
+    end
+
+    % Forward everything else to the Krylov propagator
     report(spin_system,'polyadic generator received, forwarding to krylov()...');
     answer=krylov(spin_system,L,coil,rho,timestep,nsteps,output); return;
+
 end
 
 % Gather state vectors from GPUs

--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -121,9 +121,9 @@ grumble(L,coil,rho,timestep,nsteps,output);
 % Call Krylov propagation for polyadics
 if isa(L,'polyadic')
 
-    % Refuse integrals of unitary dynamics
-    if strcmp(output,'total')&&strcmp(spin_system.bas.formalism,'zeeman-wavef')
-        error('total observable integral is not defined for unitary wavefunction evolution.');
+    % Refuse integrals outside Liouville space
+    if strcmp(output,'total')&&any(strcmp(spin_system.bas.formalism,{'zeeman-wavef','zeeman-hilb'}))
+        error('total observable integral is only defined in Liouville space.');
     end
 
     % Refuse relaxation-weighted integrals, krylov() has no such case

--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -975,9 +975,6 @@ function grumble(L,coil,rho,timestep,nsteps,output)
 if ~isnumeric(L)
     error('Liouvillian must be numeric.');
 end
-if isa(L,'polyadic')&&strcmp(output,'total')
-    error('total observable integral is not available for polyadic generators.');
-end
 if ~isnumeric(coil)
     error('coil argument must be numeric.');
 end
@@ -993,6 +990,9 @@ end
 if (~ischar(output))||(~ismember(output,{'observable','final',...
    'trajectory','total','multichannel','refocus'}))
     error('observable argument must be a valid character string.');
+end
+if isa(L,'polyadic')&&strcmp(output,'total')
+    error('total observable integral is not available for polyadic generators.');
 end
 end
 

--- a/kernel/evolution.m
+++ b/kernel/evolution.m
@@ -120,21 +120,8 @@ grumble(L,coil,rho,timestep,nsteps,output);
 
 % Call Krylov propagation for polyadics
 if isa(L,'polyadic')
-
-    % Refuse integrals outside Liouville space
-    if strcmp(output,'total')&&any(strcmp(spin_system.bas.formalism,{'zeeman-wavef','zeeman-hilb'}))
-        error('total observable integral is only defined in Liouville space.');
-    end
-
-    % Refuse relaxation-weighted integrals, krylov() has no such case
-    if strcmp(output,'total')
-        error('total observable integral is not implemented for polyadic Liouvillians, use inflate(L) to materialise it first.');
-    end
-
-    % Forward everything else to the Krylov propagator
     report(spin_system,'polyadic generator received, forwarding to krylov()...');
     answer=krylov(spin_system,L,coil,rho,timestep,nsteps,output); return;
-
 end
 
 % Gather state vectors from GPUs
@@ -987,6 +974,9 @@ end
 function grumble(L,coil,rho,timestep,nsteps,output)
 if ~isnumeric(L)
     error('Liouvillian must be numeric.');
+end
+if isa(L,'polyadic')&&strcmp(output,'total')
+    error('total observable integral is not available for polyadic generators.');
 end
 if ~isnumeric(coil)
     error('coil argument must be numeric.');


### PR DESCRIPTION
## What was wrong

`kernel/evolution.m` forwarded every polyadic generator to `krylov()` regardless of the requested output. `krylov()` has no `'total'` case, so a relaxation-weighted total integral requested with a polyadic Liouvillian died inside `krylov()` with the generic "unknown output option" message. The dense route computes that integral by a direct solve, which polyadics cannot do by design (matrix-vector products only), so the correct behaviour is a clear refusal.

## Fix

One three-line test in `grumble`: a polyadic `L` together with `output='total'` is refused with `total observable integral is not available for polyadic generators.` The message makes no claim about what would work instead, so it holds in every formalism, and the function body is exactly as on main.

## Validation

Two-spin sphten-liouv system with a damping relaxation superoperator, `L` wrapped as `polyadic({{L,speye(1)}})`:
- polyadic with `'total'`: refused from `grumble` with the message above;
- polyadic with `'observable'`: forwarded to `krylov()`, result equal to the dense route to 3e-15 relative;
- dense with `'total'`: unchanged.

`checkcode` clean; the two house-style items the checker reports in this file are pre-existing and untouched.

Finding id: F154