### PR TITLE
epi_2d: readout preroll uses the readout gradient duration (F091)

### DIFF
--- a/experiments/imaging/epi_2d.m
+++ b/experiments/imaging/epi_2d.m
@@ -64,10 +64,10 @@ if isfield(parameters,'diff_g_amp')
                          rho,parameters.diff_g_dur);
 end
 
-% Preroll the gradients
-rho=evolution(spin_system,B-parameters.pe_grad_amp*G{1}...
+% Preroll the gradients, phase encoding area rescaled to readout preroll time
+rho=evolution(spin_system,B-parameters.pe_grad_amp*G{1}*(parameters.pe_grad_dur/parameters.ro_grad_dur)...
                            -parameters.ro_grad_amp*G{2},[],rho,...
-                            parameters.pe_grad_dur/2,1,'final');
+                            parameters.ro_grad_dur/2,1,'final');
 
 % Preallocate k-space image
 fid=zeros(parameters.image_size,'like',1i);


### PR DESCRIPTION
## Finding F091

**File:** `experiments/imaging/epi_2d.m`

**What was wrong.** The combined preroll evolved under both prephasers, `-pe_grad_amp*G{1}-ro_grad_amp*G{2}`, for a single duration `pe_grad_dur/2`. The readout dwell propagators are built from `ro_grad_dur`, so the readout prephaser area was only correct when the two documented durations happened to be equal. `grumble()` validates them as independent positive scalars.

**Why it matters physically.** The readout prephaser must have exactly half the readout gradient area so that the acquisition window is centred at k=0. With `pe_grad_dur~=ro_grad_dur` the centre is displaced by `ro_grad_amp*(ro_grad_dur-pe_grad_dur)/2` (in gradient-area units), which shifts the echo along the readout axis and produces a blurred, ghosted image with no warning.

**Fix.** The preroll now runs for `ro_grad_dur/2` with the phase encoding gradient amplitude rescaled by `pe_grad_dur/ro_grad_dur`, so both prephaser areas are correct (`pe_grad_amp*pe_grad_dur/2` and `ro_grad_amp*ro_grad_dur/2`). Both prephasers still play simultaneously. For `pe_grad_dur==ro_grad_dur` (every shipped example) the expression reduces to the stock code, so existing results are unchanged.

**Probe.** Two runs with identical phase encoding areas: `pe_grad_amp=4.8e-3, pe_grad_dur=2e-3` and `pe_grad_amp=9.6e-3, pe_grad_dur=1e-3`, both with `ro_grad_dur=2e-3`, relaxation rates 1e-3 Hz, 32x32 box phantom, 21x23 image. The two images must agree up to relaxation during the preroll.

**Stock probe output:**
```
F091 relative image difference for equal k-space areas: 1.1327
F091 REPRODUCED
```

**Patched probe output:**
```
F091 relative image difference for equal k-space areas: 4.8792e-07
F091 NOT REPRODUCED
checkcode findings: 0
```
