### PR TITLE
fix(gaussian): gslice overwrites its output files instead of appending (F289)

### DIFF
--- a/interfaces/gaussian/gslice.m
+++ b/interfaces/gaussian/gslice.m
@@ -69,12 +69,12 @@ end
 header=textread([g03_header_path g03_header],'%s','delimiter','\n'); %#ok<DTXTRD>
 
 % Write the inputs
-runscript=fopen('compute.bat','a');
+runscript=fopen('compute.bat','w');
 fprintf(runscript,'%s\n','@ECHO OFF');
 fprintf(runscript,'%s\n','set GAUSS_EXEDIR=C:\G16W');
 fprintf(runscript,'%s\n','set GAUSS_SCRDIR=C:\Temp');
 for n=1:length(coord_blocks)
-    g03_input=fopen(['g16_input_' num2str(n) '.gjf'],'a');
+    g03_input=fopen(['g16_input_' num2str(n) '.gjf'],'w');
     dump(g03_input,header);
     for k=1:size(coord_blocks{n},1)
         current_line=[periodic_table{coord_blocks{n}(k,2)} '       ' num2str(coord_blocks{n}(k,4:6),'%1.8f  ')];


### PR DESCRIPTION
## What was wrong
`interfaces/gaussian/gslice.m` opened `compute.bat` and every `g16_input_N.gjf` with `fopen(...,'a')`, appending unconditionally, and nothing checked for pre-existing files.

## Why it matters
Re-running `gslice()` in a directory that already holds its outputs (a normal workflow after adjusting the header file) silently appends a second complete job, with no Link1 separator, to each existing .gjf file, and a second @ECHO OFF block to the batch file. Gaussian would be handed an invalid input while the user expects a fresh calculation.

## Fix
Open both files with `'w'`. Two characters changed, no other behaviour affected.

## Stock probe output
Probe: uigetfile stubbed to return a shipped scan log and a small header, `gslice()` run twice in a fresh scratch directory, line counts compared.
```
g16_input_1.gjf lines after run 1: 22, after run 2: 43
compute.bat lines after run 1: 5, after run 2: 9
PROBE_F289 FAIL
```

## Patched probe output
```
g16_input_1.gjf lines after run 1: 22, after run 2: 22
compute.bat lines after run 1: 5, after run 2: 5
PROBE_F289 PASS
```

## Finding id
F289