### PR TITLE
plain_diff: animate into the figure kfigure() created (F255)

### DIFF
--- a/examples/microfluidics/plain_diff.m
+++ b/examples/microfluidics/plain_diff.m
@@ -86,7 +86,7 @@ coil=state(spin_system,'Lz','1H');
 traj=fpl2phan(traj(:),coil,[2659 parameters.npoints]);
 
 % Make a figure
-kfigure(); scale_figure([1.5 1.5]); 
+fig=kfigure(); scale_figure([1.5 1.5]); 
 camproj('perspective'); view(-20,15); axis vis3d;
 
 % Set Z axis extents
@@ -96,7 +96,7 @@ spin_system.mesh.zext=[-0.02 0.02];
 for n=1:size(traj,2)
 
     % Do not steal focus
-    set(groot,'CurrentFigure',1); cla;
+    set(groot,'CurrentFigure',fig); cla;
 
     % Get the concentrations
     conc=full(real(traj(:,n)));


### PR DESCRIPTION
**Finding:** F255

**What was wrong:** `plain_diff` discarded the handle returned by `kfigure()` and then ran `set(groot,'CurrentFigure',1); cla` in the animation loop. `kfigure` just calls `figure` and returns whatever number MATLAB assigns, so with any figure already open the animation cleared and drew into that unrelated window while the figure it had just set up stayed empty.

**Why it matters:** an ordinary session state (a previous plot open) silently sends the example's output to the wrong window.

**Fix:** keep the handle (`fig=kfigure();`) and use it in the loop. Two tokens changed, no numerical result affected.

**Probe:** `probe_f255.m` opens a decoy figure 1 with an axes, runs the example headless, and counts mesh patches per figure.

Stock output:
```
figure 1: 6 patches, 1 axes
figure 2: 0 patches, 1 axes
PROBE_F255 FAIL
```

Patched output:
```
figure 2: 6 patches, 1 axes
figure 1: 0 patches, 1 axes
PROBE_F255 PASS
```

`checkcode` on the changed file is empty; house-style checker reports 0 violations.