### PR TITLE
fix(mas_powder_trp_floquet): rebuild spin_system for the second molecule

### DIFF
--- a/examples/nmr_solids/mas_powder_trp_floquet.m
+++ b/examples/nmr_solids/mas_powder_trp_floquet.m
@@ -93,6 +93,10 @@ inter.zeeman.matrix=shift_iso(inter.zeeman.matrix,10,28.0);
 inter.zeeman.matrix=shift_iso(inter.zeeman.matrix,11,52.1);
 inter.zeeman.matrix=shift_iso(inter.zeeman.matrix,12,173.3);
 
+% Spinach housekeeping
+spin_system=create(sys,inter);
+spin_system=basis(spin_system,bas);
+
 % Simulation
 fid=fid+floquet(spin_system,@acquire,parameters,'nmr');
 


### PR DESCRIPTION
Finding: F059 (examples/nmr_solids/mas_powder_trp_floquet.m:97)

**What was wrong.** For the second molecule in the unit cell the script reloads `sys` and `inter` from the Gaussian log and applies the second conformation's isotropic shifts, but never calls `create` and `basis` again. The second `floquet(spin_system,...)` call therefore ran on the first molecule's `spin_system`, and the summed FID was twice the first conformation's spectrum.

**Why it matters.** The example is meant to reproduce a 13C MAS powder spectrum with two crystallographically distinct tryptophan sites (C10 at 26.8 vs 28.0 ppm, C11 at 54.6 vs 52.1 ppm, C12 at 174.4 vs 173.3 ppm). Without the rebuild the second site's peaks are absent and the first site's are doubled, silently.

**Fix.** Insert the housekeeping block before the second simulation:
```
% Spinach housekeeping
spin_system=create(sys,inter);
spin_system=basis(spin_system,bas);
```
`parameters.rho0` and `parameters.coil` built from the first `spin_system` stay valid: both molecules have the same isotopes, coordinates, couplings, and tolerances, so the IK-0 basis is identical (dimension 1365 in both, checked by the probe). The `sys.disable={'trajlevel'}` line the script already sets for the second molecule now takes effect.

**Probe.** Replay the script up to the second `floquet` call (simulations commented out, everything else executed verbatim) and read the isotropic shifts stored in `spin_system.inter.zeeman.matrix` as the unit-free ratio (C10-C11)/(C12-C11), which is -0.232053 for the first conformation and -0.198845 for the second.

Stock output:
```
unit-free shift ratio (C10-C11)/(C12-C11) in spin_system at second floquet call: -0.232053
first conformation: -0.232053, second conformation: -0.198845
PROBE FAIL
```

Patched output:
```
unit-free shift ratio (C10-C11)/(C12-C11) in spin_system at second floquet call: -0.198845
first conformation: -0.232053, second conformation: -0.198845
rho0 length from first spin_system: 1365, basis dimension at second call: 1365
PROBE PASS
```

checkcode: 0 findings on the patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)