### PR TITLE
fix(guess_csa_pro): include the last residue in the amide proton CSA loop

### DIFF
--- a/etc/estimators/guess_csa_pro.m
+++ b/etc/estimators/guess_csa_pro.m
@@ -211,7 +211,7 @@ for n=1:(max(aa_nums)-1)
 end
 
 % Loop over amino acids
-for n=2:(max(aa_nums)-1)
+for n=2:max(aa_nums)
     
     % Assign H-N proton CSAs
     if ismember('H',pdb_ids(aa_nums==n))&&...


### PR DESCRIPTION
Finding: F004 (etc/estimators/guess_csa_pro.m:214)

**What was wrong.** The amide-proton CSA loop ran `for n=2:(max(aa_nums)-1)`, so the C-terminal residue's amide 1H CSA was never assigned even though everything the body needs (H, N, CA of residue n and C of residue n-1) is present for the last residue. No warning was printed.

**Why it matters.** Every protein imported through `protein.m` with CSA guessing silently lacked the amide-proton CSA tensor of its last residue, understating the CSA relaxation contribution for that proton with no diagnostic.

**Fix.** Loop bound changed to `for n=2:max(aa_nums)`. One line, no other physics touched. The 15N and 13C=O loops are unchanged: they need residue n+1 and are correctly bounded.

**Probe.** Synthetic three-residue backbone (N, H, CA, C, O per residue, planar, within the distance checks), `options=struct()`.

Stock output:
```
Amide proton CSA for residue 2 guessed from local geometry.
Residue 1 amide H CSA present: 0
Residue 2 amide H CSA present: 1
Residue 3 amide H CSA present: 0
```

Patched output:
```
Amide proton CSA for residue 2 guessed from local geometry.
Amide proton CSA for residue 3 guessed from local geometry.
Residue 1 amide H CSA present: 0
Residue 2 amide H CSA present: 1
Residue 3 amide H CSA present: 1
```

checkcode on the changed file: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)