### PR TITLE
read_wave: unwrap phase before resampling across the branch cut (F217)

### DIFF
--- a/kernel/pulses/read_wave.m
+++ b/kernel/pulses/read_wave.m
@@ -56,7 +56,7 @@ if (~exist('scaling_factor','var'))||isnan(scaling_factor)
 end
 
 % Get amplitude and phase
-A=waveform(:,1)/100; phi=pi*waveform(:,2)/180;
+A=waveform(:,1)/100; phi=unwrap(pi*waveform(:,2)/180);
 
 % Resample amplitude and phase
 A=interp1(linspace(0,1,numel(A)),A,linspace(0,1,npoints),'pchip');


### PR DESCRIPTION
## What was wrong
`read_wave` converted the JCAMP-DX phase column to radians and resampled it with `interp1(...,'pchip')` directly on the wrapped angle. Where a stored phase sweeps through the 0/360 degree wrap between samples, the interpolant follows a spurious ~360 degree jump instead of the small physical increment.

## Why it matters physically
Any swept or chirped waveform file (adiabatic pulses, which the header explicitly invites users to add) resampled to a different point count acquires a badly distorted Cartesian waveform near every wrap point, with no warning. Shipped files with 0/180 degree phase alternation are unaffected: `unwrap` leaves jumps of exactly pi in place.

## Fix
One token: `phi=unwrap(pi*waveform(:,2)/180);`. Cartesian outputs at the file's own sample points are identical because the conversion is 2pi-periodic.

## Stock probe output
Temporary chirp file, phase `mod(720*t^2,360)` over 200 points, resampled to 399 points, compared with the exact chirp; plus a regression signature on the shipped `sinc_1000.pk`.
```
max Cartesian error on a wrapped chirp resampled 200 -> 399 points: 2.28
sinc_1000.pk regression signature: 294.1547782 500 294.1547782 0
F217 REPRODUCED: spurious excursion across the branch cut, error 2.28
```

## Patched probe output
```
max Cartesian error on a wrapped chirp resampled 200 -> 399 points: 1.983e-05
sinc_1000.pk regression signature: 294.1547782 500 294.1547782 0
F217 NOT REPRODUCED: phase resampled continuously across the wrap
```

checkcode clean.

Finding id: F217