### PR TITLE
fix(kbr_mas_fitting): load experimental spectrum in ascending frequency order

### DIFF
--- a/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m
+++ b/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m
@@ -13,7 +13,7 @@
 
 function kbr_mas_fitting()
 
-% Load and normalise the data, the file runs from high to low frequency
+% Load and normalise the data
 kbr_data=readmatrix('KBr_400MHz_2kHz.txt');
 spec_expt=flipud(kbr_data(:,2))/100;
 

--- a/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m
+++ b/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m
@@ -13,9 +13,9 @@
 
 function kbr_mas_fitting()
 
-% Load and normalise the data
+% Load and normalise the data, the file runs from high to low frequency
 kbr_data=readmatrix('KBr_400MHz_2kHz.txt');
-spec_expt=kbr_data(:,2)/100;
+spec_expt=flipud(kbr_data(:,2))/100;
 
 % Set instrumental variables
 sys.magnet=9.3659;          % magnet field, Tesla


### PR DESCRIPTION
Finding: F056 (examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m:18)

**What was wrong.** `KBr_400MHz_2kHz.txt` lists the spectrum from +56033 Hz down to -43964 Hz (row 1 is the highest frequency). The theoretical spectrum `real(fftshift(fft(fid,zerofill)))` and `ft_axis(offset,sweep,zerofill)` run from -43965 Hz up to +56032 Hz. The error functional `norm(spec_expt-spec_theo,2)^2` compares the two index by index, so the optimiser was fitting a frequency-mirrored 79Br MAS spectrum.

**Why it matters.** The second-order quadrupolar lineshape and its spinning sideband manifold are not mirror-symmetric, so the fitted shift, NQI eigenvalues, relaxation rate, and component weights were being fitted to a reflected spectrum. The fit is close to the centre of the window, so the plot looks nearly right while the lineshape details are reversed.

**Fix.** `spec_expt=flipud(kbr_data(:,2))/100;` and a comment noting the file order. No other change.

**Probe.** Execute the data-loading lines of the example, then locate the experimental peak and read `ft_axis(6034.96,1e5,32768)` at that index; the file itself puts the peak at 6042.58 Hz. A separate liquid-state run of a single 79Br at 60.0933 ppm confirmed that Spinach places a positive-frequency peak at the ascending end of `ft_axis` (peak index 22935 of 32768, ft_axis 6024.0 Hz, expected 6024.6 Hz).

Stock output:
```
executed: spec_expt=kbr_data(:,2)/100;
expt peak index 16382, ft_axis freq there 6025.805 Hz, true file freq of the peak 6042.583 Hz
PROBE FAIL: experimental spectrum is in reverse order relative to ft_axis
```

Patched output:
```
executed: spec_expt=flipud(kbr_data(:,2))/100;
expt peak index 16387, ft_axis freq there 6041.064 Hz, true file freq of the peak 6042.583 Hz
PROBE PASS
```
The residual 1.5 Hz is half a point of the 3.05 Hz grid, inherent in the file axis.

checkcode: 0 findings on the patched file (stock had 1 pre-existing finding unrelated to this line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)