### PR TITLE
read_pdb_pro: read single-model PDB files without MODEL records (F139)

### DIFF
--- a/interfaces/pdb_bmrb/read_pdb_pro.m
+++ b/interfaces/pdb_bmrb/read_pdb_pro.m
@@ -39,15 +39,17 @@ grumble(pdb_file_name,mod_id);
 file_id=fopen(pdb_file_name,'r');
 
 % Scroll to the selected structure
+has_models=false;
 while ~feof(file_id)
     parsed_string=textscan(fgetl(file_id),'MODEL %d','delimiter',' ','MultipleDelimsAsOne',1);
+    has_models=has_models||(~isempty(parsed_string{1}));
     if parsed_string{1}==mod_id
         disp(['Reading model ' num2str(mod_id) ' from ' pdb_file_name '...' ]); break;
     end
 end
 
 % Files without MODEL records contain a single model
-if feof(file_id)&&(mod_id==1)
+if (~has_models)&&(mod_id==1)
     disp(['Reading single-model file ' pdb_file_name '...']); frewind(file_id);
 end
 

--- a/interfaces/pdb_bmrb/read_pdb_pro.m
+++ b/interfaces/pdb_bmrb/read_pdb_pro.m
@@ -46,6 +46,11 @@ while ~feof(file_id)
     end
 end
 
+% Files without MODEL records contain a single model
+if feof(file_id)&&(mod_id==1)
+    disp(['Reading single-model file ' pdb_file_name '...']); frewind(file_id);
+end
+
 % Get the outputs started
 aa_num=[]; aa_typ={};
 pdb_id={}; coords={};


### PR DESCRIPTION
## What was wrong

In `interfaces/pdb_bmrb/read_pdb_pro.m` the loop that scrolls to the requested model compares the parsed `MODEL` number with `mod_id`. On lines that are not MODEL records `textscan` returns an empty value, the comparison is empty, the `if` is false, and the loop keeps reading. In a file with no MODEL records at all the loop reaches end-of-file, so the ATOM parsing loop that follows never executes and the function returns empty outputs with no error.

## Why it matters physically

Most X-ray structures and many processed PDB files carry a single model with no MODEL/ENDMDL records. Loading one produced an empty atom list, hence an empty protein spin system, silently.

## Fix

After the scan, if end-of-file was reached and model 1 was requested, the file is rewound and read as a single-model file. Five lines added, no other behaviour changed: multi-model files and files with MODEL records still read exactly as before.

## Probe

`read_pdb_pro` on the bundled `examples/nmr_paramag/calbindin/1igv_original.pdb` (596 ATOM lines, no MODEL records) with `mod_id=1`, and on `examples/nmr_proteins/1D3Z.pdb` (10 models) with `mod_id=3` as a regression check. Stock and patched versions were run in the same MATLAB session by path shadowing.

Stock:
```
1igv_original.pdb (no MODEL records, 596 ATOM lines): 0 atoms read
Reading model 3 from .../1D3Z.pdb...
1D3Z.pdb model 3 (10 models, 1231 ATOM lines each): 1231 atoms read, first MET(1)-N, last GLY(76)-HA3
```

Patched:
```
Reading single-model file .../1igv_original.pdb...
1igv_original.pdb (no MODEL records, 596 ATOM lines): 596 atoms read
   first LYS(1)-N, last GLN(75)-OXT
Reading model 3 from .../1D3Z.pdb...
1D3Z.pdb model 3 (10 models, 1231 ATOM lines each): 1231 atoms read, first MET(1)-N, last GLY(76)-HA3
```

`checkcode` on the patched file: no findings.

Not addressed here, noted for the record: a request for a model number greater than 1 that is not present in the file still returns empty outputs silently, as it did before.

Finding id: F139