### PR TITLE
fix(cache): do not clobber a user's test.mat in the scratch directory (F144)

### DIFF
--- a/kernel/cache/cacheman.m
+++ b/kernel/cache/cacheman.m
@@ -26,8 +26,8 @@ end
 time_horizon=now-spin_system.tols.cache_mem; %#ok<TNOW1> 
 
 try % Enforce the ability to write into the scratch directory
-    test=1; save([spin_system.sys.scratch filesep 'test.mat'],'test');
-    drawnow; delete([spin_system.sys.scratch filesep 'test.mat']); 
+    test=1; test_file=[tempname(spin_system.sys.scratch) '.mat'];
+    save(test_file,'test'); drawnow; delete(test_file);
 catch
     error(['Unable to write into ' spin_system.sys.scratch]);
 end


### PR DESCRIPTION
## What was wrong

The scratch-directory writability probe in `kernel/cache/cacheman.m` unconditionally ran `save([scratch filesep 'test.mat'],'test')` followed by `delete(...)` on the same fixed name. Any pre-existing user file called `test.mat` in `sys.scratch` was silently overwritten and then deleted.

## Why it matters

`sys.scratch` is user-configurable and is often a general working directory. A scientist who keeps their own `test.mat` there loses it, without any warning, on the next Spinach run.

## Fix

The probe file name now comes from `tempname(spin_system.sys.scratch)`, which is unique by construction. Two lines changed, file length unchanged.

## Stock probe output

```
user test.mat survives: 0
user test.mat intact:   0
PROBE FAIL
```

## Patched probe output

```
user test.mat survives: 1
user test.mat intact:   1
PROBE PASS
```

`checkcode` on the patched file: 0 findings.

Finding id: F144