### PR TITLE
wise: pre-saturate parameters.spins{2} instead of hardcoded 13C (F098)

### DIFF
--- a/experiments/nmr_solids/wise.m
+++ b/experiments/nmr_solids/wise.m
@@ -50,8 +50,8 @@ function fid=wise(spin_system,parameters,H,R,K)
 % Consistency enforcement
 grumble(spin_system,parameters,H,R,K);
 
-% Wipe the state of 13C (pre-saturation)
-[~,parameters.rho0]=decouple(spin_system,[],parameters.rho0,{'13C'});
+% Wipe the state of the low-gamma spin (pre-saturation)
+[~,parameters.rho0]=decouple(spin_system,[],parameters.rho0,parameters.spins(2));
  
 % Build 1H and 13C control operators
 Hp=operator(spin_system,'L+',parameters.spins{1});


### PR DESCRIPTION
## What was wrong

`experiments/nmr_solids/wise.m` line 54 pre-saturated the low-gamma channel with `decouple(...,{'13C'})`, although `parameters.spins` is documented as a generic working-spin pair ("e.g. {'1H',13C'}") and every other channel reference in the file uses `parameters.spins{1}` / `parameters.spins{2}`. For any pair whose second isotope is not 13C (1H-15N, 1H-31P) the call fails in `decouple`'s grumbler with "the system does not contain the spins specified", so the experiment cannot be run at all on those nuclei.

## Why it matters

WISE on 15N or 31P is a legitimate and common experiment; the sequence should pre-saturate whichever low-gamma spin the user names so that only CP-transferred magnetisation contributes to the 2D correlation.

## Fix

Line 54 now wipes `parameters.spins(2)`; the comment above it no longer names 13C. One line, no other change. For the documented 1H-13C case the behaviour is identical.

## Probe

1H-15N pair, J=-90 Hz, static Hamiltonian, `spc_dim=1`, zero R and K, initial state Lz on 15N only, detection L+ on 15N. Correct pre-saturation must wipe the initial state so that the fid is zero.

Stock:
```
Error using decouple>grumble (line 208)
the system does not contain the spins specified.
Error in wise (line 54)
[~,parameters.rho0]=decouple(spin_system,[],parameters.rho0,{'13C'});
```

Patched:
```
F098 max |fid.cos| from 15N-only initial state: 0.0000e+00
```

`checkcode` on the changed file: clean.

Finding id: F098.