### PR TITLE
grape_coop: normalise the target projector (F187)

### DIFF
--- a/kernel/optimcon/wrappers/grape_coop.m
+++ b/kernel/optimcon/wrappers/grape_coop.m
@@ -39,14 +39,8 @@ rho_targ=spin_system.control.rho_targ{1};
 switch spin_system.bas.formalism
     case 'zeeman-hilb'
         targ_norm=hdot(rho_targ,rho_targ);
-        if abs(targ_norm)==0
-            error('target state has zero norm.');
-        end
     otherwise
         targ_norm=rho_targ'*rho_targ;
-        if abs(targ_norm)==0
-            error('target state has zero norm.');
-        end
         P_dirt=eye(numel(rho_targ))-rho_targ*rho_targ'/targ_norm;
 end
 
@@ -121,6 +115,9 @@ function grumble(spin_system)
 if (numel(spin_system.control.rho_targ)~=1)||...
    (numel(spin_system.control.rho_init)~=1)
     error('this function only supports point-to-point transformations.');
+end
+if norm(spin_system.control.rho_targ{1},'fro')==0
+    error('target state has zero norm.');
 end
 if mod(spin_system.control.ncontrols,2)~=0
     error('grape_coop is phase-modulated, number of controls must be even.');

--- a/kernel/optimcon/wrappers/grape_coop.m
+++ b/kernel/optimcon/wrappers/grape_coop.m
@@ -43,8 +43,11 @@ switch spin_system.bas.formalism
             error('target state has zero norm.');
         end
     otherwise
-        P_targ=rho_targ*rho_targ';
-        P_dirt=eye(size(P_targ))-P_targ;
+        targ_norm=rho_targ'*rho_targ;
+        if abs(targ_norm)==0
+            error('target state has zero norm.');
+        end
+        P_dirt=eye(numel(rho_targ))-rho_targ*rho_targ'/targ_norm;
 end
 
 % Make sure final states are available


### PR DESCRIPTION
## What was wrong

In `kernel/optimcon/wrappers/grape_coop.m`, for every formalism other than `zeeman-hilb`, the impurity projector was built as `P_dirt=eye(...)-rho_targ*rho_targ'`. That is only the orthogonal-complement projector when `rho_targ` has unit norm. The `zeeman-hilb` branch three lines above divides by the target norm; the Liouville-space and wavefunction branch did not. `optimcon()` does not enforce unit-norm targets.

## Why it matters

The cooperative pulse pair is designed so that the impurities of the two outcomes cancel on addition. With a non-unit target, `P_dirt` is not idempotent and does not annihilate the target, so the "impurity" fed into the penalty term and its gradient contains a target-dependent admixture and the penalty depends on the arbitrary scale of the target vector. The fix divides the projector by `rho_targ'*rho_targ` and adds the same zero-norm check as the `zeeman-hilb` branch. Unit-norm targets, as in `examples/optimal_control/state_transfer_coop.m`, give bit-identical results.

## Stock probe output

```
impurity penalty, unit target:   3.9343076378
impurity penalty, target x3:     4.1071639257
PROBE FAIL
```

## Patched probe output

```
impurity penalty, unit target:   3.9343076378
impurity penalty, target x3:     3.9343076378
PROBE PASS
```

Probe: glycine 14N NQI system from `state_transfer_coop.m`, 20 slices, fixed random phase pair; impurity penalty extracted as `(fid_a+fid_b)/2-fid_coop(1)` with `fid_a`, `fid_b` from `grape_phase` on each pulse, for a unit-norm target and the same target scaled by 3. The impurity component of a state does not depend on the target's scale, so the two penalties must agree.

`checkcode` on `grape_coop.m`: clean.

Finding id: F187
