### PR TITLE
zte: validate the nstates argument before indexing (F329)

### DIFF
--- a/kernel/utilities/zte.m
+++ b/kernel/utilities/zte.m
@@ -45,6 +45,12 @@ function projector=zte(spin_system,L,rho,nstates)
 % Validate the input
 grumble(spin_system,L,rho);
 
+% Validate the number of states if it is specified
+if exist('nstates','var')&&((~isnumeric(nstates))||(~isreal(nstates))||(~isscalar(nstates))||...
+                            (nstates<1)||(mod(nstates,1)~=0)||(nstates>numel(rho)))
+    error('nstates must be a positive integer not exceeding the state space dimension.');
+end
+
 % Run Zero Track Elimination
 if ismember('zte',spin_system.sys.disable)
     


### PR DESCRIPTION
## What was wrong

`kernel/utilities/zte.m` documents an optional `nstates` argument but never validated it: a value beyond the state space dimension, a non-integer, or an empty value reached `index(1:nstates)` and failed with a raw MATLAB indexing error, or silently did nothing on the early-return paths.

## Fix

One six-line block right after the existing `grumble` call: if `nstates` is present, it must be a real positive integer scalar not exceeding the state space dimension. It runs before any early return and rejects empty values. Nothing else changes: the function signature, the callers in `reduce.m`, the test, and the knowledge pages are as on main. (The branch was reset to main and redone this way at the maintainer's instruction; the earlier commits with the signature change are gone.)

## Validation (stock vs patched, two-spin sphten-liouv system, dimension 16)

- Three-argument call: projectors identical.
- `nstates=4` and `nstates=16`: projectors identical.
- Eleven invalid values (17, 0, -2, 1.5, `[]`, `{}`, `'3'`, `[2 3]`, `1i`, NaN, Inf): stock gives no error for five of them and assorted MATLAB indexing errors for the rest; patched gives `nstates must be a positive integer not exceeding the state space dimension.` for all eleven.
- With `zte` disabled and an out-of-range `nstates`: stock returns silently, patched raises the same message.
- `check_house_style.py` and `checkcode` clean.

Finding id: F329