### PR TITLE
gissmo2spinach: import the requested coupling subsystem (F121)

### DIFF
--- a/interfaces/gissmo/gissmo2spinach.m
+++ b/interfaces/gissmo/gissmo2spinach.m
@@ -168,11 +168,11 @@ for n=1:numel(xml.children)
                     
         end
           
-    elseif strcmpi(xml.children(n).name,'coupling_matrix')
-        
-        % Increment subsystem counter
+    end
+    
+    % Count coupling matrices seen so far
+    if strcmpi(xml.children(n).name,'coupling_matrix')
         current_subsystem=current_subsystem+1;
-        
     end
     
 end


### PR DESCRIPTION
## What was wrong

In `interfaces/gissmo/gissmo2spinach.m` the subsystem counter `current_subsystem` was incremented only in the `elseif` branch, which runs for `coupling_matrix` nodes encountered *before* the requested one. Once `current_subsystem==subsystem`, the `if` branch was taken for that node and for every subsequent `coupling_matrix` node, so each later matrix overwrote `sys` and `inter`. The function therefore returned the last coupling matrix in the file whenever `subsystem` was less than or equal to the number of matrices.

## Why it matters physically

Multi-subsystem GISSMO files hold separate spin systems (different molecules, or split sub-spectra) in successive `coupling_matrix` nodes. Requesting subsystem N silently produced the chemical shifts, J-couplings, and line width of the last subsystem, with no error or warning, so downstream simulations were of the wrong molecule.

## Fix

The counter is now advanced for every `coupling_matrix` node, after the import block. Four lines changed, file length unchanged.

## Probe

Synthetic GISSMO XML with three coupling matrices (labels A/B/C, shifts 1-2/3-4/5-6 ppm, J=10/20/30 Hz), requesting subsystems 1, 2, 3.

Stock:
```
subsystem 1: labels=Atom C1 Atom C2, shifts=5 6, J=30
subsystem 2: labels=Atom C1 Atom C2, shifts=5 6, J=30
subsystem 3: labels=Atom C1 Atom C2, shifts=5 6, J=30
```

Patched:
```
subsystem 1: labels=Atom A1 Atom A2, shifts=1 2, J=10
subsystem 2: labels=Atom B1 Atom B2, shifts=3 4, J=20
subsystem 3: labels=Atom C1 Atom C2, shifts=5 6, J=30
```

`checkcode` on the patched file: no findings.

Finding id: F121