### PR TITLE
g2spinach: absorb spin-rotation tensors from props.srt

### DIFF
--- a/interfaces/g2spinach.m
+++ b/interfaces/g2spinach.m
@@ -203,10 +203,10 @@ switch ismember('E',[particles{:}])
         end
         
         % Absorb spin-rotation couplings
-        if isfield(props,'src')
-            inter.spinrot.matrix=cell(nspins);
+        if isfield(props,'srt')
+            inter.spinrot.matrix=cell(1,nspins);
             for n=1:nspins
-                inter.spinrot.matrix{n}=props.src{index(n)};
+                inter.spinrot.matrix{n}=props.srt{index(n)};
             end
         end
         


### PR DESCRIPTION
## What was wrong

`gparse.m` documents and returns the spin-rotation tensors in `props.srt` (line 36 and the `[C]` block reader), but `g2spinach.m` tested `isfield(props,'src')` and read `props.src`, so the block was silently never absorbed into `inter.spinrot.matrix`. The cell was also allocated as `cell(nspins)` (nspins x nspins) where `x2spinach.m` uses `cell(1,nspins)` for the same field.

## Fix

Three lines: `src` becomes `srt` in the test and the read, and the cell becomes `1 x nspins`.

## Validation

MATLAB: `gparse` on a Gaussian 16 formamide `nmr output=pickett` log, then `g2spinach(props,{{'N','14N'},{'H','1H'}},[0 0])`: `inter.spinrot.matrix` is now a 1 x 4 cell holding the 14N tensor (3800, -2800, 0; -300, 800, 0; 0, 0, 400 Hz) and the three 1H tensors; previously the field was absent. `check_house_style.py` and `checkcode` unchanged for the touched lines.

Found during the comparison of gparse with third-party Gaussian parsers; complements #524 and #525.
