### PR TITLE
spiral: document spiral_frq in rad/s, matching the code (F094)

### DIFF
--- a/experiments/imaging/spiral.m
+++ b/experiments/imaging/spiral.m
@@ -9,7 +9,7 @@
 %
 %      parameters.t_echo      - echo time, seconds
 %
-%      parameters.spiral_frq  - frequency of the spiral, Hz
+%      parameters.spiral_frq  - angular frequency of the spiral, rad/s
 %
 %      parameters.spiral_dur  - duration of the spiral, seconds
 %

--- a/interfaces/agents/spinach-knowledge/experiments/imaging/spiral.md
+++ b/interfaces/agents/spinach-knowledge/experiments/imaging/spiral.md
@@ -77,7 +77,7 @@
 ## Parameters / inputs
 
 - parameters.t_echo -echo time, seconds
-- parameters.spiral_frq -frequency of the spiral, Hz
+- parameters.spiral_frq -angular frequency of the spiral, rad/s
 - parameters.spiral_dur -duration of the spiral, seconds
 - parameters.grad_amp -gradient amplitude at the end
 - of the spiral, T/m
@@ -97,7 +97,7 @@
 - This sequence must be called from the imaging() context, which
 - would provide H,R,K,G, and F.
 - parameters.t_echo -echo time, seconds
-- parameters.spiral_frq -frequency of the spiral, Hz
+- parameters.spiral_frq -angular frequency of the spiral, rad/s
 - parameters.spiral_dur -duration of the spiral, seconds
 - parameters.grad_amp -gradient amplitude at the end
 - of the spiral, T/m


### PR DESCRIPTION
## What was wrong

`experiments/imaging/spiral.m` documents `parameters.spiral_frq` as "frequency of the spiral, Hz", but lines 62-63 use it directly as the argument of `cos` and `sin` against the time grid, i.e. as an angular rate in rad/s, with no 2*pi factor. A user who supplies a value in Hz as documented gets a spiral that rotates 2*pi times slower than intended.

## Why the documentation is corrected rather than the code

The shipped example `examples/imaging/spiral_2d.m` uses `spiral_frq=5e4` with `spiral_dur=5e-3` and `spiral_npts=3000`. Under the code's rad/s interpretation that is 250 rad, about 40 turns, 75 samples per turn, resampled onto a 27x27 k-space grid: a sensibly filled spiral. Inserting 2*pi into the code would make the same example about 250 turns at 12 samples per turn, angularly undersampled for the grid it is interpolated onto, and would change the output of every existing user script. The code is physically correct with an angular-rate parameter, and the repository AGENTS.md rule is that where code and documentation disagree and the code is physically correct, the documentation is updated to match. One documentation line changed.

## Probe

There is no numerical change; the demonstration is the turn count of the shipped example under each reading of the parameter.

Stock code, stock documentation (user reads Hz, code applies rad/s):
```
spiral_frq*spiral_dur = 5e4*5e-3 = 250 rad = 39.8 turns delivered; 250 turns documented
```

Patched documentation (rad/s, matches code):
```
5e4 rad/s * 5e-3 s = 250 rad = 39.8 turns delivered; 39.8 turns documented
```

`checkcode` on the changed file: clean.

Finding id: F094.