### PR TITLE
fix(singlets): reject non-finite J in s2m grumble (F284)

### DIFF
--- a/experiments/singlets/s2m.m
+++ b/experiments/singlets/s2m.m
@@ -66,8 +66,8 @@ end
 if size(rho,1)~=size(L,2)
     error('dimensions of rho and L must be consistent.');
 end
-if (~isnumeric(J))||(~isreal(J))||(~isscalar(J))
-    error('J must be a real scalar.');
+if (~isnumeric(J))||(~isreal(J))||(~isscalar(J))||(~isfinite(J))
+    error('J must be a finite real scalar.');
 end
 if (~isnumeric(delta_v))||(~isreal(delta_v))||(~isscalar(delta_v))||...
    (~isfinite(delta_v))||(delta_v==0)


### PR DESCRIPTION
## What was wrong
`experiments/singlets/s2m.m` validated the J-coupling with `isnumeric`, `isreal`, and `isscalar` only, so NaN and Inf passed. `delta_v` was already checked with `isfinite`, J was not.

## Why it matters physically
The evolution delay `t=1/(4*sqrt(J^2+delta_v^2))` and the repetition count `m1=floor(pi*J/(2*delta_v))` are both computed from J. A NaN coupling (e.g. from a failed upstream fit or lookup) produces a NaN delay that only fails deep inside `step()` with an unrelated message; an Inf coupling makes the pulse-sequence loop run for 2^63 iterations. The user should get a clear input error instead.

## Fix
Add `(~isfinite(J))` to the grumble condition and say 'finite' in the message. No numerical result changes for valid input.

## Stock probe output
```
J=NaN: state descriptor is not finite.
PROBE_F284 FAIL for J=NaN
```
First attempt with J=Inf on stock had to be killed after MATLAB reported:
```
[Warning: Too many FOR loop iterations. Changing the maximum number ofiterations to 9223372036854775806 instead.] [> In s2m (line 41)In probe_f284 (line 11)
```

## Patched probe output
```
J=NaN: J must be a finite real scalar.
PROBE_F284 PASS for J=NaN
J=Inf: J must be a finite real scalar.
```

## Finding id
F284