### PR TITLE
oscillator: header declares the hbar=1 unit convention (F232)

### DIFF
--- a/kernel/utilities/oscillator.m
+++ b/kernel/utilities/oscillator.m
@@ -16,7 +16,7 @@
 %
 % Outputs:
 %
-%   H_oscl   -   oscillator Hamiltonian, Joules
+%   H_oscl   -   oscillator Hamiltonian, Joules with hbar=1
 %
 %   X_oscl   -   oscillator X operator, m
 %
@@ -24,6 +24,10 @@
 %
 % Note: gravitation is directed along the X axis. Finite difference
 %       derivative operators are used.
+%
+% Note: the reduced Planck constant is set to 1 J*s in the kinetic
+%       energy term, so the Hamiltonian is also the generator of
+%       time evolution in rad/s, as in expm(-1i*H_oscl*t).
 %
 % ilya.kuprov@weizmann.ac.il
 %


### PR DESCRIPTION
**Finding:** F232

**What was wrong:** the header of `oscillator` promised a Hamiltonian in Joules for SI inputs (N/m, kg), but the kinetic term is `-(1/(2*par_mass))*d2_dx2` with no `hbar^2`. For SI inputs that term is 68 orders of magnitude off the SI value and not dimensionally consistent with the potential term.

**Why it matters:** the documentation misleads anyone treating the output as SI Joules. The code itself is internally consistent in the convention `hbar=1 J*s`: both shipped callers (`slosh_test_1`, `slosh_test_2`, with 1 kg, 2e3 N/m, a 2 m box, and 1 ms steps) are toy models that propagate with `expm(-1i*H*t)`, which also assumes `hbar=1`. Inserting the real `hbar^2` would freeze those examples and require a rewrite of their physics, so the correct minimal fix is to state the convention the code actually uses.

**Fix:** header only. The output line now reads "Joules with hbar=1" and a note records that the reduced Planck constant is set to 1 J*s in the kinetic term, so the Hamiltonian is also the evolution generator in rad/s. No numerical result changes.

**Probe:** `probe_f232.m` compares the kinetic part of the returned Hamiltonian with the hbar=1 and SI forms, then checks that the header declares the Planck constant convention.

Stock output:
```
kinetic term ratio to hbar=1 form: 1
kinetic term ratio to SI form:     8.991821529284631e+67
header claims Joules for SI inputs without a Planck constant convention
PROBE_F232 FAIL
```

Patched output:
```
kinetic term ratio to hbar=1 form: 1
kinetic term ratio to SI form:     8.991821529284631e+67
header declares the Planck constant convention
PROBE_F232 PASS
```

`checkcode` on the changed file is empty; house-style checker reports 0 violations.