### PR TITLE
oparse: mark unprinted isotropic hyperfines as NaN (F136)

### DIFF
--- a/interfaces/orca/oparse.m
+++ b/interfaces/orca/oparse.m
@@ -32,7 +32,7 @@
 %   props.hfc.full.matrix   - hyperfine tensors, Gauss, natoms cell
 %   props.hfc.full.eigvals  - hyperfine eigenvalues, Gauss, natoms cell
 %   props.hfc.full.eigvecs  - hyperfine eigenvectors, natoms cell
-%   props.hfc.iso           - isotropic hyperfine couplings, Gauss
+%   props.hfc.iso           - isotropic hyperfine couplings, Gauss, NaN if not printed
 %   props.efg               - EFG tensors, a.u.^-3, natoms cell
 %   props.nqi               - quadrupolar tensors, Hz, natoms cell
 %   props.isotopes          - isotopes used by ORCA, natoms cell
@@ -247,7 +247,7 @@ if ~isempty(sect)
     nucleus_idx=find_lines(log_lines,'^Nucleus\s+\d+',first,last);
     hfc_found=false; efg_found=false;
     hfc_matrix=cell(1,natoms); hfc_eigvals=cell(1,natoms);
-    hfc_eigvecs=cell(1,natoms); hfc_iso=zeros(natoms,1);
+    hfc_eigvecs=cell(1,natoms); hfc_iso=NaN(natoms,1);
     efg_matrix=cell(1,natoms); nqi_matrix=cell(1,natoms);
     isotopes=cell(1,natoms);
     for n=1:numel(nucleus_idx)


### PR DESCRIPTION
## What was wrong

In `interfaces/orca/oparse.m` the isotropic hyperfine vector `hfc_iso` was initialised with `zeros(natoms,1)` and overwritten only for the nuclei whose block appears in the ELECTRIC AND MAGNETIC HYPERFINE STRUCTURE section. ORCA prints that block only for nuclei requested in `%eprnmr`, so every other atom was reported in `props.hfc.iso` with an isotropic coupling of exactly 0 Gauss. The parallel outputs `props.hfc.full.matrix`, `eigvals`, and `eigvecs` correctly stay empty for those atoms, so the zero in the isotropic vector was an oversight, not intent.

## Why it matters physically

A zero isotropic hyperfine coupling is a legitimate physical value, so a user building a spin system from `props.hfc.iso` cannot distinguish "ORCA computed 0" from "ORCA was never asked". The missing couplings then enter simulations as real zeros with no warning.

## Fix

`hfc_iso` is now initialised with `NaN(natoms,1)`, the convention this same function already uses for Mulliken charges of unprinted atoms, and the header line for `props.hfc.iso` says so. Two lines changed, file length unchanged. Values for printed nuclei are untouched.

## Probe

`oparse` on the bundled `examples/visualisation/porphyrine.out`, in which ORCA printed hyperfines for the 12 protons of 37 atoms.

Stock:
```
atoms=37, hyperfine tensors printed for 12 atoms
unprinted atoms with hfc.iso==0 : 25
unprinted atoms with hfc.iso NaN: 0
printed atoms with finite hfc.iso: 12
printed hfc.iso range, Gauss: -0.171014 to 0.383991
```

Patched:
```
atoms=37, hyperfine tensors printed for 12 atoms
unprinted atoms with hfc.iso==0 : 0
unprinted atoms with hfc.iso NaN: 25
printed atoms with finite hfc.iso: 12
printed hfc.iso range, Gauss: -0.171014 to 0.383991
```

`checkcode` on the patched file: no findings. `tests/interfaces/test_orca_parser.m` runs with no failures on the patched code. No file in the repository reads `props.hfc.iso` from an ORCA log, so no example or test changes behaviour.

Finding id: F136