### PR TITLE
F360: label the Mims ENDOR axis in endor_phenyl.m as nuclear frequency

### DIFF
--- a/examples/esr_liq_pulsed/endor_phenyl.m
+++ b/examples/esr_liq_pulsed/endor_phenyl.m
@@ -64,6 +64,7 @@ spectrum=fftshift(fft(fid,parameters.zerofill));
 
 % Plotting
 kfigure(); plot_1d(spin_system,abs(spectrum),parameters);
+kxlabel('Nuclear frequency, MHz');
 
 end
 


### PR DESCRIPTION
Finding F360.

**What was wrong.** `endor_phenyl.m` runs `endor_mims`, whose indirect dimension evolves nuclear coherence (`coherence(...,{{'nuclei',[-1 1]}})` followed by the swept `evolution` block), so the Fourier transformed axis is the nuclear ENDOR frequency. `plot_1d` labels the axis from `parameters.spins{1}='E'` as `E offset frequency / MHz`, which names the wrong physical quantity.

**Why it matters physically.** The plotted numbers are correct, but a reader of the figure is told they are electron offsets. With the electron offset fixed at zero in the example, the peaks are the nuclear ENDOR lines at the proton Larmor frequency plus or minus half the hyperfine coupling, as the probe shows. The label sends the reader to the wrong spin and the wrong frame.

**Fix.** One line after `plot_1d`: `kxlabel('Nuclear frequency, MHz')`, the same override already used by `examples/esr_sol_pulsed/endor_mims_nox_powder.m`. No numerical change.

**Stock probe output** (`reports/probes_18/probe_endor_axis.m`):
```
Example: endor_phenyl
X-axis label: E offset frequency / MHz
Spectral peaks, MHz: 0.51 11.35 16.70 27.98
1H Larmor frequency, MHz: 14.05
15N Larmor frequency, MHz: 1.42
FAIL: axis labelled as an electron offset frequency axis
```

**Patched probe output:**
```
Example: endor_phenyl
X-axis label: Nuclear frequency, MHz
Spectral peaks, MHz: 0.51 11.35 16.70 27.98
1H Larmor frequency, MHz: 14.05
15N Larmor frequency, MHz: 1.42
PASS: axis label does not claim an electron offset frequency
```

`checkcode` on the changed file is clean.