### PR TITLE
epi_3d: readout preroll uses the readout gradient duration (F092)

### DIFF
--- a/experiments/imaging/epi_3d.m
+++ b/experiments/imaging/epi_3d.m
@@ -106,10 +106,10 @@ dims([2 4 6])=+parameters.dims/2;
 kfigure(); volplot(abs(mri_slice),dims); 
 ktitle('after slice sel. and echo'); drawnow();
 
-% Preroll the gradients
-rho=evolution(spin_system,B-parameters.pe_grad_amp*G{2}...
+% Preroll the gradients, phase encoding area rescaled to readout preroll time
+rho=evolution(spin_system,B-parameters.pe_grad_amp*G{2}*(parameters.pe_grad_dur/parameters.ro_grad_dur)...
                            -parameters.ro_grad_amp*G{3},[],rho,...
-                            parameters.pe_grad_dur/2,1,'final');
+                            parameters.ro_grad_dur/2,1,'final');
 
 % Precompute propagators
 P_ro_p=propagator(spin_system,B+parameters.ro_grad_amp*G{3},...


### PR DESCRIPTION
## Finding F092

This is the 3D counterpart of F091 (#481); the two fixes are independent one-line changes in separate files.

**File:** `experiments/imaging/epi_3d.m`

**What was wrong.** The combined preroll evolved under both prephasers, `-pe_grad_amp*G{2}-ro_grad_amp*G{3}`, for a single duration `pe_grad_dur/2`. The readout dwell propagators are built from `ro_grad_dur`, so the readout prephaser area was only correct when the two documented durations happened to be equal. `grumble()` validates them as independent positive scalars.

**Why it matters physically.** The readout prephaser must have exactly half the readout gradient area so that the acquisition window is centred at k=0. With `pe_grad_dur~=ro_grad_dur` the centre is displaced by `ro_grad_amp*(ro_grad_dur-pe_grad_dur)/2` (in gradient-area units), which shifts the echo along the readout axis and produces a blurred, ghosted 3D image with no warning.

**Fix.** The preroll now runs for `ro_grad_dur/2` with the phase encoding gradient amplitude rescaled by `pe_grad_dur/ro_grad_dur`, so both prephaser areas are correct (`pe_grad_amp*pe_grad_dur/2` and `ro_grad_amp*ro_grad_dur/2`). Both prephasers still play simultaneously. For `pe_grad_dur==ro_grad_dur` (every shipped example) the expression reduces to the stock code, so existing results are unchanged.

**Probe.** Two runs with identical phase encoding areas: `pe_grad_amp=4.8e-3, pe_grad_dur=2e-3` and `pe_grad_amp=9.6e-3, pe_grad_dur=1e-3`, both with `ro_grad_dur=2e-3`, relaxation rates 1e-3 Hz, 12x16x16 box phantom with a 20-step Gaussian slice selection pulse, 13x15 k-space. The two k-space datasets must agree up to relaxation during the preroll.

**Stock probe output:**
```
F092 relative k-space difference for equal k-space areas: 1.3387
F092 REPRODUCED
```

**Patched probe output:**
```
F092 relative k-space difference for equal k-space areas: 5.3999e-07
F092 NOT REPRODUCED
checkcode findings: 0
```
