### PR TITLE
Tighten ZFS sampling tolerance in Gd-DOTA soft pulse example (F039)

### DIFF
--- a/examples/esr_sol_pulsed/spa_gd_dota_powder.m
+++ b/examples/esr_sol_pulsed/spa_gd_dota_powder.m
@@ -5,7 +5,7 @@
 % 281-295 (2005). Powder average simulation with a third-order 
 % numerical rotating frame transformation.
 %
-% Calculation time: minutes
+% Calculation time: hours
 %
 % ilya.kuprov@weizmann.ac.il
 
@@ -15,7 +15,7 @@ function spa_gd_dota_powder()
 spectrum=zeros(2048,1,'like',1i);
 
 % Get the sampling
-[D,E,W]=zfs_sampling(30,5,1e-2); drawnow;
+[D,E,W]=zfs_sampling(30,5,1e-4); drawnow;
 
 % Get the figure going
 kfigure();


### PR DESCRIPTION
**Finding:** F039, `examples/esr_sol_pulsed/spa_gd_dota_powder.m:18`

**What was wrong:** `zfs_sampling` normalises the quadrature weights to unit sum and then drops every node with `W<tol`. With the example's `tol=1e-2` only 34 of 186 nodes survive, carrying 59.18% of the probability mass. The dropped nodes are the low-weight ones in the tails of the D/D0 and E/D distributions, so the ZFS distribution actually simulated is narrower than the Raitsimring et al. (doi:10.1007/BF03166762, Fig. 5) distribution the example claims to reproduce.

**Why it matters:** the powder lineshape wings come from the large-|D| tail; truncating that tail biases the simulated Gd(III) spectrum, not just its overall scale.

**Stock probe** (`zfs_sampling(30,5,tol)`, moments renormalised over surviving nodes; "full" is `tol=0`):
```
full:       nodes=186 mass=1.0000 <|D|>=0.991609 <D^2>=1.14827 max|D|=1.994
tol=0.01:   nodes=34  mass=0.5918 <|D|>=0.948756 <D^2>=0.969534 max|D|=1.432
```

**Patched probe** (`tol=1e-4`):
```
tol=0.0001: nodes=172 mass=0.9995 <|D|>=0.991137 <D^2>=1.14699 max|D|=1.994
```
Mass retained goes from 59.2% to 99.95%; all distribution moments agree with the untruncated quadrature to 0.1%.

**Cost:** each node is a 400-orientation powder soft-pulse simulation (about 20 s on 11 workers), so the example goes from roughly 12 min to roughly 1 h. The header calculation-time line is updated accordingly. `checkcode` clean.

No new physical parameter is introduced; the tolerance was chosen from the measured retained-mass curve (1e-3 retains 97.7%, 1e-4 retains 99.95%, 1e-6 retains 100%).