### PR TITLE
fix(cyprinol): give H2 its own proton index

### DIFF
--- a/etc/molecules/cyprinol.m
+++ b/etc/molecules/cyprinol.m
@@ -26,7 +26,7 @@ function [sys,inter,bas]=cyprinol()
 H_iso=cell(1,42); H_iso(:)={'1H'}; numH=numel(H_iso);
 
 % Shorthands for human-readable coupling designations below
-H1a=1;   H1b=2;   H2=2;    H3=3;    H4a=5;   H4b=6;   H5=7;    H6a=8;   
+H1a=1;   H1b=2;   H2=4;    H3=3;    H4a=5;   H4b=6;   H5=7;    H6a=8;   
 H6b=9;   H7=10;   H8=11;   H9=12;   H11a=13; H11b=14; H12=15;  H14=16;  
 H15a=17; H15b=18; H16a=19; H16b=20; H17=21;  H18a=22; H19a=23; H20=24;  
 H21a=25; H22a=26; H22b=27; H23a=28; H23b=29; H24a=30; H24b=31; H25=32;  


### PR DESCRIPTION
Finding: F006 (etc/molecules/cyprinol.m:29)

**What was wrong.** The shorthand line read `H1a=1; H1b=2; H2=2; H3=3; H4a=5; ...`: H1b and H2 shared proton slot 2 and no proton used slot 4. H2's chemical shift (1.64 ppm) overwrote H1b's (1.42 ppm), the C2-H2 one-bond coupling was overwritten by the C2-H1b two-bond value, and slot 4 was created as a 1H with an empty shift.

**Why it matters.** Any spectrum simulated from this spin system has the wrong shift on H1b, a proton with no shift at all, and a missing one-bond C2-H coupling, with no error raised.

**Fix.** `H2=4`. One token; all shift and coupling assignments use the shorthand names, so they now land on the correct slots. No numerical value changed.

**Probe.** Call `cyprinol()` and inspect the proton shift cells and the CH coupling block.

Stock output:
```
Empty proton shift slots: 4
Shift in slot 2: 1.64, slot 4:
One-bond C2 couplings to proton slots:
One-bond C1 couplings to proton slots: 1
Number of 150 Hz one-bond CH entries: 39
```

Patched output:
```
Empty proton shift slots:
Shift in slot 2: 1.42, slot 4: 1.64
One-bond C2 couplings to proton slots: 4
One-bond C1 couplings to proton slots: 1  2
Number of 150 Hz one-bond CH entries: 41
```
(41 is the number of one-bond assignments written in the file.)

checkcode: 0 findings on both stock and patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)