### PR TITLE
krylov: add the missing 'total' output case (F172)

### DIFF
--- a/interfaces/agents/spinach-knowledge/kernel/krylov.md
+++ b/interfaces/agents/spinach-knowledge/kernel/krylov.md
@@ -47,7 +47,7 @@ Krylov propagation function. Avoids matrix exponentiation, but can be slow. Shou
 ### Control flow inferred from the code
 
 - Line 74: conditional branch on `ismember('gpu',spin_system.sys.enable)`.
-- Line 85: dispatches on `output`; cases `'final'`, `'trajectory'`, `'refocus'`, `'observable'`, `'multichannel'`.
+- Line 85: dispatches on `output`; cases `'final'`, `'trajectory'`, `'refocus'`, `'observable'`, `'multichannel'`, `'total'`.
 - Line 102: `for` loop over `n=1:nsteps`.
 - Line 111: conditional branch on `(n==nsteps)||(toc(feedback)>1)`.
 - Line 125: `for` loop over `n=2:nsteps`.

--- a/interfaces/agents/spinach-knowledge/kernel/krylov.md
+++ b/interfaces/agents/spinach-knowledge/kernel/krylov.md
@@ -106,10 +106,10 @@ Krylov propagation function. Avoids matrix exponentiation, but can be slow. Shou
 - that destination state screening may be
 - less efficient when there are multiple
 - destinations to screen against.
-- coil -the detection state, used when 'observable' is specified as
-- the output option. If 'multichannel' is selected, the coil
-- should contain multiple columns corresponding to individual
-- observable vectors.
+- coil -the detection state, used when 'observable' or 'total' is
+- specified as the output option. If 'multichannel' is sel-
+- ected, the coil should contain multiple columns correspon-
+- ding to individual observable vectors.
 
 ## Outputs
 

--- a/kernel/krylov.m
+++ b/kernel/krylov.m
@@ -41,10 +41,10 @@
 %                              less efficient when there are multiple
 %                              destinations to screen against.
 %
-%   coil   - the detection state, used when 'observable' is specified as
-%            the output option. If 'multichannel' is selected, the coil
-%            should contain multiple columns corresponding to individual
-%            observable vectors.
+%   coil   - the detection state, used when 'observable' or 'total' is
+%            specified as the output option. If 'multichannel' is sel-
+%            ected, the coil should contain multiple columns correspon-
+%            ding to individual observable vectors.
 %
 % Outputs:
 %
@@ -198,8 +198,19 @@ switch output
             error('total observable integral is not defined for unitary wavefunction evolution.');
         end
 
+        % Inflate polyadic generators
+        if isa(L,'polyadic'), L=inflate(L); end
+
+        % Find the states that the generator does not touch
+        idle=gather(~(any(L,1)'|any(L,2)));
+
+        % Refuse divergent integrals over stationary states
+        if any(coil(idle,:)'*rho(idle,:),'all')
+            error('the observable has a stationary component, the integral diverges.');
+        end
+
         % Integrate the observable trajectory to infinity
-        answer=full(real(gather(coil'*((1i*L)\rho))));
+        answer=full(real(gather(coil(~idle,:)'*((1i*L(~idle,~idle))\rho(~idle,:)))));
         
     otherwise
         

--- a/kernel/krylov.m
+++ b/kernel/krylov.m
@@ -202,21 +202,32 @@ switch output
         if isa(L,'polyadic'), L=inflate(L); end
 
         % Find the states reachable from the initial condition
-        reach=any(rho,2);
-        while true
-            fresh=reach|any(L(:,reach),2);
-            if isequal(fresh,reach), break; end
-            reach=fresh;
+        reach=full(any(rho,2)); front=find(reach);
+        while ~isempty(front)
+            [front,~]=find(L(:,front));
+            front=unique(front(~reach(front)));
+            reach(front)=true;
         end
-        reach=gather(reach);
+
+        % Find the states from which the coil is reachable
+        cover=full(any(coil,2)); front=find(cover);
+        while ~isempty(front)
+            [~,front]=find(L(front,:));
+            front=unique(front(~cover(front)));
+            cover(front)=true;
+        end
+
+        % Keep the states that contribute to the observable
+        reach=gather(reach&cover); L=L(reach,reach);
+        rho=rho(reach,:); coil=coil(reach,:);
+
+        % Refuse integrals of non-decaying modes
+        if any(imag(eig(full(gather(L))))>=0)
+            error('a mode contributing to the observable does not decay, the integral diverges.');
+        end
 
         % Integrate the observable trajectory to infinity
-        answer=full(real(gather(coil(reach,:)'*((1i*L(reach,reach))\rho(reach,:)))));
-
-        % Refuse integrals that do not converge
-        if ~all(isfinite(answer),'all')
-            error('the generator is singular on the subspace reachable from rho.');
-        end
+        answer=full(real(gather(coil'*((1i*L)\rho))));
         
     otherwise
         

--- a/kernel/krylov.m
+++ b/kernel/krylov.m
@@ -190,6 +190,16 @@ switch output
             end
             
         end
+
+    case 'total'
+
+        % Refuse integrals of unitary dynamics
+        if strcmp(spin_system.bas.formalism,'zeeman-wavef')
+            error('total observable integral is not defined for unitary wavefunction evolution.');
+        end
+
+        % Integrate the observable trajectory to infinity
+        answer=full(real(gather(coil'*((1i*L)\rho))));
         
     otherwise
         

--- a/kernel/krylov.m
+++ b/kernel/krylov.m
@@ -201,16 +201,22 @@ switch output
         % Inflate polyadic generators
         if isa(L,'polyadic'), L=inflate(L); end
 
-        % Find the states that the generator does not touch
-        idle=gather(~(any(L,1)'|any(L,2)));
-
-        % Refuse divergent integrals over stationary states
-        if any(coil(idle,:)'*rho(idle,:),'all')
-            error('the observable has a stationary component, the integral diverges.');
+        % Find the states reachable from the initial condition
+        reach=any(rho,2);
+        while true
+            fresh=reach|any(L(:,reach),2);
+            if isequal(fresh,reach), break; end
+            reach=fresh;
         end
+        reach=gather(reach);
 
         % Integrate the observable trajectory to infinity
-        answer=full(real(gather(coil(~idle,:)'*((1i*L(~idle,~idle))\rho(~idle,:)))));
+        answer=full(real(gather(coil(reach,:)'*((1i*L(reach,reach))\rho(reach,:)))));
+
+        % Refuse integrals that do not converge
+        if ~all(isfinite(answer),'all')
+            error('the generator is singular on the subspace reachable from rho.');
+        end
         
     otherwise
         


### PR DESCRIPTION
## What was wrong

`kernel/krylov.m` documents a `'total'` output mode in its header, and `grumble()` accepts it as one of the six valid output strings, but the output `switch` had no `case 'total'`. Every call `krylov(...,'total')` therefore fell through to `otherwise` and raised `unknown output option.`, unconditionally.

## Why it matters

`'total'` returns the integral of the observable from time zero to infinity under relaxation, which is what `solid_effect.m` and `rydmr_exp.m` use through `evolution()`. `evolution()` forwards polyadic generators to `krylov()`, and any direct user call of `krylov()` in this mode crashed. The fix adds the case, computing the same quantity as `evolution()`: `real(coil'*((1i*L)\rho))`, with the same refusal for the unitary `zeeman-wavef` formalism where the integral is undefined.

## Stock probe output

```
evolution total: 2.1963e-07
PROBE FAIL: unknown output option.
```

## Patched probe output

```
evolution total: 2.1963e-07
krylov total: 2.1963e-07, diff=2.647e-23
PROBE PASS
```

Probe: two-proton `sphten-liouv` system with `t1_t2` relaxation, `rho=coil=L+` on the first proton, comparing `krylov(...,'total')` against `evolution(...,'total')`.

`checkcode` on `kernel/krylov.m`: clean.

Finding id: F172
