### PR TITLE
noveldnp_steady: require a single detection state column (F090)

### DIFF
--- a/experiments/hyperpol/noveldnp_steady.m
+++ b/experiments/hyperpol/noveldnp_steady.m
@@ -23,7 +23,7 @@
 %     parameters.irr_powers   - microwave amplitude (aka electron
 %                             nutation frequency), Hz 
 %
-%     parameters.coil         - detection state(s)
+%     parameters.coil         - detection state, a column vector
 %
 %     parameters.contact_dur  - contact time, seconds
 %
@@ -135,6 +135,9 @@ if (~isnumeric(parameters.irr_powers))||(~isreal(parameters.irr_powers))||...
 end
 if ~isfield(parameters,'coil')
     error('detection state must be specified in parameters.coil variable.');
+end
+if (~isnumeric(parameters.coil))||(~iscolumn(parameters.coil))
+    error('parameters.coil must be a column vector.');
 end
 if ~isfield(parameters,'contact_dur')
     error('the contact time must be specified in parameters.contact_dur variable.');


### PR DESCRIPTION
## Finding F090

**File:** `experiments/hyperpol/noveldnp_steady.m`

**What was wrong.** The header advertised `parameters.coil` as "detection state(s)", but the output `dnp` is preallocated with one scalar slot per microwave offset and filled with `dnp(n)=gather(parameters.coil'*rho)`. A coil matrix with several columns therefore produced a vector on the right-hand side and a hard "different number of elements" crash after the full steady-state calculation, and `grumble()` only checked that the field exists.

**Why it matters physically.** The function returns the steady-state observable on one detection state as a function of offset; that is the documented output shape and what every shipped example uses. A multi-column coil has no defined output here, so the input is now rejected up front with an informative message instead of crashing inside the offset loop.

**Fix.** `grumble()` requires `parameters.coil` to be a numeric column vector, and the header describes the field as a single column vector (code overrules documentation). Single-coil results are unchanged.

**Stock probe output** (two-column coil, `[Lz(1H) Lz(E)]`):
```
F090 OUTCOME: Unable to perform assignment because the left and right sides have a different number of elements.
```

**Patched probe output** (same input):
```
F090 OUTCOME: parameters.coil must be a column vector.
checkcode findings: 0
```

**Patched single-coil check** (`Lz(1H)`, 100-point grid, zero offset):
```
F090 NOT REPRODUCED: dnp=0.00054105-1.1302e-09i
```
