### PR TITLE
rcv/size: support the two-output form (F314)

### DIFF
--- a/interfaces/agents/spinach-knowledge/kernel.md
+++ b/interfaces/agents/spinach-knowledge/kernel.md
@@ -255,7 +255,7 @@
 | `kernel/overloads/@rcv/plus.m` | `C=plus(A,B)` | Adds things to RCV sparse matrices. Syntax: C=plus(A,B) Parameters: A -left operand B -right operand Outputs: C -sum A+B | 98 |
 | `kernel/overloads/@rcv/rcv.m` | `obj=rcv(varargin)` | Creates an RCV (row-column-value storage) sparse matrix. Syntax: obj=rcv(M) obj=rcv(dim1,dim2) obj=rcv(R,C,V,dim1,dim2)  | 190 |
 | `kernel/overloads/@rcv/rdivide.m` | `A=rdivide(A,k)` | Divides an RCV sparse matrix by a numeric scalar. Syntax: A=rdivide(A,k) Parameters: A -RCV sparse matrix k -numeric sca | 42 |
-| `kernel/overloads/@rcv/size.m` | `s=size(A,dim)` | Returns the size of an RCV sparse matrix. Syntax: s=size(A,dim) Parameters: A -RCV sparse matrix dim -optional dimension | 61 |
+| `kernel/overloads/@rcv/size.m` | `[s,ncols]=size(A,dim)` | Returns the size of an RCV sparse matrix. Syntax: s=size(A,dim) [s,ncols]=size(A) Parameters: A -RCV sparse matrix dim -optional dimension | 61 |
 | `kernel/overloads/@rcv/sparse.m` | `A=sparse(A)` | Converts an RCV sparse matrix into a Matlab sparse matrix. Syntax: A=sparse(A) Parameters: A -RCV sparse matrix Outputs: | 48 |
 | `kernel/overloads/@rcv/spy.m` | `spy(A)` | Plots the sparsity pattern of an RCV matrix. Syntax: spy(A) Parameters: A -RCV sparse matrix Outputs: produces a sparsit | 50 |
 | `kernel/overloads/@rcv/times.m` | `C=times(A,B)` | Multiplies an RCV sparse matrix by a numeric scalar, in either operand order. Syntax: C=times(A,B) Parameters: A,B -an R | 57 |

--- a/interfaces/agents/spinach-knowledge/kernel/overloads/@rcv/size.md
+++ b/interfaces/agents/spinach-knowledge/kernel/overloads/@rcv/size.md
@@ -1,12 +1,12 @@
 # kernel/overloads/@rcv/size.m
 
 - Source: `/home/kuprov/.openclaw/workspace/Spinach/kernel/overloads/@rcv/size.m`
-- Signature: `s=size(A,dim)`
+- Signature: `[s,ncols]=size(A,dim)`
 - Total lines: 61
 
 ## Purpose
 
-Returns the size of an RCV sparse matrix. Syntax: s=size(A,dim)
+Returns the size of an RCV sparse matrix. Syntax: s=size(A,dim) [s,ncols]=size(A)
 
 ## Physical / mathematical content
 
@@ -22,16 +22,20 @@ Returns the size of an RCV sparse matrix. Syntax: s=size(A,dim)
 ### Comment-guided execution stages
 
 - Lines 22-23: Check consistency; implemented by `if nargin==1`.
-- Lines 29-30: Mimic Matlab; implemented by `if nargin==1`.
+- Lines 32-33: Refuse two outputs with a dimension query; implemented by `if (nargout==2)&&(nargin==2)`.
+- Lines 29-30: Mimic Matlab; implemented by `if nargout==2`.
 
 ### Control flow inferred from the code
 
 - Line 23: conditional branch on `nargin==1`.
+- Line 33: conditional branch on `(nargout==2)&&(nargin==2)`.
+- Line 38: conditional branch on `nargout==2`.
 - Line 30: conditional branch on `nargin==1`.
 - Line 33: conditional branch on `dim==1`.
 
 ### Key state/data transformations
 
+- Lines 39: computes `s` and `ncols` using `s=A.numRows; ncols=A.numCols`.
 - Lines 31: computes `s` using `s=[A.numRows A.numCols]`.
 
 ### Local helper functions
@@ -47,16 +51,22 @@ Returns the size of an RCV sparse matrix. Syntax: s=size(A,dim)
 
 ## Outputs
 
-- s -size vector or dimension length
+- s -size vector, dimension length, or number
+- of rows in the two-output form
+- ncols -number of columns in the two-output form
 
 ## Implementation structure
 
 - Returns the size of an RCV sparse matrix. Syntax:
 - s=size(A,dim)
+- [s,ncols]=size(A)
 - A -RCV sparse matrix
 - dim -optional dimension index
-- s -size vector or dimension length
+- s -size vector, dimension length, or number
+- of rows in the two-output form
+- ncols -number of columns in the two-output form
 - Check consistency
+- Refuse two outputs with a dimension query
 - Mimic Matlab
 - Consistency enforcement
 - I did not succeed in life by intelligence. I succeeded

--- a/kernel/overloads/@rcv/size.m
+++ b/kernel/overloads/@rcv/size.m
@@ -29,6 +29,11 @@ else
     grumble(A,dim);
 end
 
+% Refuse two outputs with a dimension query
+if (nargout==2)&&(nargin==2)
+    error('two-output form does not accept a dimension index.');
+end
+
 % Mimic Matlab
 if nargout==2
     s=A.numRows; ncols=A.numCols;

--- a/kernel/overloads/@rcv/size.m
+++ b/kernel/overloads/@rcv/size.m
@@ -1,7 +1,7 @@
 % Returns the size of an RCV sparse matrix. Syntax:
 %
 %                    s=size(A,dim)
-%                      
+%                    [s,ncols]=size(A)
 %
 % Parameters:
 %
@@ -11,13 +11,16 @@
 %
 % Outputs:
 %
-%    s     - size vector or dimension length
+%    s     - size vector, dimension length, or number
+%            of rows in the two-output form
+%
+%    ncols - number of columns in the two-output form
 %
 % m.keitel@soton.ac.uk
 %
 % <https://spindynamics.org/wiki/index.php?title=rcv/size.m>
 
-function s=size(A,dim)
+function [s,ncols]=size(A,dim)
 
 % Check consistency
 if nargin==1
@@ -27,7 +30,9 @@ else
 end
 
 % Mimic Matlab
-if nargin==1
+if nargout==2
+    s=A.numRows; ncols=A.numCols;
+elseif nargin==1
     s=[A.numRows A.numCols];
 else
     if dim==1


### PR DESCRIPTION
**Finding:** F314

**What was wrong:** `kernel/overloads/@rcv/size.m` declared a single output, so the standard MATLAB idiom `[nrows,ncols]=size(A)` on an RCV matrix crashed with "Too many output arguments".

**Why it matters:** RCV objects are meant to be usable in place of ordinary sparse matrices; generic code that queries dimensions the usual way failed outright on them.

**Fix:** the overload now declares a second output and, when two outputs are requested, returns the row and column counts separately. The one-output forms `size(A)` and `size(A,dim)` are unchanged.

**Stock probe output:**
```
PROBE_F314 FAIL: Too many output arguments.
```

**Patched probe output** (two-output form on a 2x3 RCV matrix, followed by `size(A)`, `size(A,2)`, `size(A,3)`, and `[r c]` from the two-output form):
```
PROBE_F314 PASS
   2   3
   3
     1
   2   3
```
`checkcode` on the changed file is clean.