### PR TITLE
eseem_nitroxide_crystal: build the ESEEM frequency axis from the FFT bins (F036)

### DIFF
--- a/examples/esr_sol_pulsed/eseem_nitroxide_crystal.m
+++ b/examples/esr_sol_pulsed/eseem_nitroxide_crystal.m
@@ -60,7 +60,7 @@ spectrum=fftshift(fft(fid,parameters.zerofill));
 
 % Plot the spectrum
 subplot(2,1,2);
-plot(linspace(-1/(parameters.timestep),1/(parameters.timestep),...
+plot(linspace(-1/(2*parameters.timestep),1/(2*parameters.timestep),...
      parameters.zerofill)*1e-6,abs(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 

--- a/examples/esr_sol_pulsed/eseem_nitroxide_crystal.m
+++ b/examples/esr_sol_pulsed/eseem_nitroxide_crystal.m
@@ -58,10 +58,12 @@ fid=apodisation(spin_system,fid-mean(fid),{{'kaiser',6}});
 % Fourier transform
 spectrum=fftshift(fft(fid,parameters.zerofill));
 
+% Frequency axis, interpulse delay increment is timestep/2
+ax=fft_freq_axis(parameters.npoints,parameters.timestep/2,...
+                 parameters.zerofill-parameters.npoints)*1e-6;
+
 % Plot the spectrum
-subplot(2,1,2);
-plot(linspace(-1/(2*parameters.timestep),1/(2*parameters.timestep),...
-     parameters.zerofill)*1e-6,abs(spectrum));
+subplot(2,1,2); plot(ax,abs(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 
 end

--- a/examples/esr_sol_pulsed/eseem_nitroxide_crystal.m
+++ b/examples/esr_sol_pulsed/eseem_nitroxide_crystal.m
@@ -59,11 +59,11 @@ fid=apodisation(spin_system,fid-mean(fid),{{'kaiser',6}});
 spectrum=fftshift(fft(fid,parameters.zerofill));
 
 % Frequency axis, interpulse delay increment is timestep/2
-ax=fft_freq_axis(parameters.npoints,parameters.timestep/2,...
-                 parameters.zerofill-parameters.npoints)*1e-6;
+freq_axis=fft_freq_axis(parameters.npoints,parameters.timestep/2,...
+                        parameters.zerofill-parameters.npoints)*1e-6;
 
 % Plot the spectrum
-subplot(2,1,2); plot(ax,abs(spectrum));
+subplot(2,1,2); plot(freq_axis,abs(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 
 end


### PR DESCRIPTION
Finding id: F036, file `examples/esr_sol_pulsed/eseem_nitroxide_crystal.m`

**Correction to the original claim.** This PR first halved the plotted frequency range to ±1/(2·timestep). That was wrong: `experiments/esr_dipolar/eseem.m` advances both echo periods by `timestep/2` per point, so the ESEEM trace is sampled at `timestep/2` and the correct Nyquist range is ±1/timestep, exactly what the stock example used. A probe with a weakly coupled proton at 0.33 T places the peaks at the proton Larmor frequency (14.05 MHz) on the stock range and at half that on the halved range. Finding F036 is therefore withdrawn as stated.

**What this PR now does.** The Codex reviewer's remaining point stands: `linspace` over the full range includes both Nyquist endpoints, so the DC bin was mislabelled (non-zero) and the bin spacing was off by a factor N/(N-1). The axis is now built with `fft_freq_axis(npoints,timestep/2,zerofill-npoints)`, which labels the DC bin zero and matches the transform's bin spacing. The frequency range is unchanged from stock.

**Validation.** `fft_freq_axis` probe: DC bin 0, min/max ±1/timestep, step 1/(zerofill·timestep/2). `checkcode` clean. Same construction as the sibling PRs #402, #463, #464, #467.
