### PR TITLE
bruker_write: normalise amplitude column to the Bruker 0-100 scale (F213)

### DIFF
--- a/kernel/pulses/bruker_write.m
+++ b/kernel/pulses/bruker_write.m
@@ -38,7 +38,7 @@ grumble(X,Y,dt,file_name);
 phi=rad2deg(wrapTo2Pi(phi));
 
 % Bruker amplitude scale is 0 to 100
-amp=100*amp/max(amp);
+if max(amp)>0, amp=100*amp/max(amp); end
 
 % Interval count, min and max
 n_ints=numel(X); T=n_ints*dt;

--- a/kernel/pulses/bruker_write.m
+++ b/kernel/pulses/bruker_write.m
@@ -37,6 +37,9 @@ grumble(X,Y,dt,file_name);
 % Wrap phases and convert to degrees
 phi=rad2deg(wrapTo2Pi(phi));
 
+% Bruker amplitude scale is 0 to 100
+amp=100*amp/max(amp);
+
 % Interval count, min and max
 n_ints=numel(X); T=n_ints*dt;
 min_amp=min(amp); max_amp=max(amp);


### PR DESCRIPTION
## What was wrong
`bruker_write` placed the absolute RF amplitudes in Hz straight into the JCAMP-DX XYPOINTS column and the MINX/MAXX headers. The Bruker shape file convention (see every shipped file in `kernel/pulses/pk_files`, all with `##MAXX= 1.000000E02`) and Spinach's own `read_wave` (`A=waveform(:,1)/100`) both treat that column as a percentage of the maximum amplitude, 0 to 100.

## Why it matters physically
A shape exported from optimal control and loaded into TopSpin, or re-read by `read_wave`, would have its amplitude scale wrong by the ratio of the peak nutation frequency to 100, so the pulse power and shape would be wrong by orders of magnitude.

## Fix
One added statement after the polar conversion: `amp=100*amp/max(amp);`. The relative shape and the phase column are unchanged; MINX/MAXX now follow the normalised column.

## Stock probe output
```
MAXX header: 2499.54, max amplitude column: 2499.54, MINX header: 0
phase column range: [0, 358.531]
F213 REPRODUCED: amplitude column peaks at 2499.54, not 100
```

## Patched probe output
```
MAXX header: 100, max amplitude column: 100, MINX header: 0
phase column range: [0, 358.531]
F213 NOT REPRODUCED: amplitude column normalised to 100
```

checkcode clean; invariants of `test_dynamic_pulse_utilities_deep` (NPOINTS, SHAPE_LENGTH, END) still hold.

Finding id: F213