### PR TITLE
psyche.m: coherence filters use parameters.spins (F112)

### DIFF
--- a/experiments/spen/psyche.m
+++ b/experiments/spen/psyche.m
@@ -109,7 +109,7 @@ rho_stack=evolution(spin_system,L,[],rho,parameters.timestep1/2,...
                     parameters.npoints(1)-1,'trajectory');
 
 % Select "+1" coherence
-rho_stack=coherence(spin_system,rho_stack,{{'1H',+1}});
+rho_stack=coherence(spin_system,rho_stack,{{parameters.spins{1},+1}});
 
 % Evolve for the delta period
 rho_stack=evolution(spin_system,L+parameters.g_amp*G{1},[],...
@@ -123,7 +123,7 @@ rho_stack=evolution(spin_system,L+parameters.g_amp*G{1},[],...
                     rho_stack,parameters.delta,1,'final');
 
 % Select "-1" coherence
-rho_stack=coherence(spin_system,rho_stack,{{'1H',-1}});
+rho_stack=coherence(spin_system,rho_stack,{{parameters.spins{1},-1}});
 
 % Apply the 1st pulse of the PSYCHE element
 durations=ones(size(Cx))*parameters.duration/numel(Cx);
@@ -131,14 +131,14 @@ rho_stack=shaped_pulse_xy(spin_system,L+parameters.g_amp*G{1},...
                           {Lx,Ly},{Cx,+Cy},durations,rho_stack,'expv-pwc');
 
 % Select "0" coherence
-rho_stack=coherence(spin_system,rho_stack,{{'1H',0}});
+rho_stack=coherence(spin_system,rho_stack,{{parameters.spins{1},0}});
 
 % Apply the 2nd pulse of the PSYCHE element
 rho_stack=shaped_pulse_xy(spin_system,L+parameters.g_amp*G{1},...
                           {Lx,Ly},{Cx,-Cy},durations,rho_stack,'expv-pwc');
 
 % Select "+1" coherence
-rho_stack=coherence(spin_system,rho_stack,{{'1H',+1}});
+rho_stack=coherence(spin_system,rho_stack,{{parameters.spins{1},+1}});
 
 % Run the second half of the t1 evolution
 rho_stack=evolution(spin_system,L,[],rho_stack,parameters.timestep1/2,...


### PR DESCRIPTION
## What was wrong
The four `coherence()` selection calls in `experiments/spen/psyche.m` were hard-coded to `'1H'`, while the pulse operators `Lp`, `Lx`, `Ly` were built from `parameters.spins{1}`. The header documents `parameters.spins` as the nuclei the sequence runs on.

## Why it matters
PSYCHE on any documented non-proton working spin (19F, 13C, ...) crashed inside `coherence()` because `'1H'` is not in the system, instead of running the pure-shift sequence on that nucleus. For `parameters.spins={'1H'}` nothing changes.

## Fix
Replace the four literal `'1H'` with `parameters.spins{1}`. Four lines changed, no new code.

## Stock probe output
Two-spin 19F system, `imaging(spin_system,@psyche,parameters)`:
```
PROBE F112: psyche on 19F FAILED: spec spin string must be 'all', 'electrons', 'nuclei', or an isotope present in the system.
```

## Patched probe output
```
PROBE F112: psyche on 19F ran, fid size [8 2], norm 0.6639
```
`checkcode` on the changed file: clean.

Finding id: F112