### PR TITLE
rcv/vertcat: accept any number of operands (F316)

### DIFF
--- a/kernel/overloads/@rcv/vertcat.m
+++ b/kernel/overloads/@rcv/vertcat.m
@@ -1,50 +1,58 @@
 % Vertical concatenation for RCV sparse matrices. Syntax:
 %
-%                      A=vertcat(A,B)
+%                      A=vertcat(A,B,...)
 %
 % Parameters:
 %
-%    A  - top RCV matrix
-%    B  - bottom RCV matrix
+%    A,B,...   - RCV sparse matrices, top to bottom
 %
 % Outputs:
 %
-%    A  - concatenated RCV sparse matrix
+%    A         - concatenated RCV sparse matrix
 %
 % m.keitel@soton.ac.uk
 %
 % <https://spindynamics.org/wiki/index.php?title=rcv/vertcat.m>
 
-function A=vertcat(A,B)
+function A=vertcat(varargin)
 
 % Check consistency
-grumble(A,B);
+grumble(varargin{:});
 
-% Align locations
-if A.isGPU||B.isGPU
-    A=gpuArray(A);
-    B=gpuArray(B);
+% Start from the top operand
+A=varargin{1};
+
+% Append the remaining operands
+for n=2:nargin
+
+    % Align locations
+    B=varargin{n};
+    if A.isGPU||B.isGPU
+        A=gpuArray(A);
+        B=gpuArray(B);
+    end
+
+    % Shift row indices
+    B.row=B.row+A.numRows;
+
+    % Concatenate indices
+    A.row=[A.row; B.row];
+    A.col=[A.col; B.col];
+    A.val=[A.val; B.val];
+
+    % Update row count in the result
+    A.numRows=A.numRows+B.numRows;
+
 end
-
-% Shift row indices
-B.row=B.row+A.numRows;
-
-% Concatenate indices
-A.row=[A.row; B.row];
-A.col=[A.col; B.col];
-A.val=[A.val; B.val];
-
-% Update row count in the result
-A.numRows=A.numRows+B.numRows;
 
 end
 
 % Consistency enforcement
-function grumble(A,B)
-if ~isa(A,'rcv')||~isa(B,'rcv')
-    error('both inputs must be RCV sparse matrices.');
+function grumble(varargin)
+if ~all(cellfun(@(x)isa(x,'rcv'),varargin))
+    error('all inputs must be RCV sparse matrices.');
 end
-if A.numCols~=B.numCols
+if numel(unique(cellfun(@(x)x.numCols,varargin)))>1
     error('column counts must match for vertical concatenation.');
 end
 end


### PR DESCRIPTION
**Finding:** F316

**What was wrong:** `kernel/overloads/@rcv/vertcat.m` was declared as `vertcat(A,B)`. MATLAB passes every operand of `[A;B;C]` to a single `vertcat` call, so three or more RCV matrices crashed with "Too many input arguments".

**Why it matters:** stacking three or more row blocks into a larger sparse operator with the standard bracket syntax is ordinary usage of the RCV class and produced a hard error instead of the concatenation.

**Fix:** the overload now takes `varargin` and folds the operands top to bottom with the same shift-and-append step as before; the grumbler checks that every operand is RCV and that all column counts agree. No numerical change for the two-operand case. Companion to #502 (horzcat).

**Stock probe output** (`[A;B;C]` of three 2x2 RCV matrices):
```
PROBE_F316 FAIL: Too many input arguments.
```

**Patched probe output** (result checked against dense concatenation, plus the two-operand and column-mismatch cases):
```
PROBE_F316 PASS
     1     0
     0     2
     1     0
     0     2
column counts must match for vertical concatenation.
```
`checkcode` on the changed file is clean.