### PR TITLE
fix(guess_j_nuc): remove duplicate C2p_C3p_H2p record from the triples database

### DIFF
--- a/etc/estimators/guess_j_nuc.m
+++ b/etc/estimators/guess_j_nuc.m
@@ -178,7 +178,7 @@ triples_database={...
 
 % Generic numbers for the backbone (to be replaced with DFT values - Zenawi)
 'C1p_C2p_C3p'   1, 2, 3,  J_CCC;  'C1p_C2p_H2p'   1, 2, 3,  J_CCH;   'C2p_C3p_C4p'  1, 2, 3,  J_CCC;
-'C3p_C4p_H4p'   3, 1, 2,  J_CCH;  'C3p_C4p_C5p'   1, 2, 3,  J_CCC;   'C2p_C3p_H2p'  1, 2, 3,  J_CCH;  
+'C3p_C4p_H4p'   3, 1, 2,  J_CCH;  'C3p_C4p_C5p'   1, 2, 3,  J_CCC;
 'C3p_C4p_H3p'   2, 1, 3,  J_CCH;  'C5p_H5p_H5pp'  2, 1, 3,  J_HCH;   'C1p_C2p_H1p'  3, 1, 2,  J_CCH;
 'C1p_C2p_H2pp'  3, 2, 1,  J_CCH;  'C2p_C3p_H2pp'  3, 1, 2,  J_CCH;  
 

--- a/etc/estimators/guess_j_nuc.m
+++ b/etc/estimators/guess_j_nuc.m
@@ -61,16 +61,16 @@ J_NH=86.0; J_CN=20.0; J_CH=180.0; J_CC=65.0;
 pairs_database={...
 
 % RNA specific values from the literature
-'C1p_N9'   , 11.0;    'C1p_N1'   , 12.0;    'H_N1'     , 95.0;   'H3_N3'    , 91.0;   
+'C1p_N9'   , 11.0;    'C1p_N1'   , 12.0;    'H1_N1'    , 95.0;   'H3_N3'    , 91.0;   
 'C6_N1'    , 7.5;     'C4_N3'    , 10.7;    'C4_C5'    , 65.0;   'C5_H5'    , 176;  
 'C8_H8'    , 216.0;   'C6_H6'    , 185.0;   'C5_C6'    , 67.0;   'C2_N3'    , 19.0;  
 'C2_N1'    , 19.0;    'C4_N9'    , 20.0;    'H41_N4'   , 86.0;   'C4_N4'    , 20.0;
-'C8_N9'    , 11.0;    'C1p_H1p'  , 170.0;   'C_C5'     , 55.0;   'H42_N4'   , 86.0;    
+'C8_N9'    , 11.0;    'C1p_H1p'  , 170.0;   'H42_N4'   , 86.0;    
 
 % Generics for the conjugated ring (to be replaced with DFT values - Zenawi)
 'C2_H2'    , J_CH;    'C5_N7'    , J_CN;    'C8_N7'    , J_CN;   'C6_N6'    , J_CN;
 'H61_N6'   , J_NH;    'H62_N6'   , J_NH;    'C2_N2'    , J_CN;   'H21_N2'   , J_NH;
-'H1_N1'    , J_NH;    'H22_N2'   , J_NH;    'H61_N1'   , J_NH;
+'H22_N2'   , J_NH;
 
 % Generics for the sugar ring (to be replaced with DFT values - Zenawi)
 'C1p_C2p'  , J_CC;    'C2p_H2p'  , J_CH;    'C3p_C4p'  , J_CC;   'C4p_H4p'  , J_CH;
@@ -153,7 +153,7 @@ triples_database={...
     
 % Backbone data from the literature
 'C4p_C5p_H5p'  1, 2, 3,  -5.5;   'C4p_C5p_H5pp'  1, 2, 3,   2.0;   'C4p_C5p_H4p' 3, 1, 2,  -5.5;
-'C2p_C3p_H3p'  1, 2, 3,  -2.3;   'C2p_C3p_H2p'   3, 2, 1,   2.3;  
+'C2p_C3p_H3p'  1, 2, 3,  -2.3;   'C2p_C3p_H2p'   2, 1, 3,   2.3;  
 
 % Conjugated ring data from the literature
 'C4_C5_C6'     1, 2, 3,   9.5;   'C4_C8_N9'      1, 3, 2,   8.0;   'C2_C4_N3'    1, 3, 2,  10.0;
@@ -168,7 +168,7 @@ triples_database={...
 'C6_H62_N6'    1, 3, 2,  J_CNH;  'C8_N7_N9'      2, 1, 3,  J_NCN;  'C1p_C8_N9'    2, 3, 1,  J_CNC;  
 'C2_N1_N2'     2, 1, 3,  J_NCN;  'C2_H1_N1'      1, 3, 2,  J_CNH;  'C2_H21_N2'    1, 3, 2,  J_CNH;  
 'C2_H22_N2'    1, 3, 2,  J_CNH;  'C2_N2_N3'      3, 1, 2,  J_NCN;  'C6_H1_N1'     1, 3, 2,  J_CNH;      
-'C5_C6_N1'     2, 1, 3,  J_CCN;  'C6_H6_N1'      3, 1, 2,  J_NCH;  'C1p_C2_N1'    2, 3, 1,  J_CNC;                                    
+'C5_C6_N1'     1, 2, 3,  J_CCN;  'C6_H6_N1'      3, 1, 2,  J_NCH;  'C1p_C2_N1'    2, 3, 1,  J_CNC;                                    
 'C4_N3_N4'     2, 1, 3,  J_NCN;  'C4_H41_N4'     1, 3, 2,  J_CNH;  'C4_H42_N4'    1, 3, 2,  J_CNH;  
 'C4_C5_N4'     2, 1, 3,  J_CCN;  'C5_C6_H6'      1, 2, 3,  J_CCH;  'C1p_C6_N1'    2, 3, 1,  J_CNC;
 'C5_C6_H5'     2, 1, 3,  J_CCH;  'C2_H3_N3'      1, 3, 2,  J_CNH;  'C4_H3_N3'     1, 3, 2,  J_CNH;    
@@ -178,11 +178,11 @@ triples_database={...
 
 % Generic numbers for the backbone (to be replaced with DFT values - Zenawi)
 'C1p_C2p_C3p'   1, 2, 3,  J_CCC;  'C1p_C2p_H2p'   1, 2, 3,  J_CCH;   'C2p_C3p_C4p'  1, 2, 3,  J_CCC;
-'C3p_C4p_H4p'   3, 1, 2,  J_CCH;  'C3p_C4p_C5p'   1, 2, 3,  J_CCC;
+'C3p_C4p_H4p'   1, 2, 3,  J_CCH;  'C3p_C4p_C5p'   1, 2, 3,  J_CCC;
 'C3p_C4p_H3p'   2, 1, 3,  J_CCH;  'C5p_H5p_H5pp'  2, 1, 3,  J_HCH;   'C1p_C2p_H1p'  3, 1, 2,  J_CCH;
 'C1p_C2p_H2pp'  3, 2, 1,  J_CCH;  'C2p_C3p_H2pp'  3, 1, 2,  J_CCH;  
 
-'C2p_C3p_H2p1' 1, 2, 3,  J_CCH; 'C1p_C2p_H2p1'  1, 2, 3,  J_CCH;  'C4p_C5p_H5p2'  1, 2, 3,  J_CCH;  
+'C2p_C3p_H2p1' 3, 1, 2,  J_CCH; 'C1p_C2p_H2p1'  1, 2, 3,  J_CCH;  'C4p_C5p_H5p2'  1, 2, 3,  J_CCH;  
 'C4p_C5p_H5p1' 1, 2, 3, J_CCH; 'C5p_H5p1_H5p2'  2, 1, 3, J_HCH};
 
 % Exception list for four-membered rings
@@ -302,7 +302,7 @@ quads_database={...
 'C2_C5_C6_N1',      1, 4, 3, 2, [0.0 0.0 0.0];  'C5_C6_H1_N1',       3, 4, 2, 1, [0.0 0.0 0.0];
 'C2_C6_N1_N2',      4, 1, 3, 2, [0.0 0.0 0.0];  'C2_H1_N1_N2',       4, 1, 3, 2, [0.0 0.0 0.0];
 'C2_H1_N1_N3',      4, 1, 3, 2, [0.0 0.0 0.0];  'C2_H21_N2_N3',      4, 1, 3, 2, [0.0 0.0 0.0];  
-'C2_H21_N1_N2',     3, 1, 4, 2, [0.0 0.0 0.0];  'C2_H22_N2_N1',      3, 1, 4, 2, [0.0 0.0 0.0];
+'C2_H21_N1_N2',     3, 1, 4, 2, [0.0 0.0 0.0];
 'C2_C4_N2_N3',      2, 4, 1, 3, [0.0 0.0 0.0];  'C1p_C4_C5_N9',      3, 2, 4, 1, [0.0 0.0 0.0];
 'C1p_C4_N3_N9',     3, 2, 4, 1, [0.0 0.0 0.0];  'C1p_C5_C6_N1',      1, 4, 3, 2, [0.0 0.0 0.0];
 'C2_C6_H6_N1',      1, 4, 2, 3, [0.0 0.0 0.0];  'C5_C6_H5_N1',       4, 2, 1, 3, [0.0 0.0 0.0];

--- a/etc/estimators/guess_j_nuc.m
+++ b/etc/estimators/guess_j_nuc.m
@@ -156,7 +156,7 @@ triples_database={...
     
 % Backbone data from the literature
 'C4p_C5p_H5p'  1, 2, 3,  -5.5;   'C4p_C5p_H5pp'  1, 2, 3,   2.0;   'C4p_C5p_H4p' 3, 1, 2,  5.5;
-'C2p_C3p_H3p'  1, 2, 3,  2.3;   'C2p_C3p_H2p'   2, 1, 3,   2.3;  
+'C2p_C3p_H3p'  1, 2, 3,  2.3;   'C2p_C3p_H2p'   2, 1, 3,   -2.3;  
 
 % Conjugated ring data from the literature
 'C4_C5_C6'     1, 2, 3,   9.5;   'C4_C8_N9'      1, 3, 2,   8.0;   'C2_C4_N3'    1, 3, 2,  10.0;

--- a/etc/estimators/guess_j_nuc.m
+++ b/etc/estimators/guess_j_nuc.m
@@ -65,10 +65,13 @@ pairs_database={...
 'C6_N1'    , -7.5;     'C4_N3'    , -10.7;    'C4_C5'    , 65.0;   'C5_H5'    , 176;  
 'C8_H8'    , 216.0;   'C6_H6'    , 185.0;   'C5_C6'    , 67.0;   'C2_N3'    , -19.0;  
 'C2_N1'    , -19.0;    'C4_N9'    , -20.0;    'H41_N4'   , -86.0;   'C4_N4'    , -20.0;
-'C8_N9'    , -11.0;    'C1p_H1p'  , 170.0;   'H42_N4'   , -86.0;    
+'C8_N9'    , -11.0;    'C1p_H1p'  , 170.0;   'H42_N4'   , -86.0;
+
+% Pyridine-type N7 bonds, small and positive (B3LYP/pcJ-2, 9-methyladenine and 9-methylguanine)
+'C5_N7'    , 1.9;     'C8_N7'    , 0.4;
 
 % Generics for the conjugated ring (to be replaced with DFT values - Zenawi)
-'C2_H2'    , J_CH;    'C5_N7'    , J_CN;    'C8_N7'    , J_CN;   'C6_N6'    , J_CN;
+'C2_H2'    , J_CH;    'C6_N6'    , J_CN;
 'H61_N6'   , J_NH;    'H62_N6'   , J_NH;    'C2_N2'    , J_CN;   'H21_N2'   , J_NH;
 'H22_N2'   , J_NH;
 

--- a/etc/estimators/guess_j_nuc.m
+++ b/etc/estimators/guess_j_nuc.m
@@ -55,17 +55,17 @@ end
 subgraphs=dfpt(sparse(proxmatrix),2);
 
 % Set generic coupling values
-J_NH=86.0; J_CN=20.0; J_CH=180.0; J_CC=65.0;
+J_NH=-86.0; J_CN=-20.0; J_CH=180.0; J_CC=65.0;
 
 % Spec all ordered connected pairs
 pairs_database={...
 
 % RNA specific values from the literature
-'C1p_N9'   , 11.0;    'C1p_N1'   , 12.0;    'H1_N1'    , 95.0;   'H3_N3'    , 91.0;   
-'C6_N1'    , 7.5;     'C4_N3'    , 10.7;    'C4_C5'    , 65.0;   'C5_H5'    , 176;  
-'C8_H8'    , 216.0;   'C6_H6'    , 185.0;   'C5_C6'    , 67.0;   'C2_N3'    , 19.0;  
-'C2_N1'    , 19.0;    'C4_N9'    , 20.0;    'H41_N4'   , 86.0;   'C4_N4'    , 20.0;
-'C8_N9'    , 11.0;    'C1p_H1p'  , 170.0;   'H42_N4'   , 86.0;    
+'C1p_N9'   , -11.0;    'C1p_N1'   , -12.0;    'H1_N1'    , -95.0;   'H3_N3'    , -91.0;   
+'C6_N1'    , -7.5;     'C4_N3'    , -10.7;    'C4_C5'    , 65.0;   'C5_H5'    , 176;  
+'C8_H8'    , 216.0;   'C6_H6'    , 185.0;   'C5_C6'    , 67.0;   'C2_N3'    , -19.0;  
+'C2_N1'    , -19.0;    'C4_N9'    , -20.0;    'H41_N4'   , -86.0;   'C4_N4'    , -20.0;
+'C8_N9'    , -11.0;    'C1p_H1p'  , 170.0;   'H42_N4'   , -86.0;    
 
 % Generics for the conjugated ring (to be replaced with DFT values - Zenawi)
 'C2_H2'    , J_CH;    'C5_N7'    , J_CN;    'C8_N7'    , J_CN;   'C6_N6'    , J_CN;
@@ -140,25 +140,25 @@ subgraphs=dfpt(sparse(proxmatrix),3);
 % Set generic coupling values
 J_CCC=-1.2;  % Zenawi's DFT
 J_CCH=0;     % Literature reference
-J_CCN=7.0;   % Zenawi's DFT
+J_CCN=-7.0;   % Zenawi's DFT
 J_NCN=0;     % Literature reference
 J_NCH=0;     % Literature reference
 J_CNH=0;     % Literature reference
 J_CNC=0;     % Literature reference
 J_HCH=-12.0; % Typical for CH2
-J_HNH=-10.0; % Typical for NH2
+J_HNH=10.0; % Typical for NH2
 
 % Spec all ordered connected triples (sorted atoms, bonding order, coupling from atom 1 to atom 3)
 triples_database={...
     
 % Backbone data from the literature
-'C4p_C5p_H5p'  1, 2, 3,  -5.5;   'C4p_C5p_H5pp'  1, 2, 3,   2.0;   'C4p_C5p_H4p' 3, 1, 2,  -5.5;
-'C2p_C3p_H3p'  1, 2, 3,  -2.3;   'C2p_C3p_H2p'   2, 1, 3,   2.3;  
+'C4p_C5p_H5p'  1, 2, 3,  -5.5;   'C4p_C5p_H5pp'  1, 2, 3,   2.0;   'C4p_C5p_H4p' 3, 1, 2,  5.5;
+'C2p_C3p_H3p'  1, 2, 3,  2.3;   'C2p_C3p_H2p'   2, 1, 3,   2.3;  
 
 % Conjugated ring data from the literature
 'C4_C5_C6'     1, 2, 3,   9.5;   'C4_C8_N9'      1, 3, 2,   8.0;   'C2_C4_N3'    1, 3, 2,  10.0;
-'C8_H8_N9'     2, 1, 3,   8.0;   'C8_H8_N7'      2, 1, 3,  11.0;   'C2_H2_N1'    2, 1, 3,  15.0;
-'C2_H2_N3'     2, 1, 3,  15.0;
+'C8_H8_N9'     2, 1, 3,   -8.0;   'C8_H8_N7'      2, 1, 3,  -11.0;   'C2_H2_N1'    2, 1, 3,  -15.0;
+'C2_H2_N3'     2, 1, 3,  -15.0;
 
 % Generic numbers for the conjugated ring (to be replaced with DFT values - Zenawi)
 'C6_N1_N6'     2, 1, 3,  J_NCN;  'C2_N1_N3'      2, 1, 3,  J_NCN;  'C2_C6_N1'     1, 3, 2,  J_CNC;                                     

--- a/interfaces/agents/spinach-knowledge/etc.md
+++ b/interfaces/agents/spinach-knowledge/etc.md
@@ -28,7 +28,7 @@
 | `etc/diamond_defects/diamond_ti.m` | `[sys,inter]=diamond_ti(parameters)` | Titanium-related defect spin system for diamond. Syntax: [sys,inter]=diamond_ti(parameters) Magnetic parameters from Nad | 186 |
 | `etc/diamond_defects/diamond_vacancy.m` | `[sys,inter]=diamond_vacancy(parameters)` | Vacancy-family defect spin systems for diamond. Syntax: [sys,inter]=diamond_vacancy(parameters) R4/W6 parameters from Tw | 144 |
 | `etc/estimators/guess_csa_pro.m` | `CSAs=guess_csa_pro(aa_nums,pdb_ids,coords,options)` | Guesses a reasonable amide bond 15N CSA tensor anisotropy, and a reasonable 13C=O tensor anisotropy, given a local prote | 338 |
-| `etc/estimators/guess_j_nuc.m` | `jmatrix=guess_j_nuc(nuc_num,nuc_typ,pdb_id,coords)` | RNA assignments of J-couplings from literature values and Karplus cur- ves. Syntax: jmatrix=guess_j_nuc(nuc_num,nuc_typ, | 462 |
+| `etc/estimators/guess_j_nuc.m` | `jmatrix=guess_j_nuc(nuc_num,nuc_typ,pdb_id,coords)` | RNA assignments of J-couplings from literature values and Karplus cur- ves. Syntax: jmatrix=guess_j_nuc(nuc_num,nuc_typ, | 465 |
 | `etc/estimators/guess_j_pro.m` | `jmatrix=guess_j_pro(aa_num,aa_typ,pdb_id,coords)` | Assigns J-couplings from literature values and Karplus curves. Syntax: jmatrix=guess_j_pro(aa_num,aa_typ,pdb_id,coords)  | 660 |
 | `etc/forum.m` | `forum()` | Opens Spinach support forum page. | 18 |
 | `etc/hebrew/hebrew.m` | `ncards=hebrew(mode,max_cards) % #NWIKI #NHEAD` | IK's Hebrew flashcards function. The Excel files should contain Hebrew vocabulary in separate spreadsheets: nouns.xlsx - | 389 |

--- a/interfaces/agents/spinach-knowledge/etc/estimators/guess_j_nuc.md
+++ b/interfaces/agents/spinach-knowledge/etc/estimators/guess_j_nuc.md
@@ -2,7 +2,7 @@
 
 - Source: `/home/kuprov/.openclaw/workspace/Spinach/etc/estimators/guess_j_nuc.m`
 - Signature: `jmatrix=guess_j_nuc(nuc_num,nuc_typ,pdb_id,coords)`
-- Total lines: 462
+- Total lines: 465
 
 ## Purpose
 
@@ -26,36 +26,36 @@ RNA assignments of J-couplings from literature values and Karplus cur- ves. Synt
 - Lines 43-44: Number the atoms; implemented by `numbers=1:numel(coords)`.
 - Lines 46-47: Determine the connectivity graph; implemented by `proxmatrix=false(numel(coords),numel(coords))`.
 - Lines 54-55: Get all connected subgraphs up to size 2; implemented by `subgraphs=dfpt(sparse(proxmatrix),2)`.
-- Lines 57-58: Set generic coupling values; implemented by `J_NH=86.0; J_CN=20.0; J_CH=180.0; J_CC=65.0`.
+- Lines 57-58: Set generic coupling values; implemented by `J_NH=-86.0; J_CN=-20.0; J_CH=180.0; J_CC=65.0`.
 - Lines 60-61: Spec all ordered connected pairs; implemented by `pairs_database={`.
-- Lines 63-64: RNA specific values from the literature; implemented by `'C1p_N9' , 11.0; 'C1p_N1' , 12.0; 'H_N1' , 95.0; 'H3_N3' , 91.0`.
-- Lines 70-71: Generics for the conjugated ring (to be replaced with DFT values -Zenawi); implemented by `'C2_H2' , J_CH; 'C5_N7' , J_CN; 'C8_N7' , J_CN; 'C6_N6' , J_CN`.
-- Lines 75-76: Generics for the sugar ring (to be replaced with DFT values -Zenawi); implemented by `'C1p_C2p' , J_CC; 'C2p_H2p' , J_CH; 'C3p_C4p' , J_CC; 'C4p_H4p' , J_CH`.
-- Lines 81-82: Loop over subgraphs; implemented by `disp(' '); disp('############# ONE-BOND J-COUPLING SUMMARY ###############')`.
-- Lines 86-87: Extract labels, residues and numbers; implemented by `spin_labels=pdb_id(subgraphs(n,:))`.
-- Lines 92-93: Index the spins; implemented by `[spin_labels,index]=sort(spin_labels)`.
-- Lines 98-99: Consult the database; implemented by `if isscalar(spin_labels)`.
-- Lines 101-102: Inform the user about solitary spins; implemented by `disp(['WARNING: solitary spin detected, ' spin_resnames{1} '(' num2str(spin_resnums(1)) '):' spin_labels{1}])`.
-- Lines 106-107: Build specification string; implemented by `spec_string=pairs_database(strcmp([spin_labels{1} '_' spin_labels{2}],pairs_database(:,1)),:)`.
-- Lines 109-110: Assign the coupling; implemented by `if isempty(spec_string)`.
-- Lines 112-114: Complain if nothing found; implemented by `disp(['WARNING: unknown atom pair or unphysical proximity, ' spin_labels{1} '_' spin_labels{2} ' in residues ' spin_resnames{1} '(' num2str(spin_resnums(1)) '), ' spin_r…`.
+- Lines 63-64: RNA specific values from the literature; implemented by `'C1p_N9' , -11.0; 'C1p_N1' , -12.0; 'H1_N1' , -95.0; 'H3_N3' , -91.0`.
+- Lines 70-71: Pyridine-type N7 bonds, small and positive (B3LYP/pcJ-2, 9-methyladenine and 9-methylguanine); implemented by `'C5_N7' , 1.9; 'C8_N7' , 0.4`.
+- Lines 73-74: Generics for the conjugated ring (to be replaced with DFT values -Zenawi); implemented by `'C2_H2' , J_CH; 'C6_N6' , J_CN`.
+- Lines 78-79: Generics for the sugar ring (to be replaced with DFT values -Zenawi); implemented by `'C1p_C2p' , J_CC; 'C2p_H2p' , J_CH; 'C3p_C4p' , J_CC; 'C4p_H4p' , J_CH`.
+- Lines 84-85: Loop over subgraphs; implemented by `disp(' '); disp('############# ONE-BOND J-COUPLING SUMMARY ###############')`.
+- Lines 89-90: Extract labels, residues and numbers; implemented by `spin_labels=pdb_id(subgraphs(n,:))`.
+- Lines 95-96: Index the spins; implemented by `[spin_labels,index]=sort(spin_labels)`.
+- Lines 101-102: Consult the database; implemented by `if isscalar(spin_labels)`.
+- Lines 104-105: Inform the user about solitary spins; implemented by `disp(['WARNING: solitary spin detected, ' spin_resnames{1} '(' num2str(spin_resnums(1)) '):' spin_labels{1}])`.
+- Lines 109-110: Build specification string; implemented by `spec_string=pairs_database(strcmp([spin_labels{1} '_' spin_labels{2}],pairs_database(:,1)),:)`.
+- Lines 112-113: Assign the coupling; implemented by `if isempty(spec_string)`.
 
 ### Control flow inferred from the code
 
 - Line 48: `for` loop over `n=1:numel(coords)`.
 - Line 49: `for` loop over `k=1:numel(coords)`.
 - Line 50: conditional branch on `(norm(coords{n}-coords{k},2)<1.55), proxmatrix(n,k)=1; end`.
-- Line 84: `for` loop over `n=1:size(subgraphs,1)`.
-- Line 99: conditional branch on `isscalar(spin_labels)`.
-- Line 110: conditional branch on `isempty(spec_string)`.
-- Line 193: `for` loop over `n=1:size(subgraphs,1)`.
-- Line 208: conditional branch on `isscalar(spin_labels)`.
-- Line 224: conditional branch on `isempty(spec_string)`.
-- Line 243: conditional branch on `proxmatrix(spin_a,spin_b)&&proxmatrix(spin_b,spin_c)`.
-- Line 246: conditional branch on `(~isempty(jmatrix{spin_a,spin_c}))&&(~ismember([spin_labels{1} '_' spin_labels{2} '_' spin_labels{3}],allowed_collision…`.
-- Line 279: `for` loop over `n=1:size(subgraphs,1)`.
-- Line 280: conditional branch on `any(sum(proxmatrix(subgraphs(n,:),subgraphs(n,:)))==4)`.
-- Line 344: `for` loop over `n=1:size(subgraphs,1)`.
+- Line 87: `for` loop over `n=1:size(subgraphs,1)`.
+- Line 102: conditional branch on `isscalar(spin_labels)`.
+- Line 113: conditional branch on `isempty(spec_string)`.
+- Line 196: `for` loop over `n=1:size(subgraphs,1)`.
+- Line 211: conditional branch on `isscalar(spin_labels)`.
+- Line 227: conditional branch on `isempty(spec_string)`.
+- Line 246: conditional branch on `proxmatrix(spin_a,spin_b)&&proxmatrix(spin_b,spin_c)`.
+- Line 249: conditional branch on `(~isempty(jmatrix{spin_a,spin_c}))&&(~ismember([spin_labels{1} '_' spin_labels{2} '_' spin_labels{3}],allowed_collision…`.
+- Line 282: `for` loop over `n=1:size(subgraphs,1)`.
+- Line 283: conditional branch on `any(sum(proxmatrix(subgraphs(n,:),subgraphs(n,:)))==4)`.
+- Line 347: `for` loop over `n=1:size(subgraphs,1)`.
 
 ### Key state/data transformations
 
@@ -63,24 +63,24 @@ RNA assignments of J-couplings from literature values and Karplus cur- ves. Synt
 - Lines 44: computes `numbers` using `numbers=1:numel(coords)`.
 - Lines 47: computes `proxmatrix` using `proxmatrix=false(numel(coords),numel(coords))`.
 - Lines 55: computes `subgraphs` using `subgraphs=dfpt(sparse(proxmatrix),2)`.
-- Lines 58: computes `J_NH` using `J_NH=86.0; J_CN=20.0; J_CH=180.0; J_CC=65.0`.
+- Lines 58: computes `J_NH` using `J_NH=-86.0; J_CN=-20.0; J_CH=180.0; J_CC=65.0`.
 - Lines 61: computes `pairs_database` using `pairs_database={`.
-- Lines 87: computes `spin_labels` using `spin_labels=pdb_id(subgraphs(n,:))`.
-- Lines 88: computes `spin_numbers` using `spin_numbers=numbers(subgraphs(n,:))`.
-- Lines 89: computes `spin_resnames` using `spin_resnames=nuc_typ(subgraphs(n,:))`.
-- Lines 90: computes `spin_resnums` using `spin_resnums=nuc_num(subgraphs(n,:))`.
-- Lines 93: computes `[spin_labels,index]` using `[spin_labels,index]=sort(spin_labels)`.
-- Lines 107: computes `spec_string` using `spec_string=pairs_database(strcmp([spin_labels{1} '_' spin_labels{2}],pairs_database(:,1)),:)`.
-- Lines 124: computes `jmatrix{spin_numbers(1),spin_numbers(2)}` using `jmatrix{spin_numbers(1),spin_numbers(2)}=spec_string{2}`.
-- Lines 141: computes `J_CCC` using `J_CCC=-1.2`.
-- Lines 142: computes `J_CCH` using `J_CCH=0`.
-- Lines 143: computes `J_CCN` using `J_CCN=7.0`.
-- Lines 144: computes `J_NCN` using `J_NCN=0`.
-- Lines 145: computes `J_NCH` using `J_NCH=0`.
+- Lines 90: computes `spin_labels` using `spin_labels=pdb_id(subgraphs(n,:))`.
+- Lines 91: computes `spin_numbers` using `spin_numbers=numbers(subgraphs(n,:))`.
+- Lines 92: computes `spin_resnames` using `spin_resnames=nuc_typ(subgraphs(n,:))`.
+- Lines 93: computes `spin_resnums` using `spin_resnums=nuc_num(subgraphs(n,:))`.
+- Lines 96: computes `[spin_labels,index]` using `[spin_labels,index]=sort(spin_labels)`.
+- Lines 110: computes `spec_string` using `spec_string=pairs_database(strcmp([spin_labels{1} '_' spin_labels{2}],pairs_database(:,1)),:)`.
+- Lines 127: computes `jmatrix{spin_numbers(1),spin_numbers(2)}` using `jmatrix{spin_numbers(1),spin_numbers(2)}=spec_string{2}`.
+- Lines 144: computes `J_CCC` using `J_CCC=-1.2`.
+- Lines 145: computes `J_CCH` using `J_CCH=0`.
+- Lines 146: computes `J_CCN` using `J_CCN=-7.0`.
+- Lines 147: computes `J_NCN` using `J_NCN=0`.
+- Lines 148: computes `J_NCH` using `J_NCH=0`.
 
 ### Local helper functions
 
-- Line 436: `grumble()` — `function grumble(nuc_num,nuc_typ,pdb_id,coords)`.
+- Line 439: `grumble()` — `function grumble(nuc_num,nuc_typ,pdb_id,coords)`.
   - Representative operation: `if ~isnumeric(nuc_num)`.
   - Representative operation: `error('nuc_num must be a vector of positive integers.')`.
 


### PR DESCRIPTION
Fixes the J-coupling database records in `guess_j_nuc.m`: four bonding orders that could never match, the guanine imino record filed under a non-existent atom, an unsorted duplicate quad, two unreachable pairs (first commit), and the signs of every 15N coupling and of the sugar two-bond C-H couplings (second commit).

Signs come from B3LYP/pcJ-2 spin-spin coupling calculations (ORCA 6.1.1, all four Ramsey terms) on 9-methyladenine, 9-methylguanine, 1-methyluracil, 1-methylcytosine, uridine and adenosine at C3'-endo/gamma+/anti, and uridine at C2'-endo, validated against known values (1J(N,H) -94 to -96, pyrrole-type 1J(C,N) -10 to -22, pyridine-type +0.5 to +3, 1J(C,H) 144 to 220).

- Negative now: all 1J(N,H) (H1_N1, H3_N3, H41_N4, H42_N4, J_NH), all one-bond C-N records (C1p_N9, C1p_N1, C2_N1, C2_N3, C4_N3, C6_N1, C4_N9, C8_N9, C4_N4, J_CN), all 2J(H,N) (C8_H8_N7, C8_H8_N9, C2_H2_N1, C2_H2_N3), J_CCN.
- Positive now: J_HNH (computed +3 to +5 Hz in the amino groups); 2J(C5',H4') and 2J(C2',H3') at C3'-endo (computed +6.3 and +2.2; 2J(C4',H5') -5.4 and 2J(C4',H5'') +1.5 already agreed).
- 2J(C3',H2') also flipped to -2.3: Ippel et al. 1996 (Table 13) give -1.5 Hz for pure N-type and +2.9 Hz for pure S-type sugars, so the stored value was the S-type one (uridine computed -1.4). Left as stored: two-bond C-C records (2J(C2,C4) is -2.5 in adenine, +2.1 in guanine, +0.8 in uracil).
- Magnitudes only flagged, not changed: 1J(C6,N1) 7.5 (computed -13), purine C2-N1/N3 at 19 (computed +2 to +3 in purines, -19 in uracil; records are keyed by atom names only), 2J(C4,C6) 9.5 and 2J(C2,C4) 10 (computed 0 to 9 and -2.5 to 2), J_HNH 10 (computed 3 to 5).

Stock versus patched estimator on `examples/nmr_nucleic/example.pdb` lists every changed coupling; the mechanical audit against the CCD residue topologies passes.
