### PR TITLE
amensolve: return the zero solution for a zero right-hand side (F192)

### DIFF
--- a/kernel/overloads/@ttclass/amensolve.m
+++ b/kernel/overloads/@ttclass/amensolve.m
@@ -105,6 +105,9 @@ x=x0;
 % Check inputs for consistency
 grumble(A,y,x,tol,opts.sv_floor);
 
+% Zero right-hand side has the zero solution
+if norm(y,'fro')==0, x=y; return; end
+
 % Read dimension and mode sizes
 d=y.ncores;     % dimension of the problem
 sz=A.sizes;     % mode sizes


### PR DESCRIPTION
## What was wrong

In `kernel/overloads/@ttclass/amensolve.m`, the interface reductions `reduce_vector` and `reduce_matrix` divide the accumulated interface by its Frobenius norm. For a right-hand side that is exactly zero the norm is zero, the cores become NaN, and the solver crashes downstream in `frob_chop`'s grumble with the unhelpful message `s must be a vector of non-negative real numbers.` Nothing in `amensolve`'s own validation rejects or handles a zero right-hand side.

## Why it matters

A zero right-hand side is a routine occurrence when a driving or coupling term vanishes by symmetry. `mldivide.m` sends `A'*y` to `amensolve`, so such a case reaches this division. The exact solution of `Ax=0` for a nonsingular `A` is `x=0`. The fix returns the right-hand side itself, which is already the zero tensor train with the correct mode sizes, straight after validation. Non-zero right-hand sides take exactly the same path as before.

## Stock probe output

```
norm of rhs: 0
PROBE FAIL: s must be a vector of non-negative real numbers.
```

## Patched probe output

```
norm of rhs: 0
solution norm: 0, all finite: 1
PROBE PASS
```

Probe: 3x3x3 Hermitian positive-definite tensor-train system, right-hand side built from zero Kronecker factors, `amensolve(A,y,1e-6)`.

The shipped `examples/fundamentals/tensor_structures/amensolve_test_1.m` passes unchanged on the patched code (all six cases). `checkcode` on `amensolve.m`: clean.

Finding id: F192
