### PR TITLE
partner_state: enumerate the exact Cartesian product of partner state sets (F221)

### DIFF
--- a/kernel/states/partner_state.m
+++ b/kernel/states/partner_state.m
@@ -98,31 +98,17 @@ for n=1:numel(active_partners)
 
     % Pull current partner
     partner=active_partners(n);
-    
-    % Over the partner state set
+
+    % Expand descriptors over the partner state set
+    new_descr=cell(0,1);
     for k=1:numel(partner_state_sets{n})
-
-        % Pull current partner spin state
-        partner_state=partner_state_sets{n}{k};
-
-        % Scan descriptors
         for m=1:numel(descr)
-
-            % Pull descriptor line
             current_line=descr{m};
-
-            % Modify the descriptor line if necessary
-            if ~strcmp(current_line{partner},partner_state)
-
-                % Write in the new state and append
-                current_line{partner}=partner_state;
-                descr=[descr; {current_line}]; %#ok<AGROW>
-
-            end
-
+            current_line{partner}=partner_state_sets{n}{k};
+            new_descr=[new_descr; {current_line}]; %#ok<AGROW>
         end
-
     end
+    descr=new_descr;
 
 end
 


### PR DESCRIPTION
## What was wrong
The descriptor expansion started from a seed row with every partner in `'E'` and only ever appended modified copies. The seed row was never removed when `'E'` was absent from a partner's requested state set, and rows already carrying the current state were re-appended as duplicates whenever the set did not begin with `'E'`. The function was only correct for state sets of the form `{'E',...}`.

## Why it matters physically
Restricting a partner to a set such as `{'Lz','L+'}` is the normal way to select coherence-transfer pathways. The stock code returned four times too many states, with unwanted `'E'` partner terms and duplicated states, so any sum or projection over the returned list was wrong.

## Fix
Replaced the append-only scan with a straightforward Cartesian product: for each partner, every existing descriptor is copied once per allowed state. The documented output order for `{'E','Lz'}` is preserved exactly. The file is 14 lines shorter.

## Stock probe output
Three-spin system, spin 1 set to `L+`, partners 2 and 3 restricted to `{'Lz','L+'}`.
```
partner sets {Lz,L+} on spins 2 and 3, set spin 1 in L+: 16 descriptors
  L+,E,E
  L+,Lz,E
  L+,L+,E
  L+,L+,E
  L+,E,Lz
  L+,Lz,Lz
  L+,L+,Lz
  L+,L+,Lz
  L+,E,L+
  L+,Lz,L+
  L+,L+,L+
  L+,L+,L+
  L+,E,L+
  L+,Lz,L+
  L+,L+,L+
  L+,L+,L+
rows with a partner left in E: 7, duplicate rows: 7
documented example order preserved: 1
F221 REPRODUCED: 7 rows with E and 7 duplicates in the partner expansion
```

## Patched probe output
```
partner sets {Lz,L+} on spins 2 and 3, set spin 1 in L+: 4 descriptors
  L+,Lz,Lz
  L+,L+,Lz
  L+,Lz,L+
  L+,L+,L+
rows with a partner left in E: 0, duplicate rows: 0
documented example order preserved: 1
F221 NOT REPRODUCED: exact Cartesian product returned
```

checkcode clean; `test_states_composite_suite` and `test_state_constructor_suite` pass with no failures.

Finding id: F221