### PR TITLE
fix(deer_3p_soft_diag): transpose singular-value matrix for rectangular echo stacks (F085)

### DIFF
--- a/experiments/esr_dipolar/deer_3p_soft_diag.m
+++ b/experiments/esr_dipolar/deer_3p_soft_diag.m
@@ -126,7 +126,7 @@ kxlabel('2nd pulse position, $\mu$s'); axis tight; kgrid;
 % Extract and phase the echo modulation
 [deer_echoes,deer_sigmas,deer_traces]=svd(echo_stack);
 deer_echoes=deer_echoes*deer_sigmas/deer_traces(1);
-deer_traces=deer_traces*deer_sigmas/deer_traces(1);
+deer_traces=deer_traces*deer_sigmas'/deer_traces(1);
 
 % Plot echo components
 kfigure(); plot(echo_axis,real(deer_echoes(:,1:3)));

--- a/interfaces/agents/spinach-knowledge/experiments/esr_dipolar/deer_3p_soft_diag.md
+++ b/interfaces/agents/spinach-knowledge/experiments/esr_dipolar/deer_3p_soft_diag.md
@@ -53,7 +53,7 @@ Complete set of simulations related to three-pulse DEER. Runs pulse diagnostics,
 - Lines 119: computes `[deer_axis_2d,echo_axis_2d]` using `[deer_axis_2d,echo_axis_2d]=meshgrid(deer_axis,echo_axis)`.
 - Lines 127: computes `[deer_echoes,deer_sigmas,deer_traces]` using `[deer_echoes,deer_sigmas,deer_traces]=svd(echo_stack)`.
 - Lines 128: computes `deer_echoes` using `deer_echoes=deer_echoes*deer_sigmas/deer_traces(1)`.
-- Lines 129: computes `deer_traces` using `deer_traces=deer_traces*deer_sigmas/deer_traces(1)`.
+- Lines 129: computes `deer_traces` using `deer_traces=deer_traces*deer_sigmas'/deer_traces(1)`.
 
 ### Local helper functions
 


### PR DESCRIPTION
## What was wrong

`experiments/esr_dipolar/deer_3p_soft_diag.m` decomposes the echo stack with `[U,S,V]=svd(echo_stack)` and then forms `deer_traces=V*S/V(1)`. For an `m`-by-`n` echo stack (`m=echo_npts+1`, `n=p2_nsteps+1`), `V` is `n`-by-`n` and `S` is `m`-by-`n`, so `V*S` only conforms when `m==n`.

## Why it matters physically

`echo_npts` (sampling of the echo window) and `p2_nsteps` (number of second-pulse positions along the DEER trace) are independent acquisition dimensions, both validated separately in the grumbler. Any user choosing them differently gets a dimension-mismatch crash after the full powder DEER simulation has run, and never sees the principal-component echo and DEER-trace plots the diagnostic exists to produce. The shipped examples happen to use 100 for both, which is why this went unnoticed.

## Fix

`deer_traces=deer_traces*deer_sigmas'/deer_traces(1)`. `V*S'` is `n`-by-`m`; its `k`-th column is `sigma_k v_k`, which is what the legend `v_k sigma_k` states and what the plot of columns 1:3 against `deer_axis` needs. For a square stack `S'=S`, so the existing examples are unchanged.

## Probe

Extract the three-line SVD block from the file and evaluate it on an 11-by-7 complex random stack (`echo_npts=10`, `p2_nsteps=6`); compare with `V*S'/V(1)` computed independently.

Stock:
```
[deer_echoes,deer_sigmas,deer_traces]=svd(echo_stack);
deer_echoes=deer_echoes*deer_sigmas/deer_traces(1);
deer_traces=deer_traces*deer_sigmas/deer_traces(1);
FAIL: Incorrect dimensions for matrix multiplication. Check that the number of columns in the first matrix matches the number of rows in the second matrix. To operate on each element of the matrix individually, use TIMES (.*) for elementwise multiplication.
```

Patched:
```
[deer_echoes,deer_sigmas,deer_traces]=svd(echo_stack);
deer_echoes=deer_echoes*deer_sigmas/deer_traces(1);
deer_traces=deer_traces*deer_sigmas'/deer_traces(1);
sizes: echoes [11 7], traces [7 11]
deviation of traces from V*S'/v11: 0
PASS: rectangular echo stack decomposed
```

`checkcode` on the patched file: 0 findings.

Finding id: F085