### PR TITLE
rydmr_exp.m: include relaxation in the zeeman-hilb branch (F114)

### DIFF
--- a/experiments/spin_chem/rydmr_exp.m
+++ b/experiments/spin_chem/rydmr_exp.m
@@ -104,8 +104,8 @@ switch spin_system.bas.formalism
             % Compute integration endpoint
             t_end=10/rates(n); %#ok<PFBNS>
             
-            % Compute RYDMR (rates inside for roundoff reasons)
-            answer(nm)=hdot(S,expmint(spin_system,H_curr,S*rates(n),H_curr+1i*rates(n)*Id,t_end));
+            % Compute RYDMR (rates inside for roundoff reasons, R damps both sides)
+            answer(nm)=hdot(S,expmint(spin_system,H_curr,S*rates(n),H_curr+1i*rates(n)*Id-2i*R,t_end));
             
         end
         


### PR DESCRIPTION
## What was wrong
In `experiments/spin_chem/rydmr_exp.m` the `zeeman-hilb` branch computed the singlet yield from `H_curr`, `S`, `rates(n)`, and `Id` only. The relaxation operator `R` was validated by the grumbler and then never used, while the `sphten-liouv`/`zeeman-liouv` branch includes `1i*R` in the Liouvillian.

## Why it matters
A user who configures relaxation (the kernel builds `R=-(rate/2)*unit_oper` in Hilbert space for `inter.relaxation={'damp'}`) gets an undamped RYDMR yield curve in `zeeman-hilb`, with no warning; the same input in Liouville space is damped. Relaxation competes with recombination and changes the field dependence of the yield, so the returned curve is physically wrong.

## Fix
In Hilbert space the kernel propagates `rho -> P*rho*P'` with `P=expm(-1i*(H+1i*R)*t)`, so the damping enters as `expm(R*t)` on both sides, i.e. `expm(2*R*t)` overall for the scalar `R` the kernel builds. `expmint` requires its first matrix to be Hermitian, so the whole decay is put into the third argument: `H_curr+1i*rates(n)*Id-2i*R`. One line changed. With `R=0` the result is bit-identical to stock.

## Stock probe output
E,E,1H radical pair, `inter.damp_rate=0.5*gauss2mhz(20)*1e6`, one field, one rate; the reference is an independent adaptive quadrature of `k*Int[exp(-k*t)*<S|P(t)*S*P(t)'|S>,{t,0,10/k}]` with `P=expm(-1i*(H+1i*R)*t)`:
```
PROBE F114 control: reference without R=0.46516518
PROBE F114: rydmr_exp yield=0.46516518, reference with R=0.28532726, diff=1.798e-01
```
Stock reproduces the no-relaxation reference exactly, i.e. `R` is ignored.

## Patched probe output
```
PROBE F114 control: reference without R=0.46516518
PROBE F114: rydmr_exp yield=0.28532726, reference with R=0.28532726, diff=-5.796e-11
```
`checkcode` on the changed file: clean.

Finding id: F114