### PR TITLE
g2fplanck: 2D gradient rotation sense matches the 3D convention (F226)

### DIFF
--- a/kernel/utilities/g2fplanck.m
+++ b/kernel/utilities/g2fplanck.m
@@ -68,8 +68,8 @@ switch numel(parameters.npts)
         
         % Rotate gradients if necessary
         if isfield(parameters,'grad_angles')
-            R=[ cos(parameters.grad_angles) sin(parameters.grad_angles);
-               -sin(parameters.grad_angles) cos(parameters.grad_angles)];
+            R=[cos(parameters.grad_angles) -sin(parameters.grad_angles);
+               sin(parameters.grad_angles)  cos(parameters.grad_angles)];
             Gx_new=Gx*R(1,1)+Gy*R(1,2);
             Gy_new=Gx*R(2,1)+Gy*R(2,2);
             Gx=Gx_new; Gy=Gy_new;


### PR DESCRIPTION
**Finding:** F226

**What was wrong:** in the two-dimensional branch of `g2fplanck`, the rotation matrix applied to the gradient set for `parameters.grad_angles` was `[cos sin; -sin cos]`, the transpose of the Z rotation block that `euler2dcm` uses (`[cos -sin; sin cos]`, ZYZ active convention). Both branches apply the matrix identically (`G_new(i)=sum_j R(i,j)*G(j)`), so a 2D angle `theta` rotated the gradients in the opposite sense to the 3D angles `[theta 0 0]`.

**Why it matters:** an oblique-gradient 2D imaging simulation set up with `grad_angles` came out mirrored relative to the 3D convention used by every shipped example. The fix makes the 2D rotation by `theta` identical to the 3D rotation by `[theta 0 0]`; users who relied on the old 2D sense will see their rotation direction flip.

**Fix:** the 2D rotation matrix is now the Z block of `euler2dcm`. Two lines changed, no other behaviour affected.

**Probe:** `probe_f226.m` builds the same 1H system with a 2D grid (4x5, angle pi/6) and a 3D grid (4x5x1, angles [pi/6 0 0]) and compares the inflated rotated operators.

Stock output:
```
Running startup checks...
Starting parallel pool (parpool) using the 'Processes' profile ...
Connected to parallel pool with 11 workers.
|Gx2D-Gx3D|/|Gx3D| = 1.4771
|Gy2D-Gy3D|/|Gx3D| = 0.7785
PROBE_F226 FAIL
```

Patched output:
```
Running startup checks...
|Gx2D-Gx3D|/|Gx3D| = 0
|Gy2D-Gy3D|/|Gx3D| = 0
PROBE_F226 PASS
```

`checkcode` on the changed file is empty; house-style checker reports 0 violations.