### PR TITLE
plot_2d: allow purely imaginary complex spectra (F207)

### DIFF
--- a/kernel/plotting/plot_2d.m
+++ b/kernel/plotting/plot_2d.m
@@ -79,13 +79,16 @@ report(spin_system,'plotting...');
 % If a complex spectrum is received, plot both components
 if nnz(imag(spectrum))>0
     
-    % Recursively plot the real part
+    % Recursively plot the real part unless it is zero
     subplot(1,2,1);
-    [axis_f1,axis_f2]=plot_2d(spin_system,real(spectrum),parameters,ncont,delta,k,ncol,m,signs);
+    if nnz(real(spectrum))>0
+        plot_2d(spin_system,real(spectrum),parameters,ncont,delta,k,ncol,m,signs);
+    end
     ktitle('Real part of the complex spectrum.');
 
     % Recursively plot the imaginary part
-    subplot(1,2,2); plot_2d(spin_system,imag(spectrum),parameters,ncont,delta,k,ncol,m,signs);
+    subplot(1,2,2);
+    [axis_f1,axis_f2]=plot_2d(spin_system,imag(spectrum),parameters,ncont,delta,k,ncol,m,signs);
     ktitle('Imaginary part of the complex spectrum.');
 
     % Return the transposed plotting matrix

--- a/kernel/plotting/plot_2d.m
+++ b/kernel/plotting/plot_2d.m
@@ -79,16 +79,15 @@ report(spin_system,'plotting...');
 % If a complex spectrum is received, plot both components
 if nnz(imag(spectrum))>0
     
-    % Recursively plot the real part unless it is zero
+    % Recursively plot the real part
     subplot(1,2,1);
-    if nnz(real(spectrum))>0
-        plot_2d(spin_system,real(spectrum),parameters,ncont,delta,k,ncol,m,signs);
-    end
+    plot_2d(spin_system,real(spectrum),parameters,ncont,delta,k,ncol,m,signs);
     ktitle('Real part of the complex spectrum.');
 
     % Recursively plot the imaginary part
     subplot(1,2,2);
-    [axis_f1,axis_f2]=plot_2d(spin_system,imag(spectrum),parameters,ncont,delta,k,ncol,m,signs);
+    [axis_f1,axis_f2]=plot_2d(spin_system,imag(spectrum),parameters,ncont,...
+                                          delta,k,ncol,m,signs);
     ktitle('Imaginary part of the complex spectrum.');
 
     % Return the transposed plotting matrix


### PR DESCRIPTION
## What was wrong

In `kernel/plotting/plot_2d.m`, a complex spectrum is handled by recursing on `real(spectrum)` and then on `imag(spectrum)`. When the real part is identically zero, as for a pure dispersion-mode spectrum, `contspacing` receives `smax=smin=0`, produces no contours, and the real-part recursion throws `spectrum contouring produced no contours.` before the imaginary part, which carries all the data, is ever plotted.

## Why it matters

The complex branch exists precisely so that unphased or deliberately phased simulated 2D spectra can be inspected. A user asking for the dispersion component got a hard crash instead of a plot. The fix skips the real-part recursion when the real part is zero, leaving that panel empty with its title, and takes the returned axes from the imaginary-part recursion, which is non-zero by construction inside this branch. Spectra with both parts non-zero draw exactly the same two panels as before; the only change is which recursion supplies the (identical) axis vectors.

## Stock probe output

```
nnz real part: 0, nnz imag part: 4096
PROBE FAIL: spectrum contouring produced no contours.
```

## Patched probe output

```
nnz real part: 0, nnz imag part: 4096
PROBE PASS
```

Probe: single-proton system, 64x64 purely imaginary Gaussian spectrum, `plot_2d(...,20,[0.02 0.2 0.02 0.2],2,256,6,'both')` on an invisible figure. A regression check with a `(1+2i)`-weighted Gaussian still returns 64-point axes for both dimensions and the 64x64 transposed spectrum.

`checkcode` on `plot_2d.m`: clean.

Finding id: F207
