### PR TITLE
endor_benzoquinone: ENDOR axis labelled as an electron offset axis (F357)

### DIFF
--- a/examples/esr_liq_pulsed/endor_benzoquinone.m
+++ b/examples/esr_liq_pulsed/endor_benzoquinone.m
@@ -33,7 +33,7 @@ parameters.offset=0;
 parameters.sweep=50e6;
 parameters.npoints=1024;
 parameters.zerofill=4096;
-parameters.spins={'E'};
+parameters.spins={'1H'};
 parameters.axis_units='MHz';
 parameters.derivative=1;
 


### PR DESCRIPTION
## What was wrong

`examples/esr_liq_pulsed/endor_benzoquinone.m` sets `parameters.spins={'E'}` and then calls `plot_1d`, whose `axis_1d` builds the label from `parameters.spins{1}`. The sequence `endor_cw` pulses the nuclei and acquires on the nuclear `L+` coil, so the Fourier transformed axis is the proton offset axis in the rotating frame, not an electron offset axis. The figure was labelled `E offset frequency / MHz`.

## Why it matters

The axis values were correct, but the label placed the ±25 MHz hyperfine-scale ENDOR lines in the electron domain. A reader identifying the physical quantity on the x-axis from the figure alone was misdirected.

## Fix

`parameters.spins={'1H'}`. One token changed. `liquid.m` uses `parameters.spins` only to apply `parameters.offset`, which is zero here, so the simulated spectrum is unchanged; the probe checksum below confirms it.

## Stock probe output

```
F357 x-axis label: E offset frequency / MHz
F357 x-axis range: -25      24.9878
F357 spectrum checksum: 1.0843751040e+03
```

## Patched probe output

```
F357 x-axis label: $^{1}$H offset frequency / MHz
F357 x-axis range: -25      24.9878
F357 spectrum checksum: 1.0843751040e+03
```

`checkcode` on the changed file: clean.

Finding id: F357