### PR TITLE
kronm_test_1: bound random dimensions so the dense reference matrix fits in memory (F041)

### DIFF
--- a/examples/fundamentals/tensor_structures/kronm_test_1.m
+++ b/examples/fundamentals/tensor_structures/kronm_test_1.m
@@ -7,7 +7,7 @@ function kronm_test_1()
 % Pick random dimensions
 nmats=randi(4,1,1)+2; disp(['number of matrices in Q: ' num2str(nmats)]);
 ncols=randi(20,1,1); disp(['number of columns in x:  ' num2str(ncols)]);
-dims=randi(7,nmats,1)+2; disp(['dims of matrices in Q:   ' num2str(dims')]);
+dims=randi(3,nmats,1)+1; disp(['dims of matrices in Q:   ' num2str(dims')]);
 
 % Generate real Q and x
 Q_terms=cell(1,nmats); Q=1;


### PR DESCRIPTION
## Finding

F041: `examples/fundamentals/tensor_structures/kronm_test_1.m`

## What was wrong

The test draws `nmats=randi(4)+2` (3 to 6) matrices of size `randi(7)+2` (3 to 9) and materialises their full Kronecker product `Q` with `kron()` as the dense reference for `kronm()`. `prod(dims)` can reach 9^6=531441, so the dense reference needs up to 2.3 TB (real) or 4.5 TB (complex). Scanning rng seeds 1 to 2000, 86 draws need more than 100 GB and the worst needs 2.5 TB.

## Why it matters

A shipped unit test should not crash or hang the MATLAB session on an unlucky random draw. The test exists to check `kronm` against `mtimes`; the reference does not need to be large for that.

## Fix

One line: matrix sizes are now `randi(3)+1` (2 to 4), so the dense reference is at most 4096x4096 (268 MB complex). Number of matrices and number of columns are unchanged.

## Stock probe output (seed 1274)

```
worst prod(dims) over 2000 seeds: 413343, seed 1274, dense Q needs 1272.9498 GB (real), 2545.8997 GB (complex)
draws needing >100 GB: 86 of 2000
number of matrices in Q: 6
number of columns in x:  1
dims of matrices in Q:   9  9  7  9  9  9
Requested 9x45927x9x45927 (1272.9GB) array exceeds maximum array size
preference (247.4GB) and might cause MATLAB to become unresponsive.
Error in kron (line 35)
Error in kronm_test_1 (line 16)
    Q=kron(Q,Q_terms{n});
```

## Patched probe output (worst seed 1233)

```
worst prod(dims) over 2000 seeds: 4096, seed 1233, dense Q needs 0.125 GB (real), 0.25 GB (complex)
draws needing >100 GB: 0 of 2000
number of matrices in Q: 6
number of columns in x:  14
dims of matrices in Q:   4  4  4  4  4  4
kronm time:  1.0469 seconds
mtimes time: 0.031393 seconds
Real matrix test PASSED.
kronm time:  0.10767 seconds
mtimes time: 0.13731 seconds
Complex matrix test PASSED.
```

`checkcode` on the changed file: 0 findings.
