### PR TITLE
fluxonium: Hamiltonian in the oscillator basis and a flux spectrum example

### DIFF
--- a/examples/quantum_tech/circuit_qed/fluxonium_spectrum.m
+++ b/examples/quantum_tech/circuit_qed/fluxonium_spectrum.m
@@ -1,0 +1,104 @@
+% Energy spectrum of a fluxonium qubit as a function of the exter-
+% nal flux, reproducing Fig. 2.3(b,c,d) of Y. Lu, Optimal Control
+% and Coherence Engineering for Superconducting Qubits, PhD thesis,
+% Northwestern University, 2026. The Hamiltonian is built in the
+% truncated harmonic oscillator basis by fluxonium.m for EJ/h=5.0
+% GHz, EC/h=1.0 GHz, and EL/h=1.0 GHz; the three lowest levels are
+% plotted against the external flux, and the potential landscape
+% with the two lowest probability densities is shown at 0.4 and
+% 0.5 flux quanta. The harmonic limit, the flux periodicity, the
+% half-flux sweet spot, the Hermiticity of the Hamiltonian, and
+% the convergence with respect to the basis size are validated.
+%
+% Calculation time: seconds
+%
+% ilya.kuprov@weizmann.ac.il
+
+function fluxonium_spectrum()
+
+% Circuit energies, Hz
+ec=1.0e9; ej=5.0e9; el=1.0e9;
+
+% Flux sweep and oscillator basis sizes
+flux_pts=linspace(0,1,201); nlev=[30 60];
+
+% Three lowest levels in GHz for both basis sizes
+levels=zeros(3,numel(flux_pts),2);
+for m=1:2
+    for k=1:numel(flux_pts)
+        H=fluxonium(ec,ej,el,2*pi*flux_pts(k),nlev(m));
+        energies=eig(H); levels(:,k,m)=energies(1:3)/(2*pi*1e9);
+    end
+end
+
+% Hermiticity check on the last Hamiltonian
+if norm(H-H',1)>1e-12*norm(H,1)
+    error('fluxonium Hamiltonian is not Hermitian.');
+end
+
+% Qubit frequency from the bigger basis
+f01=levels(2,:,2)-levels(1,:,2);
+
+% Report the qubit frequency at zero and half flux
+disp(['f01 at zero flux: ' num2str(f01(1),'%.6f') ' GHz']);
+disp(['f01 at half flux: ' num2str(f01(101),'%.6f') ' GHz']);
+
+% Convergence of the levels and of their spacings
+lev_conv=max(abs(levels(:,:,1)-levels(:,:,2)),[],'all')/max(abs(levels(:,:,2)),[],'all');
+spacings=levels(2:3,:,:)-levels([1 1],:,:);
+spc_conv=max(abs(spacings(:,:,1)-spacings(:,:,2))./spacings(:,:,2),[],'all');
+disp(['level convergence, 30 vs 60 states: ' num2str(lev_conv,'%.2e')]);
+disp(['spacing convergence, 30 vs 60 states: ' num2str(spc_conv,'%.2e')]);
+if (lev_conv>1e-6)||(spc_conv>1e-6)
+    error('levels are not converged with respect to the basis size.');
+end
+
+% Harmonic limit: tiny Josephson energy gives the plasma frequency
+energies=eig(fluxonium(ec,1,el,0,nlev(2)));
+harm_err=abs((energies(2)-energies(1))/(2*pi)-sqrt(8*ec*el))/sqrt(8*ec*el);
+disp(['harmonic limit deviation: ' num2str(harm_err,'%.2e')]);
+if harm_err>1e-6
+    error('harmonic limit does not reproduce the plasma frequency.');
+end
+
+% Sweet spot at half flux and periodicity in the flux quantum
+[~,min_idx]=min(f01);
+if min_idx~=101
+    error('qubit frequency is not minimal at half flux.');
+end
+if max(abs(levels(:,1,2)-levels(:,end,2)))>1e-6*max(abs(levels(:,1,2)))
+    error('spectrum is not periodic in the flux quantum.');
+end
+
+% Spectrum as a function of the external flux
+kfigure(); scale_figure([2.4 0.75]);
+subplot(1,3,1); plot(flux_pts,levels(:,:,2)','LineWidth',1.5);
+axis tight; kgrid; kxlabel('$\Phi_{ext}/\Phi_0$'); kylabel('energy/h, GHz');
+ktitle('fluxonium spectrum');
+
+% Phase grid and normalised Hermite functions of the oscillator basis
+phi_grid=linspace(-5,5,501); phi_zpf=(2*ec/el)^(1/4); xi=phi_grid/phi_zpf;
+herm=zeros(nlev(2),numel(phi_grid));
+herm(1,:)=exp(-xi.^2/2)/(pi^(1/4)*sqrt(phi_zpf));
+herm(2,:)=sqrt(2)*xi.*herm(1,:);
+for k=2:(nlev(2)-1)
+    herm(k+1,:)=sqrt(2/k)*xi.*herm(k,:)-sqrt((k-1)/k)*herm(k-1,:);
+end
+
+% Potential and the two lowest probability densities at 0.4 and 0.5 flux quanta
+for m=1:2
+    flux=0.3+0.1*m; phi_e=2*pi*flux;
+    H=fluxonium(ec,ej,el,phi_e,nlev(2)); [V,D]=eig(H);
+    potential=(-ej*cos(phi_grid-phi_e)+(el/2)*phi_grid.^2)/1e9;
+    densities=abs(herm'*V(:,1:2)).^2; energies=diag(D)/(2*pi*1e9);
+    subplot(1,3,m+1); plot(phi_grid,potential,'Color',[0.5 0.5 0.5],'LineWidth',1.5);
+    hold on; plot(phi_grid,energies(1)+densities(:,1),'LineWidth',1.5);
+    plot(phi_grid,energies(2)+densities(:,2),'LineWidth',1.5); ylim([-5 5]);
+    kgrid; kxlabel('$\varphi$, rad'); kylabel('energy/h, GHz');
+    ktitle(['$\Phi_{ext}=' num2str(flux) '\Phi_0$']);
+    klegend({'potential','$|\psi_0|^2$','$|\psi_1|^2$'},'Location','North');
+end
+
+end
+
+

--- a/examples/quantum_tech/circuit_qed/fluxonium_spectrum.m
+++ b/examples/quantum_tech/circuit_qed/fluxonium_spectrum.m
@@ -76,10 +76,10 @@ subplot(1,3,1); plot(flux_pts,levels(:,:,2)','LineWidth',1.5);
 axis tight; kgrid; kxlabel('$\Phi_{ext}/\Phi_0$'); kylabel('energy/h, GHz');
 ktitle('fluxonium spectrum');
 
-% Phase grid and normalised Hermite functions of the oscillator basis
-phi_grid=linspace(-5,5,501); phi_zpf=(2*ec/el)^(1/4); xi=phi_grid/phi_zpf;
+% Phase grid wide enough for the whole basis, and its normalised Hermite functions, phi=sqrt(2)*phi_zpf*xi
+phi_grid=linspace(-20,20,2001); phi_scale=sqrt(2)*(2*ec/el)^(1/4); xi=phi_grid/phi_scale;
 herm=zeros(nlev(2),numel(phi_grid));
-herm(1,:)=exp(-xi.^2/2)/(pi^(1/4)*sqrt(phi_zpf));
+herm(1,:)=exp(-xi.^2/2)/(pi^(1/4)*sqrt(phi_scale));
 herm(2,:)=sqrt(2)*xi.*herm(1,:);
 for k=2:(nlev(2)-1)
     herm(k+1,:)=sqrt(2/k)*xi.*herm(k,:)-sqrt((k-1)/k)*herm(k-1,:);
@@ -88,12 +88,19 @@ end
 % Potential and the two lowest probability densities at 0.4 and 0.5 flux quanta
 for m=1:2
     flux=0.3+0.1*m; phi_e=2*pi*flux;
-    H=fluxonium(ec,ej,el,phi_e,nlev(2)); [V,D]=eig(H);
+    [H,~,phi_op]=fluxonium(ec,ej,el,phi_e,nlev(2)); [vecs,vals]=eig(H);
     potential=(-ej*cos(phi_grid-phi_e)+(el/2)*phi_grid.^2)/1e9;
-    densities=abs(herm'*V(:,1:2)).^2; energies=diag(D)/(2*pi*1e9);
+    densities=abs(herm'*vecs(:,1:2)).^2; energies=diag(vals)/(2*pi*1e9);
+
+    % Validate the phase space wavefunctions against the operator expectation values
+    norms=trapz(phi_grid,densities); phi_sq=trapz(phi_grid,phi_grid'.^2.*densities);
+    phi_sq_op=real(diag(vecs(:,1:2)'*phi_op^2*vecs(:,1:2)))';
+    if (max(abs(norms-1))>1e-6)||(max(abs(phi_sq-phi_sq_op)./phi_sq_op)>1e-6)
+        error('phase space wavefunctions are inconsistent with the oscillator basis.');
+    end
     subplot(1,3,m+1); plot(phi_grid,potential,'Color',[0.5 0.5 0.5],'LineWidth',1.5);
     hold on; plot(phi_grid,energies(1)+densities(:,1),'LineWidth',1.5);
-    plot(phi_grid,energies(2)+densities(:,2),'LineWidth',1.5); ylim([-5 5]);
+    plot(phi_grid,energies(2)+densities(:,2),'LineWidth',1.5); xlim([-5 5]); ylim([-5 5]);
     kgrid; kxlabel('$\varphi$, rad'); kylabel('energy/h, GHz');
     ktitle(['$\Phi_{ext}=' num2str(flux) '\Phi_0$']);
     klegend({'potential','$|\psi_0|^2$','$|\psi_1|^2$'},'Location','North');

--- a/kernel/utilities/fluxonium.m
+++ b/kernel/utilities/fluxonium.m
@@ -115,11 +115,7 @@ if (~isnumeric(nlevels))||(~isreal(nlevels))||(~isscalar(nlevels))||...
 end
 end
 
-% Nature isn't classical, dammit, and if you want to make a
-% simulation of nature, you'd better make it quantum mecha-
-% nical, and by golly it's a wonderful problem, because it
-% doesn't look so easy.
+% The first draft of anything is shit.
 %
-% Richard Feynman
-
+% Ernest Hemingway
 

--- a/kernel/utilities/fluxonium.m
+++ b/kernel/utilities/fluxonium.m
@@ -1,0 +1,125 @@
+% Fluxonium Hamiltonian in the truncated basis of the harmonic
+% oscillator formed by the charging and the inductive energies
+% of the circuit (Y. Lu, Optimal Control and Coherence Engine-
+% ering for Superconducting Qubits, PhD thesis, Northwestern
+% University, 2026, Eq. 2.30):
+%
+%    H=4*ec*n^2-ej*cos(phi-phi_e)+(el/2)*phi^2,   [phi,n]=1i
+%
+% where ec is the charging energy, ej is the Josephson energy,
+% el=(Phi_0/2*pi)^2/L is the inductive energy of the shunt in-
+% ductance L (Eq. 2.31, the factor 1/2 is explicit in the po-
+% tential and is not absorbed into el), and phi_e=2*pi*Phi_e/
+% Phi_0 is the reduced external flux (Eq. 2.32). Eq. 2.30 has
+% the inductive term as (el/2)*(phi+phi_e)^2 and the Josephson
+% term as -ej*cos(phi); the form above is its image under the
+% translation of the phase origin to the minimum of the induc-
+% tive potential, which does not change the spectrum. The off-
+% set charge of Eq. 2.30 is dropped because the unbounded phase
+% variable makes it removable by a gauge transformation. Phase
+% and charge are built from the ladder operators of the linear
+% oscillator 4*ec*n^2+(el/2)*phi^2 with the plasma frequency
+% sqrt(8*ec*el) as
+%
+%          phi=phi_zpf*(b'+b),   n=1i*n_zpf*(b'-b)
+%
+%     phi_zpf=(2*ec/el)^(1/4),   n_zpf=(el/(32*ec))^(1/4)
+%
+% and the cosine is computed as a matrix function of the Her-
+% mitian phase operator using the matrix exponential.
+%
+% Syntax:
+%
+%      [H,n_op,phi_op]=fluxonium(ec,ej,el,phi_e,nlevels)
+%
+% Parameters:
+%
+%   ec      - charging energy in Hz (energy over the
+%             Planck constant), a positive real number
+%
+%   ej      - Josephson energy in Hz (energy over the
+%             Planck constant), a positive real number
+%
+%   el      - inductive energy in Hz (energy over the
+%             Planck constant), a positive real number
+%
+%   phi_e   - reduced external flux 2*pi*Phi_e/Phi_0
+%             in radians, a real number
+%
+%   nlevels - number of oscillator basis states, a
+%             positive integer
+%
+% Outputs:
+%
+%   H       - fluxonium Hamiltonian in rad/s (2*pi times
+%             the energy in Hz), a real symmetric matrix
+%             of dimension nlevels
+%
+%   n_op    - charge operator (Cooper pair number) in the
+%             oscillator basis, a Hermitian matrix of di-
+%             mension nlevels
+%
+%   phi_op  - phase operator in radians in the oscillator
+%             basis, a real symmetric matrix of dimension
+%             nlevels
+%
+% Note: the oscillator basis must be large enough for the lowest
+%       eigenstates to be converged; nlevels of the order of 30
+%       to 60 is sufficient for ej/el=5 and ec/el=1, larger ej/el
+%       ratios need more states. Check the convergence by repeat-
+%       ing the calculation with a bigger nlevels.
+%
+% ilya.kuprov@weizmann.ac.il
+%
+% <https://spindynamics.org/wiki/index.php?title=fluxonium.m>
+
+function [H,n_op,phi_op]=fluxonium(ec,ej,el,phi_e,nlevels)
+
+% Check consistency
+grumble(ec,ej,el,phi_e,nlevels);
+
+% Ladder operators of the linear oscillator
+A=weyl(nlevels);
+
+% Zero-point amplitudes of the phase and the charge
+phi_zpf=(2*ec/el)^(1/4); n_zpf=(el/(32*ec))^(1/4);
+
+% Phase and charge operators
+phi_op=full(phi_zpf*(A.c+A.a)); n_op=full(1i*n_zpf*(A.c-A.a));
+
+% Cosine of the flux-shifted phase, real part drops round-off
+U=expm(1i*(phi_op-phi_e*eye(nlevels))); cos_op=real(U+U')/2;
+
+% Hamiltonian in rad/s
+H=2*pi*(4*ec*n_op^2-ej*cos_op+(el/2)*phi_op^2);
+
+end
+
+% Consistency enforcement
+function grumble(ec,ej,el,phi_e,nlevels)
+if (~isnumeric(ec))||(~isreal(ec))||(~isscalar(ec))||(~isfinite(ec))||(ec<=0)
+    error('ec must be a positive real number.');
+end
+if (~isnumeric(ej))||(~isreal(ej))||(~isscalar(ej))||(~isfinite(ej))||(ej<=0)
+    error('ej must be a positive real number.');
+end
+if (~isnumeric(el))||(~isreal(el))||(~isscalar(el))||(~isfinite(el))||(el<=0)
+    error('el must be a positive real number.');
+end
+if (~isnumeric(phi_e))||(~isreal(phi_e))||(~isscalar(phi_e))||(~isfinite(phi_e))
+    error('phi_e must be a real number.');
+end
+if (~isnumeric(nlevels))||(~isreal(nlevels))||(~isscalar(nlevels))||...
+   (mod(nlevels,1)~=0)||(nlevels<1)
+    error('nlevels must be a positive real integer.');
+end
+end
+
+% Nature isn't classical, dammit, and if you want to make a
+% simulation of nature, you'd better make it quantum mecha-
+% nical, and by golly it's a wonderful problem, because it
+% doesn't look so easy.
+%
+% Richard Feynman
+
+


### PR DESCRIPTION
## Summary

Item 9 of the thesis extraction list (Yunwei Lu, PhD thesis, Northwestern University, 2026, Sec. 2.1.2 and Fig. 2.3). Spinach had no fluxonium; the Josephson term `-EJ*cos(phi)` is a matrix function of the phase quadrature rather than a polynomial in the ladder operators, so it needs its own constructor.

- `kernel/utilities/fluxonium.m` - `[H,n_op,phi_op]=fluxonium(ec,ej,el,phi_e,nlevels)` builds `H=4*ec*n^2-ej*cos(phi-phi_e)+(el/2)*phi^2` (thesis Eq. 2.30 with the phase origin at the minimum of the inductive potential, offset charge gauged away) in the truncated basis of the linear oscillator `4*ec*n^2+(el/2)*phi^2`, with `phi=phi_zpf*(b'+b)`, `n=1i*n_zpf*(b'-b)`, and the cosine computed through `expm` of the Hermitian phase operator. Energies in Hz in, Hamiltonian in rad/s out, as elsewhere in Spinach.
- `examples/quantum_tech/circuit_qed/fluxonium_spectrum.m` - three lowest levels against the external flux and the potential landscape with the two lowest probability densities at 0.4 and 0.5 flux quanta, for EJ/h=5 GHz, EC/h=1 GHz, EL/h=1 GHz (Fig. 2.3 b, c, d).

## Validation

- Example runs in 49 s with its built-in assertions: Hermiticity of H; convergence of the three lowest levels and of their spacings between 30 and 60 basis states (4.0e-7 and 3.3e-7 relative); harmonic limit (EJ -> 0) reproducing the plasma frequency `sqrt(8*ec*el)` to 2.5e-10; qubit frequency minimal at half flux; spectrum periodic in the flux quantum.
- Qubit frequency 5.984 GHz at zero flux and 0.340 GHz at the half-flux sweet spot.
- `checkcode` and the house-style checker are clean on both files.

## Not done

- Coupled-fluxonium spectra and control examples (the thesis provides parameter sets); this PR delivers the term form and the single-qubit spectrum only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
