### PR TITLE
summary_chemistry: diagonal outflow terms printed as negative self-reactions (F327)

### DIFF
--- a/interfaces/agents/spinach-knowledge/kernel/summaries/summary_chemistry.md
+++ b/interfaces/agents/spinach-knowledge/kernel/summaries/summary_chemistry.md
@@ -39,7 +39,7 @@ Prints chemical subsystem and exchange summary for a Spinach system. Syntax: sum
 
 ### Key state/data transformations
 
-- Lines 37: computes `[rows,cols,vals]` using `[rows,cols,vals]=find(spin_system.chem.rates)`.
+- Lines 37: computes `[rows,cols,vals]` using `[rows,cols,vals]=find(spin_system.chem.rates-diag(diag(spin_system.chem.rates)))`, the diagonal outflow terms are excluded from the reaction table.
 
 ### Local helper functions
 

--- a/kernel/summaries/summary_chemistry.m
+++ b/kernel/summaries/summary_chemistry.m
@@ -34,7 +34,7 @@ if numel(spin_system.chem.parts)>1
         report(spin_system,'===============================');
         report(spin_system,' N(from)   N(to)    Rate(Hz)   ');
         report(spin_system,'-------------------------------');
-        [rows,cols,vals]=find(spin_system.chem.rates);
+        [rows,cols,vals]=find(spin_system.chem.rates-diag(diag(spin_system.chem.rates)));
         for n=1:length(vals)
             report(spin_system,[' ' strjust([num2str(rows(n)) blanks(3-length(num2str(rows(n))))],'left') '       '...
                                     strjust([num2str(cols(n)) blanks(3-length(num2str(cols(n))))],'left') '      '...


### PR DESCRIPTION
## What was wrong

`kernel/summaries/summary_chemistry.m` builds the inter-subsystem reaction table from `find(spin_system.chem.rates)`. Conservation of matter (enforced in `create.m`, column sums must vanish) means every diagonal entry of the rate matrix is minus the total outflow of that subsystem, so `find` returns those negative diagonal terms too, and the loop prints each one as a reaction from a subsystem to itself with a negative rate.

## Why it matters

Every multi-subsystem kinetics calculation has a populated diagonal, so every printed reaction table carries one spurious negative "self-reaction" row per subsystem. These are not reactions; they are bookkeeping, and they mislead a user checking the parsed exchange scheme.

## Fix

Subtract the diagonal before calling `find`. One line changed, no change to any numerical result.

## Stock probe output

System: two subsystems, `rates=[-5e2 2e3; 5e2 -2e3]`, `concs=[2e3 5e2]`.

```
ROW from=1 to=1 rate=-5.000e+02
ROW from=2 to=1 rate=+5.000e+02
ROW from=1 to=2 rate=+2.000e+03
ROW from=2 to=2 rate=-2.000e+03
F327 FAIL: diagonal self-reaction rows printed
```

## Patched probe output

```
ROW from=2 to=1 rate=+5.000e+02
ROW from=1 to=2 rate=+2.000e+03
F327 PASS: no diagonal rows
```

The direction of the remaining rows is a separate finding (F326, #509) and is left alone here.

`checkcode` on the changed file: clean.

Finding id: F327