### PR TITLE
gparse: rotate Pickett-block NQI and spin-rotation tensors into the standard orientation

### DIFF
--- a/interfaces/gaussian/gparse.m
+++ b/interfaces/gaussian/gparse.m
@@ -62,6 +62,13 @@
 %        tensors returned are the ones that enter the spin
 %        Hamiltonian as S*A*I, in agreement with oparse.m
 %
+%        Gaussian prints the spin-rotation and quadrupole ten-
+%        sors of the output=pickett block in the principal axis
+%        frame of the inertia tensor, not in the standard orien-
+%        tation used for everything else. They are rotated here
+%        into the standard orientation using the rotation matrix
+%        that Gaussian prints before them.
+%
 % gareth.charnock@oerc.ox.ac.uk
 % jennifer.handsel@stx.ox.ac.uk
 % janm@umbc.edu
@@ -297,7 +304,17 @@ for n=1:length(g03_output)
        disp('Gaussian import: found isotropic J-couplings.');
    end
    
-   % Read spin-rotation couplings
+   % Read the rotation matrix from the standard orientation into the inertial frame
+   if strcmp(g03_output(n),'Rotation matrix to Principal Axis frame:')
+       abc_rot=zeros(3);
+       for k=1:3
+           row=sscanf(strrep(char(g03_output(n+k+1)),'D','E'),'%f');
+           abc_rot(k,:)=row(2:4);
+       end
+       disp('Gaussian import: found the rotation matrix into the inertial frame.');
+   end
+
+   % Read spin-rotation couplings and rotate them into the standard orientation
    if strcmp(g03_output(n),'nuclear spin - molecular rotation tensor [C] (MHz):')
        props.srt=cell(natoms,1);
        for k=1:natoms
@@ -307,22 +324,24 @@ for n=1:length(g03_output)
            props.srt{atom_num}=[eval(['[' line1(4:14) '     ' line1(21:31) '     ' line1(38:48) ']']);
                                 eval(['[' line2(4:14) '     ' line2(21:31) '     ' line2(38:48) ']']);
                                 eval(['[' line3(4:14) '     ' line3(21:31) '     ' line3(38:48) ']'])]*1e6;
+           props.srt{atom_num}=abc_rot*props.srt{atom_num}*abc_rot';
            if strcmp(g03_output(n+4*k+1),'Dipole moment (Debye):'), break; end
            if strcmp(g03_output(n+4*k+1),'Nuclear quadrupole coupling constants [Chi] (MHz):'), break; end
        end
        disp('Gaussian import: found nuclear spin-rotation tensors.');
    end
    
-   % Read quadrupole couplings and kill their trace
+   % Read quadrupole couplings, rotate them into the standard orientation, and kill their trace
    if strcmp(g03_output(n),'Nuclear quadrupole coupling constants [Chi] (MHz):')
        props.nqi=cell(natoms,1);
        for k=1:natoms
-           line3=char(g03_output(n+4*k));   line2=char(g03_output(n+4*k-1)); 
+           line3=char(g03_output(n+4*k));   line2=char(g03_output(n+4*k-1));
            line1=char(g03_output(n+4*k-2)); line0=char(g03_output(n+4*k-3));
            atom_num=regexp(line0,'^[0-9]*','match'); atom_num=eval(atom_num{1});
            props.nqi{atom_num}=[eval(['[' line1(4:14) '     ' line1(21:31) '     ' line1(38:48) ']']);
                                 eval(['[' line2(4:14) '     ' line2(21:31) '     ' line2(38:48) ']']);
                                 eval(['[' line3(4:14) '     ' line3(21:31) '     ' line3(38:48) ']'])]*1e6;
+           props.nqi{atom_num}=abc_rot*props.nqi{atom_num}*abc_rot';
            props.nqi{atom_num}=props.nqi{atom_num}-eye(3)*trace(props.nqi{atom_num})/3;
            if strcmp(g03_output(n+4*k+1),'Dipole moment (Debye):'), break; end
        end


### PR DESCRIPTION
## What was wrong

`gparse.m` reads the nuclear quadrupole `[Chi]` and spin-rotation `[C]` tensors from the `Output=Pickett` block and returned them as printed. Gaussian writes that block as input for Pickett's SPFIT, i.e. in the principal axis frame of the inertia tensor (a, b, c), and prints the `Rotation matrix to Principal Axis frame` R and the abc coordinates immediately before it. Every other quantity gparse returns (`std_geom`, shielding, hyperfine, g-tensor, J) is in the standard orientation, and `g2spinach` places `props.nqi` beside `std_geom` coordinates. The NQI tensor therefore sat in the wrong frame relative to the dipolar geometry and the CSA. This is the frame mismatch that PR #401 corrects by hand for one example.

Measured on fresh Gaussian 16 C.01 runs with `Prop=EFG Output=Pickett`: `Chi_abc = (eQ/h) R' V_std R`, where `V_std` is the Cartesian EFG from the `Prop=EFG` block. Formamide (R is a 21° in-plane rotation): residual 1.4e-4 with that map, 1.2e-2 unrotated. Pyridine (C2v, R is an x/z axis permutation): residual 5e-6 rotated, 0.57 unrotated. For symmetric molecules the mismatch is a whole axis swap, not a small angle.

## Fix

Parse the 3x3 R block (Fortran `D` exponents mapped to `E`) and apply `R*T*R'` to `props.nqi` and `props.srt` as they are read. The header now documents the frame. 22 lines added, 3 changed.

## Validation (stock vs patched, MATLAB probe)

- Shipped `ir_active_efg.out`: patched `props.nqi{32}` and `{33}` reproduce the hand-rotated numbers of PR #401 to 0.04 kHz (their rounding), stock reproduces the old unrotated numbers.
- Formamide and pyridine logs: patched tensors match the standard-orientation EFG block to 1.4e-4 and 4.7e-6 relative with scale -4.8027 MHz/a.u. = eQ(14N)/h; stock fails at 1.2e-2 and 0.57.
- Formamide NMR log: `[C]` is parsed and rotated; Frobenius norm and symmetric-part eigenvalues unchanged to the precision of the printed R.
- All 34 `examples/standard_systems` logs: every field other than `nqi` and `srt` is identical between stock and patched (33 parse, 1 errors identically in both).
- `check_house_style.py` and `checkcode` clean (one pre-existing three-line comment in the file, untouched).

No shipped example imports NQI through gparse, so no example output changes.
