### PR TITLE
cavity_safe_dephasing: 1/f flux-noise Monte Carlo and SAFE dephasing suppression

### DIFF
--- a/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
+++ b/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
@@ -30,8 +30,8 @@ chi=2*(g_bc/delta_bc)^2*anharm; sens_c=(g_bc/delta_bc)^2; sens_x=-4*anharm*g_bc^
 % Transmon frequency sensitivity to flux, rad/s per flux quantum
 dwb_dphi=2*pi*6e9;
 
-% Flux noise amplitude in flux quanta, infrared and ultraviolet cutoffs, Hz
-noise_amp=1e-5; f_ir=200; f_uv=5e7;
+% Flux noise amplitude in flux quanta and the ultraviolet cutoff, Hz
+noise_amp=1e-5; f_uv=5e7;
 
 % Transmon-drive detuning, Hz
 delta_bd=-19e6;
@@ -42,8 +42,8 @@ t1_b=50e-6; t1_c=2.1e-3;
 % Time step, number of steps, coherence sampling stride, and trajectory count
 dt=1e-8; nsteps=25000; stride=100; ntraj=200;
 
-% Length of the noise synthesis grid, long enough to resolve the infrared cutoff
-nlong=2^19;
+% Length of the noise synthesis grid and the infrared cutoff at its frequency resolution, Hz
+nlong=2^19; f_ir=1/(nlong*dt);
 
 % Four-level transmon in the drive frame and a three-level cavity in its own frame
 sys.magnet=0; sys.isotopes={'T4','C3'};

--- a/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
+++ b/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
@@ -145,9 +145,9 @@ for k=1:2
 
 end
 
-% Analytical undriven pure dephasing time, Eq. (4.89), and the sweet spot residual, Eq. (4.87)
+% Analytical undriven pure dephasing time, Eq. (4.89), and the sweet spot residual, Eq. (4.87), with K/2pi in Hz as in the thesis
 tphi_undriven=1/(noise_amp*dwb_dphi*sens_c*sqrt(2*abs(log(2*pi*f_ir*t2_times(1)))));
-tphi_driven=1/((delta_bd/(4*anharm))*(dwb_dphi*noise_amp)^2/abs(delta_bd)+(delta_bd/(4*anharm))^2/t1_b);
+tphi_driven=1/((dwb_dphi*noise_amp)^2/(4*abs(anharm))+(delta_bd/(4*anharm))^2/t1_b);
 disp(['pure dephasing time without the drive, us: simulated ' num2str(1e6*tphi_times(1),'%.1f') ...
       ', analytical ' num2str(1e6*tphi_undriven,'%.1f')]);
 disp(['pure dephasing time with the drive, us: simulated ' num2str(1e6*tphi_times(2),'%.1f') ...

--- a/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
+++ b/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
@@ -102,7 +102,7 @@ grid_idx=round((dwb+dw_max)*(ngrid-1)/(2*dw_max))+1;
 time_axis=dt*stride*(1:(nsteps/stride));
 
 % Preallocate the coherence decays and dephasing times
-signals=zeros(2,numel(time_axis)); t2_times=zeros(1,2); drives=[0 omega0];
+signals=zeros(2,numel(time_axis)); t2_times=zeros(1,2); tphi_times=zeros(1,2); drives=[0 omega0];
 
 % Loop over the undriven and the driven case
 for k=1:2
@@ -134,17 +134,16 @@ for k=1:2
     end
     signals(k,:)=2*abs(coherence)/ntraj;
 
-    % Coherence time from the 1/e crossing of the Gaussian decay or from an exponential fit
+    % Coherence and pure dephasing times, Eq. (E.2), from the 1/e crossing of the Gaussian decay or from an exponential fit
     if signals(k,end)<exp(-1)
         t2_times(k)=time_axis(find(signals(k,:)<exp(-1),1));
+        tphi_times(k)=t2_times(k)/sqrt(1-t2_times(k)/(2*t1_c));
     else
         decay_fit=polyfit(time_axis,log(signals(k,:)),1); t2_times(k)=-1/decay_fit(1);
+        tphi_times(k)=1/(1/t2_times(k)-1/(2*t1_c));
     end
 
 end
-
-% Pure dephasing times, Eq. (E.2), with the cavity photon loss removed
-tphi_times=1./(1./t2_times-1/(2*t1_c));
 
 % Analytical undriven pure dephasing time, Eq. (4.89), and the sweet spot residual, Eq. (4.87)
 tphi_undriven=1/(noise_amp*dwb_dphi*sens_c*sqrt(2*abs(log(2*pi*f_ir*t2_times(1)))));

--- a/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
+++ b/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
@@ -1,0 +1,194 @@
+% Stark-assisted flux-noise evasion (SAFE) for a cavity dispersively
+% coupled to a flux-tunable transmon, Chapter 4 of Yunwei Lu's PhD
+% thesis (Northwestern University, 2026). The transmon frequency ri-
+% des on 1/f flux noise, which the dispersive coupling passes on to
+% the cavity frequency; a weak off-resonant drive on the transmon
+% Stark-shifts the cavity transition by an amount whose flux depen-
+% dence cancels the direct one at the dynamical sweet spot. Flux
+% noise trajectories are synthesised with pink_noise.m, each one is
+% propagated under the Lindblad master equation in the frame rota-
+% ting with the drive, and the ensemble average of the cavity cohe-
+% rence between the dressed |g,0> and |g,1> states yields the pure
+% dephasing time with and without the drive. The sweet spot drive
+% amplitude is located numerically from the flux susceptibility of
+% the dressed cavity transition and compared with Eq. (4.22) of the
+% thesis; the noise spectrum and the coherence decay reproduce Figs.
+% E.1 and 4.3(d) of the thesis with representative parameters.
+%
+% Calculation time: minutes
+%
+% ilya.kuprov@weizmann.ac.il
+
+function cavity_safe_dephasing()
+
+% Transmon anharmonicity, transmon-cavity exchange coupling, and their detuning, Hz
+anharm=-200e6; g_bc=100e6; delta_bc=1.0e9;
+
+% Dispersive shift and the sensitivities of the cavity terms to the transmon frequency
+chi=2*(g_bc/delta_bc)^2*anharm; sens_c=(g_bc/delta_bc)^2; sens_x=-4*anharm*g_bc^2/delta_bc^3;
+
+% Transmon frequency sensitivity to flux, rad/s per flux quantum
+dwb_dphi=2*pi*6e9;
+
+% Flux noise amplitude in flux quanta, infrared and ultraviolet cutoffs, Hz
+noise_amp=1e-5; f_ir=200; f_uv=5e7;
+
+% Transmon-drive detuning, Hz
+delta_bd=-19e6;
+
+% Transmon and cavity relaxation times, seconds
+t1_b=50e-6; t1_c=2.1e-3;
+
+% Time step, number of steps, coherence sampling stride, and trajectory count
+dt=1e-8; nsteps=25000; stride=100; ntraj=200;
+
+% Length of the noise synthesis grid, long enough to resolve the infrared cutoff
+nlong=2^19;
+
+% Four-level transmon in the drive frame and a three-level cavity in its own frame
+sys.magnet=0; sys.isotopes={'T4','C3'};
+inter.modes.frqs={delta_bd 0};
+inter.modes.anharms={anharm []};
+inter.modes.lifetimes={t1_b t1_c};
+inter.temperature=0;
+bas.approximation='none';
+
+% Hilbert space twin for the dressed states
+bas.formalism='zeeman-hilb';
+ss_hilb=create(sys,inter);
+ss_hilb=basis(ss_hilb,bas);
+
+% Hilbert space Hamiltonian, drive operator, and flux noise operator, Eqs. (4.16) and (4.33)
+H_hilb=hamiltonian(assume(ss_hilb,'labframe'))+2*pi*chi*operator(ss_hilb,{'N','N'},{1,2});
+D_hilb=operator(ss_hilb,'C',1)+operator(ss_hilb,'A',1);
+N_hilb=operator(ss_hilb,'N',1)+sens_c*operator(ss_hilb,'N',2)+...
+       sens_x*operator(ss_hilb,{'N','N'},{1,2});
+
+% Positions of the bare |g,0> and |g,1> states
+idx0=find(diag(state(ss_hilb,{'BL1','BL1'},{1,2}))>0.5);
+idx1=find(diag(state(ss_hilb,{'BL1','BL2'},{1,2}))>0.5);
+
+% Analytical sweet spot drive amplitude, Eq. (4.22), rad/s
+omega0_an=2*pi*sqrt(delta_bd^3/(4*anharm));
+
+% Numerical sweet spot from the flux susceptibility of the dressed cavity transition
+omega0=fzero(@(omega)suscept(H_hilb,N_hilb,D_hilb,omega,idx0,idx1),[0.5 1.5]*omega0_an);
+disp(['sweet spot drive amplitude, MHz: analytical ' num2str(omega0_an/(2*pi*1e6),'%.3f') ...
+      ', numerical ' num2str(omega0/(2*pi*1e6),'%.3f')]);
+
+% Liouville space for the dissipative dynamics
+bas.formalism='zeeman-liouv';
+spin_system=create(sys,inter);
+spin_system=basis(spin_system,bas);
+
+% Drift, drive, and flux noise generators with the mode dissipators
+L_drift=hamiltonian(assume(spin_system,'labframe'))+...
+        2*pi*chi*operator(spin_system,{'N','N'},{1,2})+1i*relaxation(spin_system);
+L_drive=operator(spin_system,'C',1)+operator(spin_system,'A',1);
+L_noise=operator(spin_system,'N',1)+sens_c*operator(spin_system,'N',2)+...
+        sens_x*operator(spin_system,{'N','N'},{1,2});
+
+% Flux noise trajectories windowed from the long grid, transmon frequency units, rad/s
+rng(1); dwb=zeros(ntraj,nsteps);
+for m=1:ntraj
+    dphi=pink_noise(noise_amp,dt,nlong,1,f_ir,f_uv); dwb(m,:)=dwb_dphi*dphi(1:nsteps);
+end
+
+% Frequency grid for the propagator table
+ngrid=401; dw_max=max(abs(dwb(:))); dw_grid=linspace(-dw_max,dw_max,ngrid);
+grid_idx=round((dwb+dw_max)*(ngrid-1)/(2*dw_max))+1;
+
+% Time axis of the recorded coherence
+time_axis=dt*stride*(1:(nsteps/stride));
+
+% Preallocate the coherence decays and dephasing times
+signals=zeros(2,numel(time_axis)); t2_times=zeros(1,2); drives=[0 omega0];
+
+% Loop over the undriven and the driven case
+for k=1:2
+
+    % Dressed states adiabatically connected to |g,0> and |g,1>
+    [V,E]=eig(full(H_hilb+drives(k)*D_hilb)); [~,k0]=max(abs(V(idx0,:))); [~,k1]=max(abs(V(idx1,:)));
+    phi0=V(:,k0); phi1=V(:,k1); disp(['dressed transition frequency, kHz: ' num2str((E(k1,k1)-E(k0,k0))/(2*pi*1e3),'%.2f')]);
+
+    % Equal superposition initial state and the coherence detection state
+    rho=hilb2liouv((phi0+phi1)*(phi0+phi1)'/2,'statevec');
+    coil=hilb2liouv(phi0*phi1','statevec');
+
+    % Table of propagators over the frequency grid
+    P=cell(1,ngrid);
+    for n=1:ngrid
+        P{n}=full(propagator(spin_system,L_drift+drives(k)*L_drive+dw_grid(n)*L_noise,dt));
+    end
+
+    % Ensemble average of the coherence over the noise trajectories
+    coherence=zeros(1,numel(time_axis));
+    for m=1:ntraj
+        rho_traj=rho;
+        for n=1:nsteps
+            rho_traj=P{grid_idx(m,n)}*rho_traj;
+            if mod(n,stride)==0
+                coherence(n/stride)=coherence(n/stride)+coil'*rho_traj;
+            end
+        end
+    end
+    signals(k,:)=2*abs(coherence)/ntraj;
+
+    % Coherence time from the 1/e crossing of the Gaussian decay or from an exponential fit
+    if signals(k,end)<exp(-1)
+        t2_times(k)=time_axis(find(signals(k,:)<exp(-1),1));
+    else
+        decay_fit=polyfit(time_axis,log(signals(k,:)),1); t2_times(k)=-1/decay_fit(1);
+    end
+
+end
+
+% Pure dephasing times, Eq. (E.2), with the cavity photon loss removed
+tphi_times=1./(1./t2_times-1/(2*t1_c));
+
+% Analytical undriven pure dephasing time, Eq. (4.89), and the sweet spot residual, Eq. (4.87)
+tphi_undriven=1/(noise_amp*dwb_dphi*sens_c*sqrt(2*abs(log(2*pi*f_ir*t2_times(1)))));
+tphi_driven=1/((delta_bd/(4*anharm))*(dwb_dphi*noise_amp)^2/abs(delta_bd)+(delta_bd/(4*anharm))^2/t1_b);
+disp(['pure dephasing time without the drive, us: simulated ' num2str(1e6*tphi_times(1),'%.1f') ...
+      ', analytical ' num2str(1e6*tphi_undriven,'%.1f')]);
+disp(['pure dephasing time with the drive, us: simulated ' num2str(1e6*tphi_times(2),'%.1f') ...
+      ', analytical ' num2str(1e6*tphi_driven,'%.1f')]);
+
+% Power spectral density of the windowed flux noise trajectories, Fig. E.1
+freqs=(1:(nsteps/2))/(nsteps*dt); psd=mean(abs(fft(dwb/dwb_dphi,[],2)).^2,1)*dt/nsteps;
+psd=psd(2:(nsteps/2+1)); band=(freqs>2e4)&(freqs<1e7);
+
+% Validate the noise spectrum, the sweet spot location, and the dephasing suppression
+if abs(mean(psd(band).*freqs(band))/noise_amp^2-1)>0.2
+    error('flux noise spectrum deviates from 1/f.');
+end
+if abs(omega0/omega0_an-1)>0.5
+    error('numerical sweet spot deviates from the analytical estimate.');
+end
+if (tphi_times(1)>2*tphi_undriven)||(tphi_times(1)<tphi_undriven/2)
+    error('undriven dephasing time deviates from the analytical estimate.');
+end
+if tphi_times(2)<5*tphi_times(1)
+    error('SAFE drive did not suppress the cavity dephasing.');
+end
+
+% Plot the noise spectrum and the coherence decays
+kfigure(); subplot(1,2,1); loglog(freqs,psd,'.',freqs,noise_amp^2./freqs,'r-');
+kgrid; kxlabel('frequency, Hz'); kylabel('$S(f)$, $\Phi_0^2$/Hz'); ktitle('flux noise spectrum');
+subplot(1,2,2); plot(1e6*time_axis,signals'); kgrid; ylim([0 1.05]);
+kxlabel('time, $\mu$s'); kylabel('cavity coherence'); ktitle('SAFE Ramsey decay');
+klegend({'no drive','sweet spot drive'},'Location','southwest');
+
+end
+
+% Flux susceptibility of the dressed |g,0> to |g,1> cavity transition, Eq. (4.19)
+function dnm=suscept(H_hilb,N_hilb,D_hilb,omega0,idx0,idx1)
+dw=2*pi*1e3; shifts=[-dw dw]; frqs=zeros(1,2);
+for k=1:2
+    [V,E]=eig(full(H_hilb+omega0*D_hilb+shifts(k)*N_hilb));
+    [~,k0]=max(abs(V(idx0,:))); [~,k1]=max(abs(V(idx1,:)));
+    frqs(k)=E(k1,k1)-E(k0,k0);
+end
+dnm=(frqs(2)-frqs(1))/(2*dw);
+end
+

--- a/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
+++ b/examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m
@@ -50,6 +50,7 @@ sys.magnet=0; sys.isotopes={'T4','C3'};
 inter.modes.frqs={delta_bd 0};
 inter.modes.anharms={anharm []};
 inter.modes.lifetimes={t1_b t1_c};
+inter.modes.kerr=cell(2,2); inter.modes.kerr{1,2}=chi;
 inter.temperature=0;
 bas.approximation='none';
 
@@ -59,9 +60,9 @@ ss_hilb=create(sys,inter);
 ss_hilb=basis(ss_hilb,bas);
 
 % Hilbert space Hamiltonian, drive operator, and flux noise operator, Eqs. (4.16) and (4.33)
-H_hilb=hamiltonian(assume(ss_hilb,'labframe'))+2*pi*chi*operator(ss_hilb,{'N','N'},{1,2});
-D_hilb=operator(ss_hilb,'C',1)+operator(ss_hilb,'A',1);
-N_hilb=operator(ss_hilb,'N',1)+sens_c*operator(ss_hilb,'N',2)+...
+H_hilb=hamiltonian(assume(ss_hilb,'labframe'));
+drive_op=operator(ss_hilb,'C',1)+operator(ss_hilb,'A',1);
+noise_op=operator(ss_hilb,'N',1)+sens_c*operator(ss_hilb,'N',2)+...
        sens_x*operator(ss_hilb,{'N','N'},{1,2});
 
 % Positions of the bare |g,0> and |g,1> states
@@ -72,7 +73,7 @@ idx1=find(diag(state(ss_hilb,{'BL1','BL2'},{1,2}))>0.5);
 omega0_an=2*pi*sqrt(delta_bd^3/(4*anharm));
 
 % Numerical sweet spot from the flux susceptibility of the dressed cavity transition
-omega0=fzero(@(omega)suscept(H_hilb,N_hilb,D_hilb,omega,idx0,idx1),[0.5 1.5]*omega0_an);
+omega0=fzero(@(omega)suscept(H_hilb,noise_op,drive_op,omega,idx0,idx1),[0.5 1.5]*omega0_an);
 disp(['sweet spot drive amplitude, MHz: analytical ' num2str(omega0_an/(2*pi*1e6),'%.3f') ...
       ', numerical ' num2str(omega0/(2*pi*1e6),'%.3f')]);
 
@@ -82,8 +83,7 @@ spin_system=create(sys,inter);
 spin_system=basis(spin_system,bas);
 
 % Drift, drive, and flux noise generators with the mode dissipators
-L_drift=hamiltonian(assume(spin_system,'labframe'))+...
-        2*pi*chi*operator(spin_system,{'N','N'},{1,2})+1i*relaxation(spin_system);
+L_drift=hamiltonian(assume(spin_system,'labframe'))+1i*relaxation(spin_system);
 L_drive=operator(spin_system,'C',1)+operator(spin_system,'A',1);
 L_noise=operator(spin_system,'N',1)+sens_c*operator(spin_system,'N',2)+...
         sens_x*operator(spin_system,{'N','N'},{1,2});
@@ -108,8 +108,8 @@ signals=zeros(2,numel(time_axis)); t2_times=zeros(1,2); drives=[0 omega0];
 for k=1:2
 
     % Dressed states adiabatically connected to |g,0> and |g,1>
-    [V,E]=eig(full(H_hilb+drives(k)*D_hilb)); [~,k0]=max(abs(V(idx0,:))); [~,k1]=max(abs(V(idx1,:)));
-    phi0=V(:,k0); phi1=V(:,k1); disp(['dressed transition frequency, kHz: ' num2str((E(k1,k1)-E(k0,k0))/(2*pi*1e3),'%.2f')]);
+    [vecs,vals]=eig(full(H_hilb+drives(k)*drive_op)); [~,k0]=max(abs(vecs(idx0,:))); [~,k1]=max(abs(vecs(idx1,:)));
+    phi0=vecs(:,k0); phi1=vecs(:,k1); disp(['dressed transition frequency, kHz: ' num2str((vals(k1,k1)-vals(k0,k0))/(2*pi*1e3),'%.2f')]);
 
     % Equal superposition initial state and the coherence detection state
     rho=hilb2liouv((phi0+phi1)*(phi0+phi1)'/2,'statevec');
@@ -182,12 +182,12 @@ klegend({'no drive','sweet spot drive'},'Location','southwest');
 end
 
 % Flux susceptibility of the dressed |g,0> to |g,1> cavity transition, Eq. (4.19)
-function dnm=suscept(H_hilb,N_hilb,D_hilb,omega0,idx0,idx1)
+function dnm=suscept(H_hilb,noise_op,drive_op,omega0,idx0,idx1)
 dw=2*pi*1e3; shifts=[-dw dw]; frqs=zeros(1,2);
 for k=1:2
-    [V,E]=eig(full(H_hilb+omega0*D_hilb+shifts(k)*N_hilb));
-    [~,k0]=max(abs(V(idx0,:))); [~,k1]=max(abs(V(idx1,:)));
-    frqs(k)=E(k1,k1)-E(k0,k0);
+    [vecs,vals]=eig(full(H_hilb+omega0*drive_op+shifts(k)*noise_op));
+    [~,k0]=max(abs(vecs(idx0,:))); [~,k1]=max(abs(vecs(idx1,:)));
+    frqs(k)=vals(k1,k1)-vals(k0,k0);
 end
 dnm=(frqs(2)-frqs(1))/(2*dw);
 end

--- a/kernel/utilities/pink_noise.m
+++ b/kernel/utilities/pink_noise.m
@@ -31,7 +31,10 @@
 %             variance of each point is 2*amp^2*log(f_uv/f_ir)
 %
 % Note: the trajectories are periodic with the period npts*dt;
-%       use a duration well above 1/f_ir to avoid artefacts.
+%       use a duration well above 1/f_ir to avoid artefacts. The
+%       band must contain at least one grid frequency below the
+%       Nyquist frequency; the Nyquist bin itself is not synthe-
+%       sised because it has no independent quadrature.
 %
 % ilya.kuprov@weizmann.ac.il
 %
@@ -42,8 +45,8 @@ function trajs=pink_noise(amp,dt,npts,ntraj,f_ir,f_uv)
 % Check consistency
 grumble(amp,dt,npts,ntraj,f_ir,f_uv);
 
-% Positive frequency bins of the grid
-nbins=floor(npts/2); freqs=(1:nbins)/(npts*dt);
+% Positive frequency bins of the grid, self-conjugate Nyquist bin excluded
+nbins=ceil(npts/2)-1; freqs=(1:nbins)/(npts*dt);
 
 % Standard deviation of the quadrature amplitudes in the band
 sigma=zeros(1,nbins); band=(freqs>=f_ir)&(freqs<=f_uv);
@@ -60,11 +63,11 @@ end
 
 % Consistency enforcement
 function grumble(amp,dt,npts,ntraj,f_ir,f_uv)
-if (~isnumeric(amp))||(~isreal(amp))||(~isscalar(amp))||(amp<=0)
-    error('amp must be a positive real scalar.');
+if (~isnumeric(amp))||(~isreal(amp))||(~isscalar(amp))||(~isfinite(amp))||(amp<=0)
+    error('amp must be a positive finite real scalar.');
 end
-if (~isnumeric(dt))||(~isreal(dt))||(~isscalar(dt))||(dt<=0)
-    error('dt must be a positive real scalar.');
+if (~isnumeric(dt))||(~isreal(dt))||(~isscalar(dt))||(~isfinite(dt))||(dt<=0)
+    error('dt must be a positive finite real scalar.');
 end
 if (~isnumeric(npts))||(~isreal(npts))||(~isscalar(npts))||(npts<4)||(mod(npts,1)~=0)
     error('npts must be an integer greater than 3.');
@@ -72,11 +75,14 @@ end
 if (~isnumeric(ntraj))||(~isreal(ntraj))||(~isscalar(ntraj))||(ntraj<1)||(mod(ntraj,1)~=0)
     error('ntraj must be a positive integer.');
 end
-if (~isnumeric(f_ir))||(~isreal(f_ir))||(~isscalar(f_ir))||(f_ir<1/(npts*dt))
-    error('f_ir must be a real scalar not below 1/(npts*dt).');
+if (~isnumeric(f_ir))||(~isreal(f_ir))||(~isscalar(f_ir))||(~isfinite(f_ir))||(f_ir<1/(npts*dt))
+    error('f_ir must be a finite real scalar not below 1/(npts*dt).');
 end
-if (~isnumeric(f_uv))||(~isreal(f_uv))||(~isscalar(f_uv))||(f_uv<=f_ir)||(f_uv>1/(2*dt))
-    error('f_uv must be a real scalar between f_ir and 1/(2*dt).');
+if (~isnumeric(f_uv))||(~isreal(f_uv))||(~isscalar(f_uv))||(~isfinite(f_uv))||(f_uv<=f_ir)||(f_uv>1/(2*dt))
+    error('f_uv must be a finite real scalar between f_ir and 1/(2*dt).');
+end
+if min(floor(f_uv*npts*dt),ceil(npts/2)-1)<ceil(f_ir*npts*dt)
+    error('the band between f_ir and f_uv contains no frequency grid points below the Nyquist frequency.');
 end
 end
 

--- a/kernel/utilities/pink_noise.m
+++ b/kernel/utilities/pink_noise.m
@@ -88,8 +88,8 @@ if min(floor(f_uv*npts*dt),ceil(npts/2)-1)<ceil(f_ir*npts*dt)
 end
 end
 
-% The noise is the signal.
-%
-% (a proverb of every spectroscopist who has
-%  ever tried to measure a relaxation time)
+% Про тридцать восемь попугаев
+% Училка спрашивает нас:
+% Кто они были, как их звали,
+% И в чём их подвиг состоял.
 

--- a/kernel/utilities/pink_noise.m
+++ b/kernel/utilities/pink_noise.m
@@ -1,0 +1,87 @@
+% Trajectories of a real random process with a 1/f power spectral
+% density S(omega)=amp^2/|omega/2pi| between an infrared and an ul-
+% traviolet cutoff, synthesised in the frequency domain: every Fou-
+% rier component within the band receives a complex Gaussian ampli-
+% tude with the variance set by the spectral density, and the inver-
+% se FFT returns the time domain trajectory (Timmer and Koenig, As-
+% tron. Astrophys. 300, 707, 1995). Syntax:
+%
+%           trajs=pink_noise(amp,dt,npts,ntraj,f_ir,f_uv)
+%
+% Parameters:
+%
+%    amp    - noise amplitude, the two-sided spectral density
+%             is amp^2/|f| in units of [amp]^2/Hz
+%
+%    dt     - sampling interval, seconds
+%
+%    npts   - number of points in each trajectory
+%
+%    ntraj  - number of trajectories
+%
+%    f_ir   - infrared cutoff frequency, Hz, not below the
+%             frequency resolution 1/(npts*dt)
+%
+%    f_uv   - ultraviolet cutoff frequency, Hz, not above the
+%             Nyquist frequency 1/(2*dt)
+%
+% Outputs:
+%
+%    trajs  - trajectories, [ntraj x npts] real array, the
+%             variance of each point is 2*amp^2*log(f_uv/f_ir)
+%
+% Note: the trajectories are periodic with the period npts*dt;
+%       use a duration well above 1/f_ir to avoid artefacts.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=pink_noise.m>
+
+function trajs=pink_noise(amp,dt,npts,ntraj,f_ir,f_uv)
+
+% Check consistency
+grumble(amp,dt,npts,ntraj,f_ir,f_uv);
+
+% Positive frequency bins of the grid
+nbins=floor(npts/2); freqs=(1:nbins)/(npts*dt);
+
+% Standard deviation of the quadrature amplitudes in the band
+sigma=zeros(1,nbins); band=(freqs>=f_ir)&(freqs<=f_uv);
+sigma(band)=sqrt(2*amp^2./(freqs(band)*npts*dt));
+
+% Complex Gaussian spectrum in the MATLAB ifft normalisation
+spec=zeros(ntraj,npts);
+spec(:,2:(nbins+1))=(npts/2)*(randn(ntraj,nbins)+1i*randn(ntraj,nbins)).*sigma;
+
+% Real trajectories from the positive frequency half
+trajs=2*real(ifft(spec,[],2));
+
+end
+
+% Consistency enforcement
+function grumble(amp,dt,npts,ntraj,f_ir,f_uv)
+if (~isnumeric(amp))||(~isreal(amp))||(~isscalar(amp))||(amp<=0)
+    error('amp must be a positive real scalar.');
+end
+if (~isnumeric(dt))||(~isreal(dt))||(~isscalar(dt))||(dt<=0)
+    error('dt must be a positive real scalar.');
+end
+if (~isnumeric(npts))||(~isreal(npts))||(~isscalar(npts))||(npts<4)||(mod(npts,1)~=0)
+    error('npts must be an integer greater than 3.');
+end
+if (~isnumeric(ntraj))||(~isreal(ntraj))||(~isscalar(ntraj))||(ntraj<1)||(mod(ntraj,1)~=0)
+    error('ntraj must be a positive integer.');
+end
+if (~isnumeric(f_ir))||(~isreal(f_ir))||(~isscalar(f_ir))||(f_ir<1/(npts*dt))
+    error('f_ir must be a real scalar not below 1/(npts*dt).');
+end
+if (~isnumeric(f_uv))||(~isreal(f_uv))||(~isscalar(f_uv))||(f_uv<=f_ir)||(f_uv>1/(2*dt))
+    error('f_uv must be a real scalar between f_ir and 1/(2*dt).');
+end
+end
+
+% The noise is the signal.
+%
+% (a proverb of every spectroscopist who has
+%  ever tried to measure a relaxation time)
+

--- a/kernel/utilities/pink_noise.m
+++ b/kernel/utilities/pink_noise.m
@@ -28,7 +28,9 @@
 % Outputs:
 %
 %    trajs  - trajectories, [ntraj x npts] real array, the
-%             variance of each point is 2*amp^2*log(f_uv/f_ir)
+%             variance of each point is 2*amp^2*sum(1./k) over
+%             the synthesised bin indices k, which approaches
+%             2*amp^2*log(f_uv/f_ir) for bands with many bins
 %
 % Note: the trajectories are periodic with the period npts*dt;
 %       use a duration well above 1/f_ir to avoid artefacts. The


### PR DESCRIPTION
## Summary

Monte Carlo simulation of 1/f flux-noise dephasing of a cavity dispersively coupled to a flux-tunable transmon, and its suppression by Stark-assisted flux-noise evasion (SAFE), Chapter 4 and Appendix E of Yunwei Lu's PhD thesis (Northwestern University, 2026).

- `kernel/utilities/pink_noise.m`: trajectories of a real random process with a 1/f spectral density between infrared and ultraviolet cutoffs, synthesised in the frequency domain (Gaussian complex Fourier amplitudes with the variance set by the spectrum, inverse FFT; Timmer and Koenig 1995, the method the thesis uses). The two-sided density is `amp^2/|f|`, so the point variance is `2*amp^2*log(f_uv/f_ir)`. Spinach had no non-Markovian noise route.
- `examples/quantum_tech/circuit_qed/cavity_safe_dephasing.m`: the thesis's effective driven Hamiltonian in the drive frame (Eq. 4.16) with the flux noise entering through the transmon frequency and the dispersive terms (Eq. 4.33), Lindblad relaxation of the transmon and the cavity from `relaxation()`, sweet-spot drive amplitude located numerically from the flux susceptibility of the dressed cavity transition (Eq. 4.19) and compared with the analytical Eq. (4.22), 200 windowed noise trajectories propagated with a table of exact propagators over a grid of transmon frequency shifts, ensemble-averaged coherence between the dressed |g,0> and |g,1> states, pure dephasing times from the 1/e crossing (Gaussian, undriven) or an exponential fit (driven) with the cavity photon loss removed (Eq. E.2). Reproduces Fig. E.1 (noise spectrum) and Fig. 4.3(d) (Ramsey decay with and without the drive) with representative parameters: K/2pi = -200 MHz, g/2pi = 100 MHz, Delta_bc/2pi = 1 GHz, chi/2pi = -4 MHz, dw_b/dPhi = 2pi x 6 GHz per flux quantum, A = 1e-5 flux quanta, Delta_bd/2pi = -19 MHz, T1 = 50 us (transmon) and 2.1 ms (cavity).

## Validation

Numbers printed by the example (368 s on this host, including 200 noise syntheses of 2^19 points; numbers from the current head, the noise realisation changed when the Nyquist bin was dropped from the synthesis):

| quantity | simulated | analytical |
|---|---|---|
| sweet spot drive amplitude, MHz | 3.69 (susceptibility root) | 2.93 (Eq. 4.22) |
| pure dephasing time without drive, us | 154 | 144 (Eq. 4.89) |
| pure dephasing time with drive, us | 5386 | 5293 (Eq. 4.87) |

The drive lengthens the cavity pure dephasing time 26-fold; the thesis reports 20-fold (0.1 ms to 2 ms) for its parameter set. The example asserts the 1/f spectrum of the generated trajectories (mean of S(f) f within 20 percent of A^2 over 20 kHz to 10 MHz), the sweet spot within 50 percent of the analytical estimate, the undriven dephasing time within a factor of two of Eq. (4.89), and at least fivefold suppression.

Generator check (separate probe): 100 trajectories of 25000 points, variance 1.681e-9 against 1.703e-9 expected, mean two-sided PSD over A^2/f in band 1.000 (min 0.63, max 1.36 across bins).

A first version with the infrared cutoff at 10 kHz and a 250 us window showed no undriven dephasing at all: the noise then has no quasi-static components and the accumulated phase stays bounded. The example therefore synthesises 5 ms trajectories with the infrared cutoff at the grid resolution (191 Hz) and windows them, which puts omega_ir t at about 0.3 as in the thesis (10 kHz cutoff, 5 us fitting windows).

Style checker and checkcode clean on both files.

## Not done

- Thermal excitation (zero temperature throughout), the Purcell corrections of Eq. (4.32), and the full transmon cosine potential; the effective Duffing-plus-dispersive model of Eq. (4.16) is used as in the thesis's analysis.
- The noise trajectories are quantised onto a 401-point frequency grid for the propagator table; the grid spacing is 2pi x 6 kHz in the transmon frequency, three orders of magnitude below the cavity dephasing scale after the dispersive factor.

