### PR TITLE
rcv/horzcat: accept any number of operands (F313)

### DIFF
--- a/kernel/overloads/@rcv/horzcat.m
+++ b/kernel/overloads/@rcv/horzcat.m
@@ -19,31 +19,26 @@ function A=horzcat(varargin)
 % Check consistency
 grumble(varargin{:});
 
-% Start from the leftmost operand
-A=varargin{1};
-
-% Append the remaining operands
-for n=2:nargin
-
-    % Align locations
-    B=varargin{n};
-    if A.isGPU||B.isGPU
-        A=gpuArray(A);
-        B=gpuArray(B);
-    end
-
-    % Shift column indices
-    B.col=B.col+A.numCols;
-
-    % Concatenate RCV arrays
-    A.row=[A.row; B.row];
-    A.col=[A.col; B.col];
-    A.val=[A.val; B.val];
-
-    % Update column count
-    A.numCols=A.numCols+B.numCols;
-
+% Move all operands to the GPU if any of them is there
+if any(cellfun(@(x)x.isGPU,varargin))
+    varargin=cellfun(@gpuArray,varargin,'UniformOutput',false);
 end
+
+% Shift column indices by the running column count
+rows=cell(nargin,1); cols=cell(nargin,1); vals=cell(nargin,1); ncols=int64(0);
+for n=1:nargin
+    rows{n}=varargin{n}.row;
+    cols{n}=varargin{n}.col+ncols;
+    vals{n}=varargin{n}.val;
+    ncols=ncols+varargin{n}.numCols;
+end
+
+% Concatenate RCV arrays once
+A=varargin{1};
+A.row=vertcat(rows{:});
+A.col=vertcat(cols{:});
+A.val=vertcat(vals{:});
+A.numCols=ncols;
 
 end
 

--- a/kernel/overloads/@rcv/horzcat.m
+++ b/kernel/overloads/@rcv/horzcat.m
@@ -1,51 +1,58 @@
 % Horizontal concatenation for RCV sparse matrices. Syntax:
 %
-%                        A=horzcat(A,B)
+%                        A=horzcat(A,B,...)
 %
 % Parameters:
 %
-%    A   - left RCV sparse matrix
-%
-%    B   - right RCV sparse matrix
+%    A,B,...   - RCV sparse matrices, left to right
 %
 % Outputs:
 %
-%    A   - RCV sparse matrix
+%    A         - RCV sparse matrix
 %
 % m.keitel@soton.ac.uk
 %
 % <https://spindynamics.org/wiki/index.php?title=rcv/horzcat.m>
 
-function A=horzcat(A,B)
+function A=horzcat(varargin)
 
 % Check consistency
-grumble(A,B);
+grumble(varargin{:});
 
-% Align locations
-if A.isGPU||B.isGPU
-    A=gpuArray(A);
-    B=gpuArray(B);
+% Start from the leftmost operand
+A=varargin{1};
+
+% Append the remaining operands
+for n=2:nargin
+
+    % Align locations
+    B=varargin{n};
+    if A.isGPU||B.isGPU
+        A=gpuArray(A);
+        B=gpuArray(B);
+    end
+
+    % Shift column indices
+    B.col=B.col+A.numCols;
+
+    % Concatenate RCV arrays
+    A.row=[A.row; B.row];
+    A.col=[A.col; B.col];
+    A.val=[A.val; B.val];
+
+    % Update column count
+    A.numCols=A.numCols+B.numCols;
+
 end
-
-% Shift column indices
-B.col=B.col+A.numCols;
-
-% Concatenate RCV arrays
-A.row=[A.row; B.row];
-A.col=[A.col; B.col];
-A.val=[A.val; B.val];
-
-% Update column count
-A.numCols=A.numCols+B.numCols;
 
 end
 
 % Consistency enforcement
-function grumble(A,B)
-if ~isa(A,'rcv')||~isa(B,'rcv')
-    error('both inputs must be RCV sparse matrices.');
+function grumble(varargin)
+if ~all(cellfun(@(x)isa(x,'rcv'),varargin))
+    error('all inputs must be RCV sparse matrices.');
 end
-if A.numRows~=B.numRows
+if numel(unique(cellfun(@(x)x.numRows,varargin)))>1
     error('row counts must match for horizontal concatenation.');
 end
 end


### PR DESCRIPTION
**Finding:** F313

**What was wrong:** `kernel/overloads/@rcv/horzcat.m` was declared as `horzcat(A,B)`. MATLAB passes every operand of `[A B C]` to a single `horzcat` call, so three or more RCV matrices crashed with "Too many input arguments".

**Why it matters:** RCV is a general-purpose sparse storage class; assembling a block operator from three or more column blocks with the standard bracket syntax is ordinary usage and produced a hard error instead of the concatenation.

**Fix:** the overload now takes `varargin` and folds the operands left to right with the same shift-and-append step as before; the grumbler checks that every operand is RCV and that all row counts agree. No numerical change for the two-operand case.

**Stock probe output** (`[A B C]` of three 2x2 RCV matrices):
```
PROBE_F313 FAIL: Too many input arguments.
```

**Patched probe output** (result checked against dense concatenation, plus the two-operand and row-mismatch cases):
```
PROBE_F313 PASS
     1     0     1     0
     0     2     0     2
row counts must match for horizontal concatenation.
```
`checkcode` on the changed file is clean.