### PR TITLE
fix(kbr_mas_fitting): keep the fminsearch result and evaluate the fit at the optimum

### DIFF
--- a/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m
+++ b/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m
@@ -39,7 +39,10 @@ options=optimset('Display','iter','MaxIter',5000,'MaxFunEvals',Inf);
 kfigure(); scale_figure([1.75 1.50]);
 
 % Run the optimisation
-fminsearch(@errfun,guess,options);
+best_fit=fminsearch(@errfun,guess,options);
+
+% Plot and print the fitted parameters
+errfun(best_fit);
 
     % Least squares error function
     function err=errfun(params)

--- a/interfaces/agents/spinach-knowledge/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.md
+++ b/interfaces/agents/spinach-knowledge/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.md
@@ -2,7 +2,7 @@
 
 - Source: `/home/kuprov/.openclaw/workspace/Spinach/examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m`
 - Signature: `kbr_mas_fitting()`
-- Total lines: 113
+- Total lines: 116
 
 ## Purpose
 
@@ -28,7 +28,8 @@ Fitting of a 79Br MAS NMR spectrum of potassium bromide with respect to the quad
 - Lines 20-21: Set instrumental variables; implemented by `sys.magnet=9.3659`.
 - Lines 35-36: Set optimizer options; implemented by `options=optimset('Display','iter','MaxIter',5000,'MaxFunEvals',Inf)`.
 - Lines 38-39: Get a figure going; implemented by `kfigure(); scale_figure([1.75 1.50])`.
-- Lines 41-42: Run the optimisation; implemented by `fminsearch(@errfun,guess,options)`.
+- Lines 41-42: Run the optimisation; implemented by `best_fit=fminsearch(@errfun,guess,options)`.
+- Lines 44-45: Plot and print the fitted parameters; implemented by `errfun(best_fit)`.
 
 ### Key state/data transformations
 
@@ -42,10 +43,11 @@ Fitting of a 79Br MAS NMR spectrum of potassium bromide with respect to the quad
 - Lines 26: computes `parameters.zerofill` using `parameters.zerofill=32768`.
 - Lines 28: computes `guess` using `guess=[60.0933`.
 - Lines 36: computes `options` using `options=optimset('Display','iter','MaxIter',5000,'MaxFunEvals',Inf)`.
+- Lines 42: computes `best_fit` using `best_fit=fminsearch(@errfun,guess,options)`.
 
 ### Local helper functions
 
-- Line 45: `errfun()` — `function err=errfun(params)`. Silence Spinach
+- Line 48: `errfun()` — `function err=errfun(params)`. Silence Spinach
   - Representative operation: `sys.output='hush'`.
   - Representative operation: `sys.disable={'hygiene','trajlevel'}`.
 
@@ -62,6 +64,7 @@ Fitting of a 79Br MAS NMR spectrum of potassium bromide with respect to the quad
 - Set optimizer options
 - Get a figure going
 - Run the optimisation
+- Plot and print the fitted parameters
 - Least squares error function
 
 ## Internal Spinach / MATLAB structure cues


### PR DESCRIPTION
Finding: F057 (examples/nmr_solids/fitting/bromide_csa_nqi/kbr_mas_fitting.m:42)

**What was wrong.** `fminsearch(@errfun,guess,options);` discarded its return value. The only parameter output was `disp(params)` inside `errfun`, which prints each trial point of the Nelder-Mead simplex. The last trial point is not the minimiser fminsearch returns, so the printout and plot the user is left with are not the fit.

**Why it matters.** This example exists to return fitted 79Br chemical shift, NQI eigenvalues, relaxation rate, and component weights. After hours of computation the user has no certified optimum, only whichever simplex vertex was evaluated last.

**Fix.** Keep the return value and call `errfun` once at the optimum, so the final plot and the final printed vector are the converged fit:
```
best_fit=fminsearch(@errfun,guess,options);

% Plot and print the fitted parameters
errfun(best_fit);
```
One extra simulation at the end; no numerical result changes.

**Probe.** A two-parameter fminsearch with the same call pattern (nested error function that records the last trial point, `MaxIter` 5000, `MaxFunEvals` Inf), comparing the last evaluated point against the returned minimiser.

Stock output:
```
returned minimiser: -2.62214e-05  1.91123e-05   err 1.05e-09
last trial printed:  3.48485e-05 -4.87075e-05   err 3.59e-09
PROBE: last printed vector is NOT the returned minimiser
```

Patched output (same pattern with the final `errfun(xopt)` call):
```
returned minimiser: -2.62214e-05  1.91123e-05   err 1.05e-09
last trial printed:  -2.62214e-05  1.91123e-05   err 1.05e-09
last printed vector is the minimiser
```

checkcode: 0 findings on the patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)