### PR TITLE
ilpcs.m: validate that ranks start with rank 0 (F106)

### DIFF
--- a/experiments/pseudocon/ilpcs.m
+++ b/experiments/pseudocon/ilpcs.m
@@ -150,7 +150,7 @@ end
 if (~isnumeric(mguess))||(size(mguess,2)~=3)||(size(mguess,1)~=1)||(~isreal(mguess))
     error('mxyz parameter should be a real row vector with three elements.');
 end
-if (~isnumeric(L))||(~isreal(L))||(~isrow(L))||any(mod(L,1)~=0)||...
+if (~isnumeric(L))||(~isreal(L))||(~isrow(L))||isempty(L)||any(mod(L,1)~=0)||...
    (numel(unique(L))~=numel(L))||any(L<0)||(L(1)~=0)
     error('ranks must be a row of unique non-negative integers starting with 0.');
 end

--- a/experiments/pseudocon/ilpcs.m
+++ b/experiments/pseudocon/ilpcs.m
@@ -17,7 +17,8 @@
 %              in ppm  
 %
 %      ranks - row of multipole expansion ranks to be used in the
-%              fitting procedure
+%              fitting procedure, starting with 0; the rank 0 moment
+%              is fixed by normalisation and is not fitted
 %
 %     mguess - guess value for the paramagnetic centre position,
 %              a three-element vector in Angstrom
@@ -149,8 +150,9 @@ end
 if (~isnumeric(mguess))||(size(mguess,2)~=3)||(size(mguess,1)~=1)||(~isreal(mguess))
     error('mxyz parameter should be a real row vector with three elements.');
 end
-if (~isnumeric(L))||(~isreal(L))
-    error('L must be a real vector.');
+if (~isnumeric(L))||(~isreal(L))||(~isrow(L))||any(mod(L,1)~=0)||...
+   (numel(unique(L))~=numel(L))||any(L<0)||(L(1)~=0)
+    error('ranks must be a row of unique non-negative integers starting with 0.');
 end
 end
 


### PR DESCRIPTION
## What was wrong
`ilpcs.m` counts fitted multipole variables with `nonzeros(ranks)` and always prepends the fixed rank-0 moment `0.5/sqrt(pi)` before calling `multipack(ranks,...)`. The grumbler only checked that `ranks` is real. A rank list without 0 therefore crashed deep inside `multipack` with "the number of entries in moments does not match the declared ranks", and a rank list with 0 not in first position (e.g. `[1 0 2]`) did not crash at all: the monopole was silently packed into the rank-1 slot and a wrong fit was returned.

## Why it matters
The rank-0 moment is the normalisation of the paramagnetic centre probability density (N/2/sqrt(pi), doi:10.1039/c6cp05437d); it is fixed, not fitted, and the point-dipole term it carries is the leading PCS contribution, so a fit without it is not a meaningful model. The correct behaviour is an informative error at the entrance, not a cryptic crash or a silently mispacked fit.

## Fix
The grumbler now requires `ranks` to be a row of unique non-negative integers starting with 0, mirroring the `multipack` grumbler plus the first-element condition; the header documents the requirement. No numerical result changes for any input that previously ran correctly.

## Stock probe output
```
PROBE F106: ranks=[0 1 2] ran, mxyz=[0.453 0.423 0.39], Ilm{1}=0.282
PROBE F106: ranks=[1 2] FAILED: the number of entries in moments does not match the declared ranks.
PROBE F106: ranks=[1 0 2] ran, mxyz=[-0.113 0.814 0.0249], Ilm{1}=[0.282 -0.032 0.0271]
```

## Patched probe output
```
PROBE F106: ranks=[0 1 2] ran, mxyz=[0.453 0.423 0.39], Ilm{1}=0.282
PROBE F106: ranks=[1 2] FAILED: ranks must be a row of unique non-negative integers starting with 0.
PROBE F106: ranks=[1 0 2] FAILED: ranks must be a row of unique non-negative integers starting with 0.
```
`checkcode` on the changed file: clean.

Finding id: F106