### PR TITLE
fix(examples): draw reacting_flow animation into its own figure (F257)

### DIFF
--- a/examples/microfluidics/reacting_flow.m
+++ b/examples/microfluidics/reacting_flow.m
@@ -74,7 +74,7 @@ for n=1:npoints
 end
 
 % Make a figure
-kfigure(); scale_figure([2.5 2.5]);
+fig=kfigure(); scale_figure([2.5 2.5]);
 subplot(2,2,1); camproj('perspective'); view(-20,15); axis vis3d;
 subplot(2,2,2); camproj('perspective'); view(-20,15); axis vis3d;
 subplot(2,2,3); camproj('perspective'); view(-20,15); axis vis3d;
@@ -84,9 +84,8 @@ subplot(2,2,4); camproj('perspective'); view(-20,15); axis vis3d;
 for n=1:size(traj,3)
 
     % First reactant
-    subplot(2,2,1); 
+    set(groot,'CurrentFigure',fig); subplot(2,2,1); cla;
     spin_system.mesh.zext=[-0.005 0.01];
-    set(groot,'CurrentFigure',1); cla;
     conc=squeeze(full(real(traj(1,:,n))));
     mesh_plot(spin_system,0,0);
     conc_plot(spin_system,conc');
@@ -96,9 +95,8 @@ for n=1:size(traj,3)
     camorbit(0.5,0.02); ktitle('cyclopentadiene');
 
     % Second reactant
-    subplot(2,2,2); 
+    set(groot,'CurrentFigure',fig); subplot(2,2,2); cla;
     spin_system.mesh.zext=[-0.005 0.01];
-    set(groot,'CurrentFigure',1); cla;
     conc=squeeze(full(real(traj(2,:,n))));
     mesh_plot(spin_system,0,0);
     conc_plot(spin_system,conc');
@@ -108,9 +106,8 @@ for n=1:size(traj,3)
     camorbit(0.5,0.02); ktitle('acrylonitrile');
 
     % First product
-    subplot(2,2,3); 
+    set(groot,'CurrentFigure',fig); subplot(2,2,3); cla;
     spin_system.mesh.zext=[-0.005 0.01]/8;
-    set(groot,'CurrentFigure',1); cla;
     conc=squeeze(full(real(traj(3,:,n))));
     mesh_plot(spin_system,0,0);
     conc_plot(spin_system,conc');
@@ -120,9 +117,8 @@ for n=1:size(traj,3)
     camorbit(0.5,0.02); ktitle('exo-NBCN');
 
     % Second product
-    subplot(2,2,4); 
+    set(groot,'CurrentFigure',fig); subplot(2,2,4); cla;
     spin_system.mesh.zext=[-0.005 0.01]/8;
-    set(groot,'CurrentFigure',1); cla;
     conc=squeeze(full(real(traj(4,:,n))));
     mesh_plot(spin_system,0,0);
     conc_plot(spin_system,conc');


### PR DESCRIPTION
## What was wrong
`examples/microfluidics/reacting_flow.m` creates its four-panel figure with `kfigure()`, which takes whatever handle number is next available, but each of the four per-frame subplot updates ran `set(groot,'CurrentFigure',1); cla`, hard-coding figure 1. `subplot(2,2,k)` was also called before the current figure was set, so from the second panel onwards it acted on figure 1 too.

## Why it matters
With any pre-existing figure window open, the concentration animation clears and overwrites the user's figure 1 rather than the figure it just built, and the newly created figure stays empty.

## Fix
Keep the handle returned by `kfigure()`, make it current before each `subplot` call, and drop the hard-coded figure 1 lines. File is four lines shorter.

## Stock probe output
Probe: decoy figure 1 opened first, then `reacting_flow()` run, then patches per figure counted.
```
figure 1: 24 patches, 4 axes
figure 2: 0 patches, 4 axes
PROBE_F257 FAIL
```

## Patched probe output
```
figure 2: 24 patches, 4 axes
figure 1: 0 patches, 1 axes
PROBE_F257 PASS
```

## Finding id
F257