### PR TITLE
gparse: token-based parsing, coordinate-fitted Pickett frame, isotope table, job boundaries, self-checks

### DIFF
--- a/interfaces/gaussian/gparse.m
+++ b/interfaces/gaussian/gparse.m
@@ -66,8 +66,12 @@
 %        sors of the output=pickett block in the principal axis
 %        frame of the inertia tensor, not in the standard orien-
 %        tation used for everything else. They are rotated here
-%        into the standard orientation using the rotation matrix
-%        that Gaussian prints before them.
+%        into the standard orientation using a rotation fitted
+%        between the principal axis coordinates that Gaussian
+%        prints before them and the current orientation. The
+%        rotation matrix Gaussian prints is not used because it
+%        is an identity matrix in some logs where the principal
+%        axis coordinates are visibly permuted.
 %
 % gareth.charnock@oerc.ox.ac.uk
 % jennifer.handsel@stx.ox.ac.uk
@@ -304,14 +308,19 @@ for n=1:length(g03_output)
        disp('Gaussian import: found isotropic J-couplings.');
    end
    
-   % Read the rotation matrix from the standard orientation into the inertial frame
-   if strcmp(g03_output(n),'Rotation matrix to Principal Axis frame:')
-       abc_rot=zeros(3);
-       for k=1:3
-           row=sscanf(strrep(char(g03_output(n+k+1)),'D','E'),'%f');
-           abc_rot(k,:)=row(2:4);
+   % Fit the rotation from the inertial frame into the current orientation using the printed coordinates
+   if strcmp(g03_output(n),'Principal axis orientation:')
+       k=n+5; abc_geom=zeros(0,3);
+       while ~strcmp(deblank(g03_output(k)),'---------------------------------------------------------------------')
+           S=sscanf(char(g03_output(k)),'%f'); abc_geom(end+1,:)=S((end-2):end)'; k=k+1; %#ok<AGROW>
        end
-       disp('Gaussian import: found the rotation matrix into the inertial frame.');
+       cur_geom=atoms; if size(abc_geom,1)~=size(atoms,1), cur_geom=atoms(atomic_numbers>0,:); end
+       cur_geom=cur_geom-mean(cur_geom,1); abc_geom=abc_geom-mean(abc_geom,1);
+       [U,~,V]=svd(abc_geom'*cur_geom); abc_rot=V*diag([1 1 det(V*U')])*U';
+       if norm(cur_geom-abc_geom*abc_rot','fro')>(1e-3*norm(cur_geom,'fro')+1e-3)
+           error('Gaussian import: inertial frame coordinates do not match the molecule.');
+       end
+       disp('Gaussian import: found the inertial frame orientation.');
    end
 
    % Read spin-rotation couplings and rotate them into the standard orientation

--- a/interfaces/gaussian/gparse.m
+++ b/interfaces/gaussian/gparse.m
@@ -62,6 +62,13 @@
 %        tensors returned are the ones that enter the spin
 %        Hamiltonian as S*A*I, in agreement with oparse.m
 %
+%        Gaussian prints the spin-rotation and quadrupole ten-
+%        sors of the output=pickett block in the principal axis
+%        frame of the inertia tensor, not in the standard orien-
+%        tation used for everything else. They are rotated here
+%        into the standard orientation using the rotation matrix
+%        that Gaussian prints before them.
+%
 % gareth.charnock@oerc.ox.ac.uk
 % jennifer.handsel@stx.ox.ac.uk
 % janm@umbc.edu
@@ -297,7 +304,17 @@ for n=1:length(g03_output)
        disp('Gaussian import: found isotropic J-couplings.');
    end
    
-   % Read spin-rotation couplings
+   % Read the rotation matrix from the standard orientation into the inertial frame
+   if strcmp(g03_output(n),'Rotation matrix to Principal Axis frame:')
+       abc_rot=zeros(3);
+       for k=1:3
+           row=sscanf(strrep(char(g03_output(n+k+1)),'D','E'),'%f');
+           abc_rot(k,:)=row(2:4);
+       end
+       disp('Gaussian import: found the rotation matrix into the inertial frame.');
+   end
+
+   % Read spin-rotation couplings and rotate them into the standard orientation
    if strcmp(g03_output(n),'nuclear spin - molecular rotation tensor [C] (MHz):')
        props.srt=cell(natoms,1);
        for k=1:natoms
@@ -307,22 +324,24 @@ for n=1:length(g03_output)
            props.srt{atom_num}=[eval(['[' line1(4:14) '     ' line1(21:31) '     ' line1(38:48) ']']);
                                 eval(['[' line2(4:14) '     ' line2(21:31) '     ' line2(38:48) ']']);
                                 eval(['[' line3(4:14) '     ' line3(21:31) '     ' line3(38:48) ']'])]*1e6;
+           props.srt{atom_num}=abc_rot*props.srt{atom_num}*abc_rot';
            if strcmp(g03_output(n+4*k+1),'Dipole moment (Debye):'), break; end
            if strcmp(g03_output(n+4*k+1),'Nuclear quadrupole coupling constants [Chi] (MHz):'), break; end
        end
        disp('Gaussian import: found nuclear spin-rotation tensors.');
    end
    
-   % Read quadrupole couplings and kill their trace
+   % Read quadrupole couplings, rotate them into the standard orientation, and kill their trace
    if strcmp(g03_output(n),'Nuclear quadrupole coupling constants [Chi] (MHz):')
        props.nqi=cell(natoms,1);
        for k=1:natoms
-           line3=char(g03_output(n+4*k));   line2=char(g03_output(n+4*k-1)); 
+           line3=char(g03_output(n+4*k));   line2=char(g03_output(n+4*k-1));
            line1=char(g03_output(n+4*k-2)); line0=char(g03_output(n+4*k-3));
            atom_num=regexp(line0,'^[0-9]*','match'); atom_num=eval(atom_num{1});
            props.nqi{atom_num}=[eval(['[' line1(4:14) '     ' line1(21:31) '     ' line1(38:48) ']']);
                                 eval(['[' line2(4:14) '     ' line2(21:31) '     ' line2(38:48) ']']);
                                 eval(['[' line3(4:14) '     ' line3(21:31) '     ' line3(38:48) ']'])]*1e6;
+           props.nqi{atom_num}=abc_rot*props.nqi{atom_num}*abc_rot';
            props.nqi{atom_num}=props.nqi{atom_num}-eye(3)*trace(props.nqi{atom_num})/3;
            if strcmp(g03_output(n+4*k+1),'Dipole moment (Debye):'), break; end
        end


### PR DESCRIPTION
## Scope

Applies the ports recommended by the comparison of `gparse.m` with third-party Gaussian parsers, and carries the Pickett-frame fix of #524 (closed) with a correction found during testing. One file changes: `interfaces/gaussian/gparse.m`.

## What changes

- **Token parsing everywhere.** Every fixed-column `eval` slice is replaced by `sscanf`/`regexp` on the printed labels, so widened fields, Fortran `D` exponents, and overflow asterisks no longer break or silently misread a block. (The g-tensor sign slip of #525 was one instance of this class.)
- **Pickett-block frame from coordinates, not from the printed matrix.** Gaussian's `Rotation matrix to Principal Axis frame` is an identity matrix in some logs whose `Principal axis orientation` coordinates are visibly a permutation of the standard orientation (pyridine and ammonia in certain input orientations; the same glitch is the axis-label swap reported for near-prolate tops). The rotation is now fitted by a Kabsch fit between the two printed coordinate sets, with an error if they do not describe the same molecule, and applied to `props.nqi` and `props.srt`.
- **Header-driven K/J reader.** Coupling matrices are filled from the printed row and column indices, so `ReadAtoms` subsets land on the right atoms; the outer-loop index hack is gone.
- **Isotope table.** `Isotopes and Nuclear Properties` is parsed into `props.mass_numbers`, `atom_masses`, `nuc_spins`, `nuc_qmom`, `nuc_mmom`. `props.isotopes` keeps its meaning (the magnetic isotope of the hyperfine block, e.g. 13C), which differs from the mass isotope of the table (12C); the two are documented separately.
- **Job boundaries.** Each job starts at its route echo (Gaussian prints `Link1:` only for internal steps and prints `Entering Gaussian System` once per file); geometry arrays start afresh at the first orientation block of a job, with a warning when the atom count changes between jobs; charge and multiplicity come from the first `Charge =` line of each job (fragment-guess and ONIOM lines follow it, and the old `textscan` cycle returned vectors on them).
- **Layouts met in the corpus.** Z-matrix-only orientations (IRC, ADMP), PBC translation-vector rows, ghost and dummy atoms (`Bq`, `X`, `TV` symbols), hyperfine blocks listing an atom subset with true atom numbers, the `nmr=print` shielding layout with eigenvector lines, the dash-less anisotropic block of anharmonic runs, empty orientation tables, Fortran overflow asterisks in isotope and shielding fields.
- **Self-checks.** The parsed g-tensor is checked against the printed g-shifts (1e-6), each shielding tensor against its printed isotropic value (1e-3 ppm), and the hyperfine MHz and Gauss columns against each other; a disagreement is an error.
- **Behaviour changes to note.** (1) A closed-shell log carrying a zero hyperfine block now warns and drops it instead of erroring, so its shieldings remain importable. (2) The `#p` guard now warns instead of erroring: in the public corpus 324 logs without `#p` carry shielding tensors and 471 carry hyperfine blocks, and the old guard (a literal `# ` test) both let `#N`-style routes through and misfired on IRC comment lines such as `# OF POINTS ALONG THE PATH`. (3) `std_geom` falls back on the input orientation when Gaussian did not reorient (NoSymm), which is the frame the tensors are printed in.

## Validation

Old (main) and new parser were run on every log with a harness that compares all fields; the new parser's tensors were then checked against quantities Gaussian prints independently.

| corpus | logs | old parses | new parses | notes |
| --- | --- | --- | --- | --- |
| Spinach examples | 106 | 105 | 106 | every shared field identical |
| Gaussian 16 test suite (local install) | 1166 | 1000 | 1164 | the 2 remaining are `#p restart` jobs that print neither geometry nor multiplicity |
| generated G16 EPR/NMR/Pickett jobs | 220 | 94 | 220 | 207 quadrupolar nuclei match the Prop=EFG block; 77 K/J matrices symmetric with correct indices; 76 hyperfine sets consistent |
| orientation study (9 molecules, random orientations, NoSymm on/off) | 45 | – | 45 | all 35 quadrupolar nuclei match the EFG block to 2e-5, scale eQ/h to 2e-5 |
| public repositories, batch 2 (G90 to G16) | 1082 | 708 | 1082 | five Gaussian 94/03 edge layouts fixed after the batch run and re-verified |
| public repositories, batch 1 (G94 to G16) | 3737 readable | 1871 | 3735 | 1 remaining is a `#p restart` job, 1 is a Gaussian 94 layout fixed after the run and re-verified; per family old/new: G16 704/2236, G09 957/1218, G03 182/241, G98 12/15, G94 0/8 |

The final head was re-run on the Gaussian 16 suite and the generated corpus after the review fixes (same numbers). Every value difference between old and new on logs both parse is one of: the charge/multiplicity vector-vs-scalar fix, the first-per-job charge line, geometry arrays no longer holding stale rows from a larger earlier job, the g-tensor sign fix of #525, or the Pickett frame. `check_house_style.py` and `checkcode` are clean (the one pre-existing three-line comment in the file is untouched).

