### PR TITLE
deer_4p_soft_diag: require at least two p3 steps and echo points (F086)

### DIFF
--- a/experiments/esr_dipolar/deer_4p_soft_diag.m
+++ b/experiments/esr_dipolar/deer_4p_soft_diag.m
@@ -32,13 +32,13 @@
 %      parameters.p3_nsteps  - number of third pulse posi-
 %                              tions in the interval between
 %                              the first echo and the fourth
-%                              pulse
+%                              pulse, at least two
 %
 %      parameters.echo_time  - time to sample around the ex-
 %                              pected second echo position
 %
 %      parameters.echo_npts  - number of points in the second
-%                              echo discretization
+%                              echo discretization, at least two
 %
 %      parameters.rho0       - initial state
 %
@@ -246,9 +246,9 @@ if ~isfield(parameters,'p3_nsteps')
     error('number of points in the trace must be specified in parameters.p3_nsteps field.');
 end
 if (~isnumeric(parameters.p3_nsteps))||(~isreal(parameters.p3_nsteps))||...
-   (~isscalar(parameters.p3_nsteps))||(parameters.p3_nsteps<1)||...
+   (~isscalar(parameters.p3_nsteps))||(parameters.p3_nsteps<2)||...
    (mod(parameters.p3_nsteps,1)~=0)
-    error('parameters.p3_nsteps must be a positive real integer.');
+    error('parameters.p3_nsteps must be a real integer greater than one.');
 end
 if ~isfield(parameters,'echo_time')
     error('width of the echo window must be specified in parameters.echo_time field.');
@@ -261,9 +261,9 @@ if ~isfield(parameters,'echo_npts')
     error('number of points in the echo must be specified in parameters.echo_npts field.');
 end
 if (~isnumeric(parameters.echo_npts))||(~isreal(parameters.echo_npts))||...
-   (~isscalar(parameters.echo_npts))||(parameters.echo_npts<1)||...
+   (~isscalar(parameters.echo_npts))||(parameters.echo_npts<2)||...
    (mod(parameters.echo_npts,1)~=0)
-    error('parameters.echo_npts must be a positive real integer.');
+    error('parameters.echo_npts must be a real integer greater than one.');
 end
 if ~isfield(parameters,'method')
     error('shaped pulse simulation method must be specified in parameters.method field.');


### PR DESCRIPTION
## Finding F086

**File:** `experiments/esr_dipolar/deer_4p_soft_diag.m`

**What was wrong.** The diagnostic extracts three principal components of the echo stack with `deer_sigmas(1:3,1:3)` after an SVD, but `grumble()` only required `p3_nsteps>=1` and `echo_npts>=1`. The stack has `(echo_npts+1)` rows and `(p3_nsteps+1)` columns, so any accepted input with fewer than two steps in either dimension gave an index-out-of-bounds crash after the full powder simulation had already run.

**Why it matters physically.** The three-component decomposition (echo shape, DEER modulation, and their leading correction) is the point of the diagnostic; it is undefined for a stack with fewer than three rows or columns. The input validation now states the real requirement up front instead of letting the simulation run and then crash.

**Fix.** `grumble()` requires `p3_nsteps>=2` and `echo_npts>=2`, and the header documents the minimum. No numerical result changes for any input that previously ran to completion.

**Stock probe output** (`p3_nsteps=1`, `echo_npts=1`):
```
F086 OUTCOME: Index in position 1 exceeds array bounds. Index must not exceed 2.
```

**Patched probe output** (same input):
```
F086 OUTCOME: parameters.p3_nsteps must be a real integer greater than one.
```

**Patched minimum-stack check** (`p3_nsteps=2`, `echo_npts=2`):
```
F086 NOT REPRODUCED: diagnostic completed
checkcode findings: 0
```
