### PR TITLE
Fix F030: pass scanned T1e into r1n_dnp in xix_q_rep_time_ensemble_r_T1e

### DIFF
--- a/examples/dnp_sol/steady_state/xix_q_rep_time_ensemble_r_T1e.m
+++ b/examples/dnp_sol/steady_state/xix_q_rep_time_ensemble_r_T1e.m
@@ -78,7 +78,7 @@ for n=1:numel(r)
     % dependence provided using a function handle
     inter.relaxation={'t1_t2'};
     r1n_rate=@(alp,bet,gam)r1n_dnp(sys.magnet,inter.temperature,...
-                                   2.00230,1e-3,52,r(n),bet);
+                                   2.00230,T1e,52,r(n),bet);
     inter.r1_rates={1/T1e r1n_rate};
     inter.r2_rates={200e3 50e3};
     inter.rlx_keep='diagonal';


### PR DESCRIPTION
Finding id: F030

**What was wrong.** `xix_q_rep_time_ensemble_r_T1e.m` scans T1e over {10, 3, 1, 0.3, 0.1} ms and sets the electron R1 to `1/T1e`, but the nuclear relaxation handle was built as `r1n_dnp(...,1e-3,52,r(n),bet)`, hard-coding T1e=1 ms. `r1n_dnp` computes R1n = (dipolar prefactor)^2 * sech^2 / T1e + 1/T1n_bulk, so the electron-driven nuclear relaxation channel was frozen at its 1 ms value for four of the five plotted curves. Companion of F029 (PR #460), which fixes the same line in the field-profile example.

**Why it matters physically.** The example shows how the optimum XiX repetition time depends on T1e. The nuclear leakage rate driven by electron flips scales as 1/T1e in this model, so keeping it fixed while scanning T1e mixes two inconsistent T1e values in one simulation and the plotted optimum-versus-T1e is not that of the model.

**Fix.** One token: `1e-3` -> `T1e` in the `r1n_dnp` call.

**Stock probe output** (nuclear R1n from the stock handle vs the T1e-consistent value, `bet=0`):
```
r= 3.5 A  T1e= 10.0 ms  stock R1n=5.1081e+00 Hz  T1e-consistent R1n=5.2812e-01 Hz  ratio=  0.1034
r= 3.5 A  T1e=  3.0 ms  stock R1n=5.1081e+00 Hz  T1e-consistent R1n=1.7155e+00 Hz  ratio=  0.3358
r= 3.5 A  T1e=  1.0 ms  stock R1n=5.1081e+00 Hz  T1e-consistent R1n=5.1081e+00 Hz  ratio=  1.0000
r= 3.5 A  T1e=  0.3 ms  stock R1n=5.1081e+00 Hz  T1e-consistent R1n=1.6982e+01 Hz  ratio=  3.3245
r= 3.5 A  T1e=  0.1 ms  stock R1n=5.1081e+00 Hz  T1e-consistent R1n=5.0908e+01 Hz  ratio=  9.9661
r=20.0 A  T1e= 10.0 ms  stock R1n=1.9377e-02 Hz  T1e-consistent R1n=1.9245e-02 Hz  ratio=  0.9932
r=20.0 A  T1e=  0.1 ms  stock R1n=1.9377e-02 Hz  T1e-consistent R1n=2.0692e-02 Hz  ratio=  1.0679
```

**Patched probe output.** After the fix the handle evaluates to the T1e-consistent column above for every curve (identical to stock only at T1e=1 ms). This example is a multi-hour run and was not re-run in full; the field-profile companion (PR #460) carries the full stock-vs-patched curve comparison.

`checkcode` on the changed file: clean.