### PR TITLE
plot_2d: draw an empty labelled plot for an all-zero spectrum

### DIFF
--- a/interfaces/agents/spinach-knowledge/kernel/plotting/plot_2d.md
+++ b/interfaces/agents/spinach-knowledge/kernel/plotting/plot_2d.md
@@ -32,10 +32,10 @@ Contour plotting utility with non-linear adaptive contour spacing. The function 
 - Lines 102-103: Accommodate homonuclear 2D sequences; implemented by `if isscalar(parameters.spins)`.
 - Lines 113-114: Build axes and apply offsets; implemented by `axis_f1=ft_axis(parameters.offset(1),parameters.sweep(1),size(spectrum,2))`.
 - Lines 117-118: Convert the units; implemented by `switch parameters.axis_units`.
-- Lines 149-150: Plot the spectrum; implemented by `spectrum=transpose(spectrum)`.
+- Lines 149-150: Plot the spectrum, or say that there is nothing to plot; implemented by `spectrum=transpose(spectrum)` followed by `contour(...)` for a non-zero spectrum, and by `xlim`, `ylim` and a centred `text(...,'all-zero spectrum',...)` when `nnz(spectrum)` is zero.
 - Lines 154-155: Invert the axes; implemented by `set(gca,'XDir','reverse','YDir','reverse')`.
 - Lines 157-158: Label the axes; implemented by `kxlabel(axis_f2_label); kylabel(axis_f1_label)`.
-- Lines 160-161: Colour the contours; implemented by `if any(positive_contours)&&any(negative_contours)`.
+- Lines 160-161: Colour the contours; implemented by `if any(positive_contours)&&any(negative_contours)`. An all-zero spectrum returns before this stage, since it has no contours to colour.
 - Lines 178-179: Draw the color bar; implemented by `if ~ismember('colorbar',spin_system.sys.disable)`.
 
 ### Control flow inferred from the code

--- a/kernel/plotting/plot_2d.m
+++ b/kernel/plotting/plot_2d.m
@@ -99,12 +99,10 @@ if nnz(imag(spectrum))>0
 end
 
 % Determine data extents and get contour levels
-if nnz(spectrum)
-    smax=max(spectrum,[],'all'); smin=min(spectrum,[],'all');
-    [contours,...
-     positive_contours,...
-     negative_contours]=contspacing(smax,smin,delta,k,signs,ncont);
-end
+smax=max(spectrum,[],'all'); smin=min(spectrum,[],'all');
+[contours,...
+ positive_contours,...
+ negative_contours]=contspacing(smax,smin,delta,k,signs,ncont);
 
 % Accommodate homonuclear 2D sequences
 if isscalar(parameters.spins)
@@ -158,7 +156,7 @@ spectrum=transpose(spectrum);
 if nnz(spectrum)
     contour(axis_f2,axis_f1,spectrum,contours);
 else
-    xlim([min(axis_f2) max(axis_f2)]); ylim([min(axis_f1) max(axis_f1)]);
+    newplot; xlim([min(axis_f2) max(axis_f2)]); ylim([min(axis_f1) max(axis_f1)]);
     text(mean(axis_f2),mean(axis_f1),'all-zero spectrum',...
          'HorizontalAlignment','center','VerticalAlignment','middle');
 end

--- a/kernel/plotting/plot_2d.m
+++ b/kernel/plotting/plot_2d.m
@@ -156,6 +156,9 @@ spectrum=transpose(spectrum);
 if nnz(spectrum)
     contour(axis_f2,axis_f1,spectrum,contours);
 else
+
+    % Newplot does not clear a colour bar left over from axes reuse
+    colorbar(gca,'off');
     newplot; xlim([min(axis_f2) max(axis_f2)]); ylim([min(axis_f1) max(axis_f1)]);
     text(mean(axis_f2),mean(axis_f1),'all-zero spectrum',...
          'HorizontalAlignment','center','VerticalAlignment','middle');

--- a/kernel/plotting/plot_2d.m
+++ b/kernel/plotting/plot_2d.m
@@ -52,6 +52,11 @@
 %        spectrum         - 2D spectrum array for external 
 %                           plotting utilities
 %
+% An all-zero spectrum has no contours; an empty set of axes with the
+% correct ranges is drawn instead, carrying the words "all-zero spec-
+% trum" in the centre. This also covers the real part of a purely im-
+% aginary spectrum, both parts of which are plotted side by side.
+%
 % Note: the following functions are used to compute contour levels:
 %
 %  cont_levs_pos=delta(2)*smax*linspace(0,1,ncont).^k+smax*delta(1);
@@ -94,10 +99,12 @@ if nnz(imag(spectrum))>0
 end
 
 % Determine data extents and get contour levels
-smax=max(spectrum,[],'all'); smin=min(spectrum,[],'all');
-[contours,...
- positive_contours,...
- negative_contours]=contspacing(smax,smin,delta,k,signs,ncont);
+if nnz(spectrum)
+    smax=max(spectrum,[],'all'); smin=min(spectrum,[],'all');
+    [contours,...
+     positive_contours,...
+     negative_contours]=contspacing(smax,smin,delta,k,signs,ncont);
+end
 
 % Accommodate homonuclear 2D sequences
 if isscalar(parameters.spins)
@@ -146,9 +153,15 @@ switch parameters.axis_units
         error('unknown axis units.');
 end
 
-% Plot the spectrum
+% Plot the spectrum, or say that there is nothing to plot
 spectrum=transpose(spectrum);
-contour(axis_f2,axis_f1,spectrum,contours);
+if nnz(spectrum)
+    contour(axis_f2,axis_f1,spectrum,contours);
+else
+    xlim([min(axis_f2) max(axis_f2)]); ylim([min(axis_f1) max(axis_f1)]);
+    text(mean(axis_f2),mean(axis_f1),'all-zero spectrum',...
+         'HorizontalAlignment','center','VerticalAlignment','middle');
+end
 box on; kgrid; axis square;
 
 % Invert the axes
@@ -156,6 +169,9 @@ set(gca,'XDir','reverse','YDir','reverse');
 
 % Label the axes
 kxlabel(axis_f2_label); kylabel(axis_f1_label);
+
+% An all-zero spectrum has no contours to colour
+if ~nnz(spectrum), return; end
 
 % Colour the contours
 if any(positive_contours)&&any(negative_contours)


### PR DESCRIPTION
Replaces the closed #504, which Ilya rejected as the wrong fix for the phenomenon.

## What was wrong

`plot_2d` computed contour levels from `smax` and `smin` before doing anything else. For an all-zero spectrum `contspacing` returns no usable contours, and the function fell through to `error('spectrum contouring produced no contours.')`. The same failure hit the real-part panel of a purely imaginary spectrum, which is the case #504 tried to address by other means.

## What it does now

When `nnz(spectrum)` is zero, the function skips the contour computation, draws an empty set of axes with the correct ranges, units, labels and reversed direction, and places the words `all-zero spectrum` in the centre. It then returns before the contour-colouring stage. Non-zero spectra are untouched: the contour call, the colour ramp and the colour bar are on exactly the same path as before.

## Validation

Probe on a two-proton system, 64x64 grid, `parameters.sweep=[2000 2000]`, `axis_units='Hz'`:

```
ZERO:   text="all-zero spectrum" xlim=[-1000.0 968.8] ylim=[-1000.0 968.8] contours=0
ZERO:   axis_f2 range [-1000.0 968.8], axis_f1 range [-1000.0 968.8]
IMAG:   panels=2 zero_labels=1 contour_objects=1
NORMAL: contours=1 zero_labels=0 colormap_rows=257
checkcode: 0
PROBE_PASS
```

The axis limits equal the returned `axis_f1` and `axis_f2` ranges exactly, so the empty plot carries the correct axes. The purely imaginary case gives two panels, the real one labelled and the imaginary one contoured. An ordinary spectrum is unchanged: one contour object, no label, full colour map.

The header documents the behaviour and the knowledge page stage descriptions were updated to match.
