### PR TITLE
Sample Woods-Saxon potential on the fdlap grid (F040)

### DIFF
--- a/examples/fundamentals/nuclear_structure/woods_saxon.m
+++ b/examples/fundamentals/nuclear_structure/woods_saxon.m
@@ -36,8 +36,12 @@ Z=box_extents(5)+(0:(box_npts(3)-1))*box_sizes(3)/box_npts(3);
 [X,Y,Z]=ndgrid(X,Y,Z); R=sqrt(X.^2+Y.^2+Z.^2);
 V=-V0./(1+exp((R-r_nuc)/a));
 
+% Plot extents ending at the last grid point
+plot_extents=box_extents;
+plot_extents([2 4 6])=box_extents([2 4 6])-box_sizes./box_npts;
+
 % Plot the potential
-kfigure(); volplot(V,box_extents);
+kfigure(); volplot(V,plot_extents);
 ktitle(['Woods-Saxon potential, M=' num2str(mass_number)]);
 kxlabel('X, fm'); kylabel('Y, fm'); kzlabel('Z, fm');
 
@@ -50,7 +54,7 @@ E=diag(E); disp('Energies, MeV:'); disp(E);
 
 % Plot the state
 psi=reshape(real(psi(:,level_number)),box_npts);
-kfigure(); volplot(psi,box_extents);
+kfigure(); volplot(psi,plot_extents);
 ktitle(['Eig ' num2str(level_number) ' ,real part']); 
 kxlabel('X, fm'); kylabel('Y, fm'); kzlabel('Z, fm');
 

--- a/examples/fundamentals/nuclear_structure/woods_saxon.m
+++ b/examples/fundamentals/nuclear_structure/woods_saxon.m
@@ -29,10 +29,10 @@ box_npts=[50 50 50];
 premult=1e-6*1e30*hbar^2/(2*pmass*eV);
 L=premult*fdlap(box_npts,box_sizes,5);
 
-% Potential part
-X=linspace(box_extents(1),box_extents(2),box_npts(1));
-Y=linspace(box_extents(3),box_extents(4),box_npts(2));
-Z=linspace(box_extents(5),box_extents(6),box_npts(3));
+% Potential part on the periodic grid of fdlap
+X=box_extents(1)+(0:(box_npts(1)-1))*box_sizes(1)/box_npts(1);
+Y=box_extents(3)+(0:(box_npts(2)-1))*box_sizes(2)/box_npts(2);
+Z=box_extents(5)+(0:(box_npts(3)-1))*box_sizes(3)/box_npts(3);
 [X,Y,Z]=ndgrid(X,Y,Z); R=sqrt(X.^2+Y.^2+Z.^2);
 V=-V0./(1+exp((R-r_nuc)/a));
 

--- a/interfaces/agents/spinach-knowledge/examples/fundamentals/nuclear_structure/woods_saxon.md
+++ b/interfaces/agents/spinach-knowledge/examples/fundamentals/nuclear_structure/woods_saxon.md
@@ -26,8 +26,8 @@ A loose implementation of single-nucleon Hamiltonian eigenfunction calculation i
 - Lines 20-21: Nuclear radius; implemented by `r_nuc=r0*mass_number^(1/3)`.
 - Lines 23-24: Simulation box dimensions; implemented by `box_extents=3*[-r_nuc,r_nuc,-r_nuc,r_nuc,-r_nuc,r_nuc]`.
 - Lines 28-29: Laplacian part; implemented by `premult=1e-6*1e30*hbar^2/(2*pmass*eV)`.
-- Lines 32-33: Potential part; implemented by `X=linspace(box_extents(1),box_extents(2),box_npts(1))`.
-- Lines 39-40: Plot the potential; implemented by `kfigure(); volplot(V,box_extents)`.
+- Lines 32-33: Potential part on the periodic grid of fdlap; implemented by `X=box_extents(1)+(0:(box_npts(1)-1))*box_sizes(1)/box_npts(1)`.
+- Lines 39-40: Plot the potential; implemented by `kfigure(); volplot(V,plot_extents)`.
 - Lines 44-45: Assemble the Hamiltonian; implemented by `H=spdiags(V(:),0,prod(box_npts),prod(box_npts))-L`.
 - Lines 47-48: Get the state; implemented by `[psi,E]=eigs(H,level_number,'smallestreal')`.
 - Lines 51-52: Plot the state; implemented by `psi=reshape(real(psi(:,level_number)),box_npts)`.
@@ -49,9 +49,9 @@ A loose implementation of single-nucleon Hamiltonian eigenfunction calculation i
 - Lines 26: computes `box_npts` using `box_npts=[50 50 50]`.
 - Lines 29: computes `premult` using `premult=1e-6*1e30*hbar^2/(2*pmass*eV)`.
 - Lines 30: computes `L` using `L=premult*fdlap(box_npts,box_sizes,5)`.
-- Lines 33: computes `X` using `X=linspace(box_extents(1),box_extents(2),box_npts(1))`.
-- Lines 34: computes `Y` using `Y=linspace(box_extents(3),box_extents(4),box_npts(2))`.
-- Lines 35: computes `Z` using `Z=linspace(box_extents(5),box_extents(6),box_npts(3))`.
+- Lines 33: computes `X` using `X=box_extents(1)+(0:(box_npts(1)-1))*box_sizes(1)/box_npts(1)`.
+- Lines 34: computes `Y` using `Y=box_extents(3)+(0:(box_npts(2)-1))*box_sizes(2)/box_npts(2)`.
+- Lines 35: computes `Z` using `Z=box_extents(5)+(0:(box_npts(3)-1))*box_sizes(3)/box_npts(3)`.
 - Lines 36: computes `[X,Y,Z]` using `[X,Y,Z]=ndgrid(X,Y,Z); R=sqrt(X.^2+Y.^2+Z.^2)`.
 - Lines 37: computes `V` using `V=-V0./(1+exp((R-r_nuc)/a))`.
 - Lines 41: computes `ktitle(['Woods-Saxon potential, M` using `ktitle(['Woods-Saxon potential, M=' num2str(mass_number)])`.


### PR DESCRIPTION
**Finding:** F040, `examples/fundamentals/nuclear_structure/woods_saxon.m:33`

**What was wrong:** `fdlap(dims,extents,nstenc)` builds a periodic finite-difference Laplacian normalised by `(dims/extents)^2`, i.e. grid spacing `extents/dims`. The example sampled the Woods-Saxon potential with `linspace(box_extents(1),box_extents(2),box_npts(1))`, an endpoint-inclusive grid of spacing `extents/(dims-1)`. The kinetic and potential operators were therefore built on grids of different pitch and summed.

**Why it matters:** the mismatch is an O(1/N) error that does not go away with stencil order, so the computed single-nucleon shell energies are systematically too shallow and converge very slowly with grid size. Anyone reusing this pattern for a finite-difference eigenproblem gets wrong energies from code that looks internally consistent.

**Stock probe** (ground-state energy, A=20, 5-point stencil, potential on the `linspace` grid vs on the `fdlap` grid `x0+(0:N-1)*extent/N`):
```
npts= 30  E0 stock=-33.072206  E0 consistent=-33.781920 MeV
npts= 40  E0 stock=-33.247458  E0 consistent=-33.775433 MeV
npts= 50  E0 stock=-33.353423  E0 consistent=-33.773622 MeV
npts= 70  E0 stock=-33.474351  E0 consistent=-33.772680 MeV
npts=100  E0 stock=-33.564552  E0 consistent=-33.772426 MeV
```
The stock grid is still 0.2 MeV off at N=100; the consistent grid is converged to 0.01 MeV at N=30.

**Patched probe / example output** (`woods_saxon()` defaults, N=50, five lowest levels, MeV):
```
stock:    -33.3534  -19.4529  -19.4529  -19.4529  -4.8759
patched:  -33.7736  -20.1910  -20.1910  -20.1910  -5.8494
```

**Fix:** the three `linspace` lines are replaced by the periodic grid `box_extents+(0:npts-1)*box_sizes/npts`, matching the spacing `fdlap` assumes. Same file length. `checkcode` clean.