### PR TITLE
rcv/vertcat: decide and move to the GPU once, concatenate once

### DIFF
--- a/kernel/overloads/@rcv/vertcat.m
+++ b/kernel/overloads/@rcv/vertcat.m
@@ -8,7 +8,7 @@
 %
 % Outputs:
 %
-%    A         - concatenated RCV sparse matrix
+%    A         - RCV sparse matrix
 %
 % m.keitel@soton.ac.uk
 %
@@ -19,31 +19,26 @@ function A=vertcat(varargin)
 % Check consistency
 grumble(varargin{:});
 
-% Start from the top operand
-A=varargin{1};
-
-% Append the remaining operands
-for n=2:nargin
-
-    % Align locations
-    B=varargin{n};
-    if A.isGPU||B.isGPU
-        A=gpuArray(A);
-        B=gpuArray(B);
-    end
-
-    % Shift row indices
-    B.row=B.row+A.numRows;
-
-    % Concatenate indices
-    A.row=[A.row; B.row];
-    A.col=[A.col; B.col];
-    A.val=[A.val; B.val];
-
-    % Update row count in the result
-    A.numRows=A.numRows+B.numRows;
-
+% Move all operands to the GPU if any of them is there
+if any(cellfun(@(x)x.isGPU,varargin))
+    varargin=cellfun(@gpuArray,varargin,'UniformOutput',false);
 end
+
+% Shift row indices by the running row count
+rows=cell(nargin,1); cols=cell(nargin,1); vals=cell(nargin,1); nrows=int64(0);
+for n=1:nargin
+    rows{n}=varargin{n}.row+nrows;
+    cols{n}=varargin{n}.col;
+    vals{n}=varargin{n}.val;
+    nrows=nrows+varargin{n}.numRows;
+end
+
+% Concatenate RCV arrays once
+A=varargin{1};
+A.row=vertcat(rows{:});
+A.col=vertcat(cols{:});
+A.val=vertcat(vals{:});
+A.numRows=nrows;
 
 end
 


### PR DESCRIPTION
## What changes

`rcv/vertcat` now follows the same route as `rcv/horzcat` at every stage: the GPU decision and move happen once for all operands (`cellfun(@gpuArray,...)` when any operand is on the GPU), the row indices are shifted by a running `int64` row count in a single pass over the operands, and the row, column, and value arrays are concatenated once. The previous version decided and moved pairwise inside the operand loop and appended in every iteration. Apart from the function name and the row/column roles, the two bodies are now letter-for-letter identical (checked by textual diff with the roles swapped). No other stage of either function was more elegant in `vertcat`, so `horzcat` is untouched.

## Validation

- Stock (main 80309cdd) versus patched on five operand sets (two, three, and five operands; an empty operand in the middle; a repeated operand; a one-row operand first): results identical to each other and to the dense `vertcat` of the underlying sparse blocks, index class `int64` preserved, sizes correct.
- `tests/kernel/test_overload_arithmetic_suite` (covers `[R1;R2]` for RCV) run on the branch: no failures.
- `check_house_style.py` and `checkcode` clean.
- The mixed CPU/GPU operand case could not be executed on the build host (no GPU); that stage is the exact code already merged and exercised in `horzcat` (#502), applied to rows.
