### PR TITLE
fix(kinetics): weight diffusion rates by the source cell area in flow_gen (F168)

### DIFF
--- a/kernel/kinetics/flow_gen.m
+++ b/kernel/kinetics/flow_gen.m
@@ -95,10 +95,10 @@ parfor k=1:ncells %#ok<*PFBNS>
                 F_local=[F_local; m, k, -F_km];
             end
             
-            % Diffusion goes both ways
-            D_km=(1/A_k)*(b_km/norm(r_km,2))*parameters.diff;
-            F_local=[F_local; k m  D_km];
-            F_local=[F_local; m k  D_km];
+            % Diffusion goes both ways, per unit amount in the source cell
+            D_km=(b_km/norm(r_km,2))*parameters.diff;
+            F_local=[F_local; k m  D_km/mesh.vor.weights(m)];
+            F_local=[F_local; m k  D_km/A_k];
 
         end
 


### PR DESCRIPTION
## What was wrong

`flow_gen.m` assembles an amount-space generator (balanced with zero column sums) and converts it to concentration space with `F=A_back*F*A_forw`. In amount space, the rate of diffusive transfer from cell m into cell k per unit amount held in m is `diff*b_km/(r_km*A_m)`, i.e. it carries the area of the **source** cell. Both diffusion triples inserted per shared boundary used `1/A_k`, the area of the current cell, so the `(k,m)` entry was scaled by the wrong area whenever `A_k~=A_m`.

## Why it matters physically

After the conversion to concentration space the generator had nonzero row sums on any mesh with unequal Voronoi cell areas, so an initially uniform concentration developed spurious gradients under pure diffusion. Fick's law demands zero flux at zero gradient; every reaction-diffusion simulation on a real imported COMSOL mesh got quantitatively wrong transport. Total amount was conserved on stock code (the `A_back*F*A_forw` step guarantees that), which is why the defect did not show up as a population leak.

## Fix

Three lines inside the boundary loop: the geometric factor is computed once and each of the two diffusion entries is divided by the area of its own source cell (`mesh.vor.weights(m)` for `(k,m)`, `A_k` for `(m,k)`). For equal cell areas the result is unchanged, and `tests/kernel/test_kinetics_generator_suite.m` passes unmodified. Flow terms are not touched.

## Stock probe output

Two cells of areas 1 and 2 sharing a unit boundary at unit separation, `diff=0.5`:

```
F=
   -0.7500    1.5000
    0.3750   -0.7500

max |F*ones|       (uniform drift): 0.75
max |w'*F|         (amount leak):   0
PROBE FAIL
```

## Patched probe output

```
F=
   -1.0000    1.0000
    0.5000   -0.5000

max |F*ones|       (uniform drift): 0
max |w'*F|         (amount leak):   0
PROBE PASS
```

`checkcode` on the patched file: 0 findings. `test_kinetics_generator_suite` passes with no failures.

Note: this touches the same lines as #431 (F169, double counting of shared faces). The two fixes are independent in content; whichever merges second needs a trivial conflict resolution keeping one diffusion triple per boundary with the source-cell area.

Finding id: F168