### PR TITLE
fix(isoswap): use the documented inter.giant.coeff field name

### DIFF
--- a/kernel/utilities/isoswap.m
+++ b/kernel/utilities/isoswap.m
@@ -54,8 +54,8 @@ end
 % Wipe high-rank couplings
 if isfield(inter,'giant')
     for n=spins(:)'
-        if ~isempty(inter.giant.coef{n})
-            inter.giant.coef{n}={}; inter.giant.euler{n}={};
+        if ~isempty(inter.giant.coeff{n})
+            inter.giant.coeff{n}={}; inter.giant.euler{n}={};
             disp(['WARNING: high-rank coupling for spin ' int2str(n) ...
                   ' wiped (not transferable).']);
         end


### PR DESCRIPTION
## What was wrong

`kernel/utilities/isoswap.m` read and wrote `inter.giant.coef` (single
trailing `f`). Every other consumer and producer of this data —
`kernel/create.m`, `kernel/hamiltonian.m`,
`kernel/utilities/kill_spin.m`, and `kernel/utilities/validate_sym.m`
— stores and reads it under `inter.giant.coeff` (double `ff`). The
field simply does not exist under the name `isoswap.m` used.

## Why it matters physically

Any isotope swap (`isoswap`) on a spin system that has the documented
high-rank giant-spin interaction (`inter.giant` present, as built by
`kernel/create.m`) crashes outright with an undefined-field error,
regardless of whether the particular spin being swapped actually
carries a giant-spin coefficient — the check itself throws before it
can determine that.

## Stock probe output

```
PROBE FAIL: Unrecognized field name "coef".
```

## Patched probe output

```
PROBE PASS
```

Probe: two-spin `'1H'`/`'1H'` system with `inter.giant.coeff`/`euler`
present (empty cells) and `isoswap(sys,inter,1,'2H')`. A second probe
with a non-empty `inter.giant.coeff{1}` confirms the existing
wipe-and-warn path (quadratic/high-rank couplings are not transferable
across an isotope swap) still fires correctly and empties the field.
The existing `tests/kernel/test_dynamic_remaining_core_suite.m` suite
still passes unchanged.

Finding id: F228