### PR TITLE
fix(kinetics): make equilibrate() conditioning check unit-independent

### DIFF
--- a/kernel/kinetics/equilibrate.m
+++ b/kernel/kinetics/equilibrate.m
@@ -39,6 +39,10 @@ if n_indep_rxns>1
     return;
 end
 
+% Normalise the rate scale so that conditioning does not depend on time units
+rate_scale=max(abs(K(:)));
+if rate_scale>0, K=K/rate_scale; end
+
 % Assemble the steady state system
 A=vertcat(ones(1,size(K,2)),K);
 b=vertcat(sum(c0),zeros(size(K,1),1));


### PR DESCRIPTION
## What was wrong

`kernel/kinetics/equilibrate.m` line 47: the equilibrium solver stacks
an unscaled row of ones on top of the raw rate matrix `K` (forming
`A=[ones(1,n); K]`) and rejects the system whenever `cond(A)` exceeds
`1/sqrt(eps)`. For a fully connected, uniquely constrained `K` whose
rate constants are uniformly small in whatever time units were chosen
(e.g. an intermediate or slow rate around `1e-8` in SI units, or during
least-squares fitting where rate magnitude is poorly bounded, as in
`examples/fitting/nmr_kinetics/glucose_exsy_*.m`), `cond(A)` is pushed
past the threshold purely by the scale mismatch between the
dimensionless `ones` row (magnitude 1) and the small-magnitude rate
rows — not by any real singularity.

## Why it matters physically

A scientist supplying a structurally well-connected but small- or
intermediate-magnitude rate matrix gets a hard error
(`"kinetic matrix does not constrain the equilibrium."`) instead of
the correct answer, purely as an artefact of the time units chosen.
The equilibrium of a fully connected, mass-conserving reaction network
is unique and well posed independent of the numerical value of the
(nonzero) rate constants — equal long-time populations do not depend
on how fast the system gets there, only on the connectivity.

## Fix

Normalise `K` by its own largest-magnitude entry (`max(abs(K(:)))`)
before assembling `A` and checking `cond(A)`, guarding the division
for the edge case of an isolated single species with `K=0`. Scaling
`K` by a positive constant leaves its null space unchanged (so the
equilibrium condition `K*c=0` is unaffected), and every scaled row's
target in `b` is still exactly zero, so `A\b` returns the identical
equilibrium as before for any `K` that previously passed — this is a
pure scale-invariance fix, not a change to the underlying physics or
the accepted-vs-rejected boundary for genuinely singular cases.

## Stock probe output (fails)

Two-state exchange, `k=1e-8`, fully connected, unique equilibrium
`[0.5 0.5]` by inspection:

```
CAUGHT ERROR: kinetic matrix does not constrain the equilibrium.
```

## Patched probe output (passes)

```
equilibrium concentrations: 0.5000000000 0.5000000000
max abs error vs analytic equilibrium: 0.000000e+00
```

## Regression check

- Normal-magnitude rate matrix (`k~O(1)`): equilibrium unchanged,
  matches the analytic `[3/5 2/5]` reference to `5.6e-17`.
- Isolated single species (`K=0`, no reactions): returns `c0`
  unchanged, division-by-zero guard verified.

`checkcode` on `kernel/kinetics/equilibrate.m`: clean, no findings.

## Finding id

F167

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>