### PR TITLE
fix(jaynes_cummings_b): confine initial spin coherence to the empty cavity (F078)

### DIFF
--- a/examples/quantum_tech/jaynes_cummings_b.m
+++ b/examples/quantum_tech/jaynes_cummings_b.m
@@ -33,7 +33,7 @@ spin_system=basis(spin_system,bas);
 % Sequence parameters
 parameters.spins={'E'};
 parameters.offset=5e6;
-parameters.rho0=state(spin_system,{'Lx','E'  },{1,2})+...
+parameters.rho0=state(spin_system,{'Lx','BL1'},{1,2})+...
                 state(spin_system,{'E' ,'BL1'},{1,2})/2;
 parameters.sweep=1e8;
 parameters.npoints=251;


### PR DESCRIPTION
## What was wrong

`examples/quantum_tech/jaynes_cummings_b.m` builds the initial state as `Lx (x) E + E (x) BL1 / 2`, where `E` on the cavity is the identity over all five Fock levels. The coherence term is therefore replicated on every cavity level, while the population term sits on the empty cavity only. The header says the simulation starts with transverse spin magnetisation and an empty cavity mode, and the sibling `jaynes_cummings_c.m` uses `{'Lx','BL1'}` for the same purpose.

## Why it matters physically

The stock `rho0` is not a density matrix: it has trace 1 but a minimum eigenvalue of -0.5. The spin coherence on the occupied Fock levels 2-5 evolves under the Jaynes-Cummings coupling with the photon-number-dependent Rabi frequencies, so the plotted spin `Lx` and cavity field trajectories are a superposition of five different Rabi oscillations instead of the vacuum Rabi oscillation the example is meant to show. With the fix, `rho0=(E/2+Lx) (x) |0><0|`, the pure state `|+x> (x) |0>`.

## Fix

One label on line 36: `{'Lx','E'}` becomes `{'Lx','BL1'}`.

## Probe

Same system in `zeeman-hilb` formalism, evaluate the `parameters.rho0=` line extracted from the file, report trace, minimum eigenvalue, cavity level populations and the spin `Lx` coherence projected on each cavity level.

Stock:
```
rho0 line: parameters.rho0=state(spin_system,{'Lx','E' },{1,2})+... state(spin_system,{'E' ,'BL1'},{1,2})/2;
trace = 1, min eigenvalue = -0.5
cavity level populations: 1 -2.3592e-16   2.498e-16 -2.3177e-32 -1.3618e-16
spin Lx coherence on each cavity level: 1           1           1           1           1
FAIL: rho0 has negative eigenvalues
```

Patched:
```
rho0 line: parameters.rho0=state(spin_system,{'Lx','BL1'},{1,2})+... state(spin_system,{'E' ,'BL1'},{1,2})/2;
trace = 1, min eigenvalue = -9.0206e-17
cavity level populations: 1 -2.3592e-16   2.498e-16 -2.3177e-32 -1.3618e-16
spin Lx coherence on each cavity level: 1 -1.8041e-16  2.2204e-16 -9.7145e-17 -6.9389e-17
PASS: rho0 is a valid density matrix
```

The patched example runs to completion (`jaynes_cummings_b()` with figures suppressed). `checkcode` on the patched file: 0 findings.

Finding id: F078