### PR TITLE
eseem_nitroxide_powder: build the ESEEM frequency axis from the FFT bins (F037)

### DIFF
--- a/examples/esr_sol_pulsed/eseem_nitroxide_powder.m
+++ b/examples/esr_sol_pulsed/eseem_nitroxide_powder.m
@@ -59,9 +59,12 @@ kfigure(); subplot(2,1,1);
 plot((0:(parameters.npoints-1))*parameters.timestep*1e6,real(fid));
 kxlabel('time, $\mu$s'); axis tight; kgrid;
 
+% Frequency axis, interpulse delay increment is timestep/2
+ax=fft_freq_axis(parameters.npoints,parameters.timestep/2,...
+                 parameters.zerofill-parameters.npoints)*1e-6;
+
 % Plot the spectrum
-subplot(2,1,2);
-plot(ft_axis(0,1/parameters.timestep,parameters.zerofill)*1e-6,real(spectrum));
+subplot(2,1,2); plot(ax,real(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 
 end

--- a/examples/esr_sol_pulsed/eseem_nitroxide_powder.m
+++ b/examples/esr_sol_pulsed/eseem_nitroxide_powder.m
@@ -61,8 +61,7 @@ kxlabel('time, $\mu$s'); axis tight; kgrid;
 
 % Plot the spectrum
 subplot(2,1,2);
-plot(linspace(-1/(2*parameters.timestep),1/(2*parameters.timestep),...
-     parameters.zerofill)*1e-6,real(spectrum));
+plot(ft_axis(0,1/parameters.timestep,parameters.zerofill)*1e-6,real(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 
 end

--- a/examples/esr_sol_pulsed/eseem_nitroxide_powder.m
+++ b/examples/esr_sol_pulsed/eseem_nitroxide_powder.m
@@ -61,7 +61,7 @@ kxlabel('time, $\mu$s'); axis tight; kgrid;
 
 % Plot the spectrum
 subplot(2,1,2);
-plot(linspace(-1/parameters.timestep,1/parameters.timestep,...
+plot(linspace(-1/(2*parameters.timestep),1/(2*parameters.timestep),...
      parameters.zerofill)*1e-6,real(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 

--- a/examples/esr_sol_pulsed/eseem_nitroxide_powder.m
+++ b/examples/esr_sol_pulsed/eseem_nitroxide_powder.m
@@ -60,11 +60,11 @@ plot((0:(parameters.npoints-1))*parameters.timestep*1e6,real(fid));
 kxlabel('time, $\mu$s'); axis tight; kgrid;
 
 % Frequency axis, interpulse delay increment is timestep/2
-ax=fft_freq_axis(parameters.npoints,parameters.timestep/2,...
-                 parameters.zerofill-parameters.npoints)*1e-6;
+freq_axis=fft_freq_axis(parameters.npoints,parameters.timestep/2,...
+                        parameters.zerofill-parameters.npoints)*1e-6;
 
 % Plot the spectrum
-subplot(2,1,2); plot(ax,real(spectrum));
+subplot(2,1,2); plot(freq_axis,real(spectrum));
 kxlabel('frequency, MHz'); axis tight; kgrid;
 
 end


### PR DESCRIPTION
Finding id: F037, file `examples/esr_sol_pulsed/eseem_nitroxide_powder.m`

**Correction to the original claim.** This PR first halved the plotted frequency range to ±1/(2·timestep). That was wrong: `experiments/esr_dipolar/eseem.m` advances both echo periods by `timestep/2` per point, so the ESEEM trace is sampled at `timestep/2` and the correct Nyquist range is ±1/timestep, exactly what the stock example used. A probe with a weakly coupled proton at 0.33 T places the peaks at the proton Larmor frequency (14.05 MHz) on the stock range and at half that on the halved range. Finding F037 is therefore withdrawn as stated.

**What this PR now does.** The Codex reviewer's remaining point stands: `linspace` over the full range includes both Nyquist endpoints, so the DC bin was mislabelled (non-zero) and the bin spacing was off by a factor N/(N-1). The axis is now built with `fft_freq_axis(npoints,timestep/2,zerofill-npoints)`, which labels the DC bin zero and matches the transform's bin spacing. The frequency range is unchanged from stock.

**Validation.** `fft_freq_axis` probe: DC bin 0, min/max ±1/timestep, step 1/(zerofill·timestep/2). `checkcode` clean. Same construction as the sibling PRs #402, #463, #464, #467.
